### PR TITLE
feat(repo): L1SLOAD precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "reth-revm",
  "revm-database-interface",
  "serde",
+ "serial_test",
  "tracing",
 ]
 
@@ -10163,6 +10164,31 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap 5.5.3",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -20,3 +20,6 @@ reth-revm = { workspace = true }
 revm-database-interface = { workspace = true }
 serde = { workspace = true, optional = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+serial_test = "2"

--- a/crates/evm/src/factory.rs
+++ b/crates/evm/src/factory.rs
@@ -8,12 +8,12 @@ use reth_revm::{
     },
     inspector::NoOpInspector,
     interpreter::interpreter::EthInterpreter,
-    precompile::{PrecompileSpecId, Precompiles},
 };
 
 use crate::{
     alloy::{TaikoEvmContext, TaikoEvmWrapper},
     evm::TaikoEvm,
+    precompiles::TaikoPrecompiles,
     spec::TaikoSpecId,
 };
 
@@ -47,14 +47,13 @@ impl EvmFactory for TaikoEvmFactory {
         input: EvmEnv<Self::Spec, Self::BlockEnv>,
     ) -> Self::Evm<DB, NoOpInspector> {
         let spec_id = input.cfg_env.spec;
+        let taiko_precompiles = TaikoPrecompiles::new_with_spec(spec_id).into();
         let evm = Context::mainnet()
             .with_cfg(input.cfg_env)
             .with_block(input.block_env)
             .with_db(db)
             .build_mainnet_with_inspector(NoOpInspector {})
-            .with_precompiles(PrecompilesMap::from_static(Precompiles::new(
-                PrecompileSpecId::from_spec_id(spec_id.into()),
-            )));
+            .with_precompiles(taiko_precompiles);
 
         TaikoEvmWrapper::new(TaikoEvm::new(evm), false)
     }
