### PR TITLE
chore(consensus): update pre-execution block validation

### DIFF
--- a/crates/consensus/src/validation/mod.rs
+++ b/crates/consensus/src/validation/mod.rs
@@ -116,7 +116,8 @@ impl<B: Block> Consensus<B> for TaikoBeaconConsensus {
             ));
         }
 
-        let body_ommers_hash = block.body().calculate_ommers_root().unwrap_or(EMPTY_OMMER_ROOT_HASH);
+        let body_ommers_hash =
+            block.body().calculate_ommers_root().unwrap_or(EMPTY_OMMER_ROOT_HASH);
         if body_ommers_hash != EMPTY_OMMER_ROOT_HASH {
             return Err(ConsensusError::BodyOmmersHashDiff(
                 GotExpected { got: body_ommers_hash, expected: EMPTY_OMMER_ROOT_HASH }.into(),

--- a/crates/consensus/src/validation/mod.rs
+++ b/crates/consensus/src/validation/mod.rs
@@ -13,7 +13,8 @@ use reth_consensus_common::validation::{
 use reth_ethereum_consensus::validate_block_post_execution;
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{
-    Block, BlockHeader, GotExpected, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
+    Block, BlockBody, BlockHeader, GotExpected, NodePrimitives, RecoveredBlock, SealedBlock,
+    SealedHeader,
 };
 
 use crate::eip4396::{
@@ -106,11 +107,24 @@ impl<B: Block> Consensus<B> for TaikoBeaconConsensus {
     /// - Compares the ommer hash in the block header to the block body
     /// - Compares the transactions root in the block header to the block body
     fn validate_block_pre_execution(&self, block: &SealedBlock<B>) -> Result<(), ConsensusError> {
+        let ommers_hash = block.ommers_hash();
+
         // In Taiko network, ommer hash is always empty.
-        if block.ommers_hash() != EMPTY_OMMER_ROOT_HASH {
+        if ommers_hash != EMPTY_OMMER_ROOT_HASH {
             return Err(ConsensusError::BodyOmmersHashDiff(
-                GotExpected { got: block.ommers_hash(), expected: EMPTY_OMMER_ROOT_HASH }.into(),
+                GotExpected { got: ommers_hash, expected: EMPTY_OMMER_ROOT_HASH }.into(),
             ));
+        }
+
+        let body_ommers_hash = block.body().calculate_ommers_root().unwrap_or(EMPTY_OMMER_ROOT_HASH);
+        if body_ommers_hash != EMPTY_OMMER_ROOT_HASH {
+            return Err(ConsensusError::BodyOmmersHashDiff(
+                GotExpected { got: body_ommers_hash, expected: EMPTY_OMMER_ROOT_HASH }.into(),
+            ));
+        }
+
+        if let Err(error) = block.ensure_transaction_root_valid() {
+            return Err(ConsensusError::BodyTransactionRootDiff(error.into()));
         }
 
         Ok(())

--- a/crates/consensus/src/validation/tests.rs
+++ b/crates/consensus/src/validation/tests.rs
@@ -134,14 +134,14 @@ fn test_validate_block_pre_execution_rejects_non_empty_ommer_hash() {
 }
 
 #[test]
-fn test_validate_block_pre_execution_ignores_non_empty_ommers_body_when_header_hash_is_empty() {
+fn test_validate_block_pre_execution_rejects_non_empty_ommers_body() {
     let header = Header::default();
     let body = BlockBody { ommers: vec![Header::default()], ..Default::default() };
 
     let block = SealedBlock::seal_slow(Block { header, body });
 
-    assert!(
-        test_consensus().validate_block_pre_execution(&block).is_ok(),
-        "main-branch behavior only enforced the header ommer hash here"
-    );
+    assert!(matches!(
+        test_consensus().validate_block_pre_execution(&block),
+        Err(ConsensusError::BodyOmmersHashDiff(_))
+    ));
 }


### PR DESCRIPTION
## Summary
- reject blocks whose body contains non-empty ommers even when the header ommers hash is empty
- validate transaction roots during `validate_block_pre_execution`
- simplify ommers hash handling by reusing the header value and normalizing empty body ommers to the empty root
- update the consensus test to assert non-empty body ommers are rejected

## Testing
- `cargo test -p alethia-reth-consensus test_validate_block_pre_execution -- --nocapture`
- `just clippy`