@@ -67,14 +66,13 @@ impl EvmFactory for TaikoEvmFactory {
         inspector: I,
     ) -> Self::Evm<DB, I> {
         let spec_id = input.cfg_env.spec;
+        let taiko_precompiles = TaikoPrecompiles::new_with_spec(spec_id).into();
         let evm = Context::mainnet()
             .with_cfg(input.cfg_env)
             .with_block(input.block_env)
             .with_db(db)
             .build_mainnet_with_inspector(NoOpInspector {})
-            .with_precompiles(PrecompilesMap::from_static(Precompiles::new(
-                PrecompileSpecId::from_spec_id(spec_id.into()),
-            )))
+            .with_precompiles(taiko_precompiles)
             .with_inspector(inspector);
 
         TaikoEvmWrapper::new(TaikoEvm::new(evm), true)

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -4,4 +4,5 @@ pub mod evm;
 pub mod execution;
 pub mod factory;
 pub mod handler;
+pub mod precompiles;
 pub mod spec;

--- a/crates/evm/src/precompiles/l1sload.rs
+++ b/crates/evm/src/precompiles/l1sload.rs
@@ -1,0 +1,299 @@
+use std::{
+    collections::HashMap,
+    sync::{LazyLock, Mutex},
+};
+
+use alloy_primitives::{Address, B256, Bytes};
+use reth_revm::precompile::{
+    Precompile, PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult, u64_to_address,
+};
+
+pub const L1SLOAD: Precompile = Precompile::new(
+    PrecompileId::Custom(std::borrow::Cow::Borrowed("L1SLOAD")),
+    u64_to_address(0x10001),
+    l1sload_run,
+);
+
+/// Gas constants for L1SLOAD precompile
+pub const L1SLOAD_FIXED_GAS: u64 = 2000;
+pub const L1SLOAD_PER_LOAD_GAS: u64 = 2000;
+
+/// Expected input length: 20 bytes (address) + 32 bytes (storage key) + 32 bytes (block number),
+/// total 84 bytes
+pub const EXPECTED_INPUT_LENGTH: usize = 84;
+
+/// Type alias for the L1 storage cache map.
+type L1StorageCache = HashMap<(Address, B256, B256), B256>;
+
+/// In-memory cache for L1 storage values
+/// Key: (contract_address, storage_key, block_number) -> Value: storage_value
+static L1_STORAGE_CACHE: LazyLock<Mutex<L1StorageCache>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Set a value in the L1 storage cache (keyed by address, storage key, and block number)
+pub fn set_l1_storage_value(
+    contract_address: Address,
+    storage_key: B256,
+    block_number: B256,
+    value: B256,
+) {
+    if let Ok(mut cache) = L1_STORAGE_CACHE.lock() {
+        cache.insert((contract_address, storage_key, block_number), value);
+    }
+}
+
+/// Clear L1 storage cache
+pub fn clear_l1_storage() {
+    if let Ok(mut cache) = L1_STORAGE_CACHE.lock() {
+        cache.clear();
+    }
+}
+
+/// Get a value from the L1 storage cache
+fn get_l1_storage_value(
+    contract_address: Address,
+    storage_key: B256,
+    block_number: B256,
+) -> Option<B256> {
+    if let Ok(cache) = L1_STORAGE_CACHE.lock() {
+        cache.get(&(contract_address, storage_key, block_number)).copied()
+    } else {
+        None
+    }
+}
+
+/// L1SLOAD precompile - read storage values from L1 contracts (RIP-7728).
+///
+/// The input to the L1SLOAD precompile consists of:
+/// - [0: 19]  (20 bytes)  - address: The L1 contract address
+/// - [20: 51] (32 bytes)  - storageKey: The storage key to read
+/// - [52: 83] (32 bytes)  - blockNumber: The L1 block number to read from
+///
+/// Output: Storage value (32 bytes)
+pub fn l1sload_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    // Check gas limit
+    let gas_used = L1SLOAD_FIXED_GAS + L1SLOAD_PER_LOAD_GAS;
+    if gas_used > gas_limit {
+        return Err(PrecompileError::OutOfGas);
+    }
+
+    // Validate input length
+    if input.len() != EXPECTED_INPUT_LENGTH {
+        return Err(PrecompileError::Other("Invalid input length".into()));
+    }
+
+    // Parse input parameters
+    let contract_address = Address::from_slice(&input[0..20]);
+    let storage_key = B256::from_slice(&input[20..52]);
+    let block_number = B256::from_slice(&input[52..84]);
+
+    // Get cached L1 storage value (keyed by address, storage key, and block number)
+    let storage_value = get_l1_storage_value(contract_address, storage_key, block_number);
+
+    match storage_value {
+        Some(value) => {
+            // Convert storage value to output bytes (32 bytes)
+            let mut output = [0u8; 32];
+            output.copy_from_slice(value.as_slice());
+            Ok(PrecompileOutput::new(gas_used, Bytes::from(output)))
+        }
+        None => {
+            // Return error if no cached data found
+            Err(PrecompileError::Other("L1 storage value not found in cache".into()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::U256;
+    use serial_test::serial;
+
+    const TEST_ADDRESS: [u8; 20] = [1u8; 20];
+    const TEST_STORAGE_KEY: [u8; 32] = [2u8; 32];
+    const TEST_STORAGE_VALUE: [u8; 32] = [5u8; 32];
+    const SUFFICIENT_GAS: u64 = L1SLOAD_FIXED_GAS + L1SLOAD_PER_LOAD_GAS;
+    const INSUFFICIENT_GAS: u64 = SUFFICIENT_GAS - 1;
+
+    /// Helper: create a B256 block number from a u64
+    fn block_number_b256(n: u64) -> B256 {
+        B256::from(U256::from(n))
+    }
+
+    /// Helper function to create test input (84 bytes) with given block number
+    fn create_test_input(block_number: u64) -> Vec<u8> {
+        let mut input = vec![0u8; EXPECTED_INPUT_LENGTH];
+        input[0..20].copy_from_slice(&TEST_ADDRESS);
+        input[20..52].copy_from_slice(&TEST_STORAGE_KEY);
+        let bn_b256 = block_number_b256(block_number);
+        input[52..84].copy_from_slice(bn_b256.as_slice());
+        input
+    }
+
+    /// Helper function to setup storage cache with test data
+    fn setup_test_storage(block: u64) -> (Address, B256, B256, B256) {
+        let address = Address::from(TEST_ADDRESS);
+        let key = B256::from(TEST_STORAGE_KEY);
+        let block_num = block_number_b256(block);
+        let value = B256::from(TEST_STORAGE_VALUE);
+
+        set_l1_storage_value(address, key, block_num, value);
+        (address, key, block_num, value)
+    }
+
+    #[test]
+    #[serial]
+    fn test_l1sload_rejects_invalid_input_lengths() {
+        clear_l1_storage();
+
+        // Test input too short (52 bytes - old format)
+        let short_input = Bytes::from(vec![0u8; 52]);
+        let result = l1sload_run(&short_input, SUFFICIENT_GAS);
+        assert!(result.is_err(), "Should reject too short input");
+
+        // Test input too long
+        let long_input = Bytes::from(vec![0u8; 116]);
+        let result = l1sload_run(&long_input, SUFFICIENT_GAS);
+        assert!(result.is_err(), "Should reject too long input");
+    }
+
+    #[test]
+    #[serial]
+    fn test_l1sload_fails_without_cached_storage() {
+        clear_l1_storage();
+
+        let input = create_test_input(100);
+        let result = l1sload_run(&Bytes::from(input), SUFFICIENT_GAS);
+
+        assert!(result.is_err(), "Should fail when storage value is not cached");
+    }
+
+    #[test]
+    #[serial]
+    fn test_l1sload_succeeds_with_cached_storage() {
+        clear_l1_storage();
+
+        let block = 100u64;
+        let (_, _, _, expected_value) = setup_test_storage(block);
+        let input = create_test_input(block);
+
+        let result = l1sload_run(&Bytes::from(input), SUFFICIENT_GAS);
+        assert!(
+            result.is_ok(),
+            "Should succeed when storage value is cached. Error: {:?}",
+            result.err()
+        );
+
+        let output = result.unwrap();
+
+        // Verify gas usage
+        let expected_gas = L1SLOAD_FIXED_GAS + L1SLOAD_PER_LOAD_GAS;
+        assert_eq!(output.gas_used, expected_gas, "Gas usage should be fixed cost + per-load cost");
+
+        // Verify output length
+        assert_eq!(output.bytes.len(), 32, "Output should be exactly 32 bytes");
+
+        // Verify output content matches stored value
+        assert_eq!(
+            output.bytes.as_ref(),
+            &expected_value.0,
+            "Output should match the cached storage value"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_l1sload_fails_with_insufficient_gas() {
+        clear_l1_storage();
+
+        let input = Bytes::from(create_test_input(100));
+        let result = l1sload_run(&input, INSUFFICIENT_GAS);
+
+        assert!(result.is_err(), "Should fail when gas limit is insufficient");
+    }
+
+    #[test]
+    #[serial]
+    fn test_l1sload_succeeds_with_different_blocks() {
+        clear_l1_storage();
+
+        let block1 = 100u64;
+        let block2 = 50u64; // arbitrary older block
+        let (_, _, _, expected_value1) = setup_test_storage(block1);
+
+        // Setup a second entry at a different block
+        let address = Address::from(TEST_ADDRESS);
+        let key = B256::from(TEST_STORAGE_KEY);
+        let block_num2 = block_number_b256(block2);
+        let value2 = B256::from([9u8; 32]);
+        set_l1_storage_value(address, key, block_num2, value2);
+
+        // Both blocks should return their respective values
+        let result1 = l1sload_run(&Bytes::from(create_test_input(block1)), SUFFICIENT_GAS);
+        assert!(result1.is_ok(), "Should succeed for block1");
+        assert_eq!(result1.unwrap().bytes.as_ref(), &expected_value1.0);
+
+        let result2 = l1sload_run(&Bytes::from(create_test_input(block2)), SUFFICIENT_GAS);
+        assert!(result2.is_ok(), "Should succeed for block2");
+        assert_eq!(result2.unwrap().bytes.as_ref(), &value2.0);
+    }
+
+    #[test]
+    #[serial]
+    fn test_storage_cache_operations() {
+        clear_l1_storage();
+
+        let address = Address::from(TEST_ADDRESS);
+        let key = B256::from(TEST_STORAGE_KEY);
+        let block = block_number_b256(100);
+        let value = B256::from(TEST_STORAGE_VALUE);
+
+        // Verify cache is initially empty
+        assert!(
+            get_l1_storage_value(address, key, block).is_none(),
+            "Cache should be empty initially"
+        );
+
+        set_l1_storage_value(address, key, block, value);
+        assert_eq!(
+            get_l1_storage_value(address, key, block),
+            Some(value),
+            "Should retrieve the cached value"
+        );
+
+        // Different block number should not have the value
+        let other_block = block_number_b256(101);
+        assert!(
+            get_l1_storage_value(address, key, other_block).is_none(),
+            "Different block number should not match"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_cache_key_uniqueness() {
+        clear_l1_storage();
+
+        let address1 = Address::from([1u8; 20]);
+        let address2 = Address::from([2u8; 20]);
+        let key1 = B256::from([1u8; 32]);
+        let key2 = B256::from([2u8; 32]);
+        let block1 = block_number_b256(100);
+        let block2 = block_number_b256(200);
+        let value1 = B256::from([10u8; 32]);
+        let value2 = B256::from([20u8; 32]);
+
+        set_l1_storage_value(address1, key1, block1, value1);
+        set_l1_storage_value(address2, key2, block2, value2);
+
+        // Verify each key returns its correct value
+        assert_eq!(get_l1_storage_value(address1, key1, block1), Some(value1));
+        assert_eq!(get_l1_storage_value(address2, key2, block2), Some(value2));
+
+        // Verify non-existent combinations return None
+        assert!(get_l1_storage_value(address1, key2, block1).is_none());
+        assert!(get_l1_storage_value(address2, key1, block2).is_none());
+        assert!(get_l1_storage_value(address1, key1, block2).is_none());
+    }
+}

--- a/crates/evm/src/precompiles/mod.rs
+++ b/crates/evm/src/precompiles/mod.rs
@@ -1,0 +1,183 @@
+//! Taiko precompiles implementation
+
+use alloy_primitives::Address;
+use reth_evm::precompiles::PrecompilesMap;
+use reth_revm::{
+    context::Cfg,
+    context_interface::ContextTr,
+    handler::{EthPrecompiles, PrecompileProvider},
+    interpreter::{CallInputs, InterpreterResult},
+    precompile::Precompiles,
+    primitives::hardfork::SpecId,
+};
+use std::{boxed::Box, sync::OnceLock};
+
+use crate::spec::TaikoSpecId;
+
+pub mod l1sload;
+
+/// Taiko precompile provider
+#[derive(Debug, Clone)]
+pub struct TaikoPrecompiles {
+    /// Inner precompile provider is same as Ethereum's.
+    inner: EthPrecompiles,
+    /// Spec id of the precompile provider.
+    spec: TaikoSpecId,
+}
+
+impl TaikoPrecompiles {
+    /// Create a new precompile provider with the given TaikoSpecId.
+    #[inline]
+    pub fn new_with_spec(spec: TaikoSpecId) -> Self {
+        let precompiles = match spec {
+            TaikoSpecId::GENESIS => Precompiles::new(spec.into_eth_spec().into()),
+            TaikoSpecId::ONTAKE => ontake(),
+            TaikoSpecId::PACAYA => pacaya(),
+            TaikoSpecId::SHASTA => shasta(),
+        };
+
+        Self { inner: EthPrecompiles { precompiles, spec: SpecId::default() }, spec }
+    }
+
+    /// Precompiles getter.
+    #[inline]
+    pub fn precompiles(&self) -> &'static Precompiles {
+        self.inner.precompiles
+    }
+}
+
+/// Returns precompiles for Ontake spec.
+pub fn ontake() -> &'static Precompiles {
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+    INSTANCE.get_or_init(|| Precompiles::berlin().clone())
+}
+
+/// Returns precompiles for Pacaya spec.
+pub fn pacaya() -> &'static Precompiles {
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        let mut precompiles = ontake().clone();
+        precompiles.extend([l1sload::L1SLOAD]);
+        precompiles
+    })
+}
+
+/// Returns precompiles for Shasta spec.
+pub fn shasta() -> &'static Precompiles {
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+    INSTANCE.get_or_init(|| pacaya().clone())
+}
+
+impl<CTX> PrecompileProvider<CTX> for TaikoPrecompiles
+where
+    CTX: ContextTr<Cfg: Cfg<Spec = TaikoSpecId>>,
+{
+    type Output = InterpreterResult;
+
+    #[inline]
+    fn set_spec(&mut self, spec: <CTX::Cfg as Cfg>::Spec) -> bool {
+        if spec == self.spec {
+            return false;
+        }
+        *self = Self::new_with_spec(spec);
+        true
+    }
+
+    #[inline]
+    fn run(
+        &mut self,
+        context: &mut CTX,
+        inputs: &CallInputs,
+    ) -> Result<Option<Self::Output>, String> {
+        self.inner.run(context, inputs)
+    }
+
+    #[inline]
+    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
+        self.inner.warm_addresses()
+    }
+
+    #[inline]
+    fn contains(&self, address: &Address) -> bool {
+        self.inner.contains(address)
+    }
+}
+
+impl Default for TaikoPrecompiles {
+    fn default() -> Self {
+        Self::new_with_spec(TaikoSpecId::default())
+    }
+}
+
+impl From<TaikoPrecompiles> for PrecompilesMap {
+    fn from(val: TaikoPrecompiles) -> Self {
+        PrecompilesMap::from_static(val.inner.precompiles)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::address;
+
+    #[test]
+    fn test_taiko_precompiles_creation() {
+        let specs = vec![
+            TaikoSpecId::GENESIS,
+            TaikoSpecId::ONTAKE,
+            TaikoSpecId::PACAYA,
+            TaikoSpecId::SHASTA,
+        ];
+
+        for spec in specs {
+            let precompiles = TaikoPrecompiles::new_with_spec(spec);
+            assert_eq!(precompiles.spec, spec);
+
+            let addresses: Vec<_> = precompiles.precompiles().addresses().collect();
+            assert!(!addresses.is_empty(), "Precompiles should not be empty for spec {:?}", spec);
+
+            let ecrecover_addr = address!("0000000000000000000000000000000000000001");
+            assert!(
+                addresses.contains(&&ecrecover_addr),
+                "ECRECOVER should be present for spec {:?}",
+                spec
+            );
+        }
+    }
+
+    #[test]
+    fn test_spec_specific_precompiles() {
+        let ontake_p = TaikoPrecompiles::new_with_spec(TaikoSpecId::ONTAKE);
+        let pacaya_p = TaikoPrecompiles::new_with_spec(TaikoSpecId::PACAYA);
+        let shasta_p = TaikoPrecompiles::new_with_spec(TaikoSpecId::SHASTA);
+
+        let ontake_count = ontake_p.precompiles().addresses().count();
+        let pacaya_count = pacaya_p.precompiles().addresses().count();
+        let shasta_count = shasta_p.precompiles().addresses().count();
+
+        assert_eq!(
+            pacaya_count,
+            ontake_count + 1,
+            "Pacaya should have L1SLOAD precompile added to Ontake"
+        );
+        assert_eq!(shasta_count, pacaya_count, "Shasta inherits from Pacaya");
+
+        let l1sload_addr = address!("0000000000000000000000000000000000010001");
+        let pacaya_addrs: Vec<_> = pacaya_p.precompiles().addresses().collect();
+        let shasta_addrs: Vec<_> = shasta_p.precompiles().addresses().collect();
+        let ontake_addrs: Vec<_> = ontake_p.precompiles().addresses().collect();
+
+        assert!(pacaya_addrs.contains(&&l1sload_addr), "Pacaya should contain L1SLOAD");
+        assert!(shasta_addrs.contains(&&l1sload_addr), "Shasta should contain L1SLOAD");
+        assert!(!ontake_addrs.contains(&&l1sload_addr), "Ontake should NOT contain L1SLOAD");
+    }
+
+    #[test]
+    fn test_default_implementation() {
+        let default_precompiles = TaikoPrecompiles::default();
+        let expected_spec = TaikoSpecId::default();
+
+        assert_eq!(default_precompiles.spec, expected_spec);
+        assert!(!default_precompiles.precompiles().addresses().collect::<Vec<_>>().is_empty());
+    }
+}


### PR DESCRIPTION
Adds L1SLOAD precompile to Reth. Allows reading & writing L1SLOAD values with the given key (L1 contract address, storage key and L1 block number). The implementation for the precompile is basic, since this is required for proving in Raiko, which is responsible for fetching the actual verified L1 values during proving.

For details on complete Nethermind implementation, please refer: https://github.com/NethermindEth/nethermind/pull/9030