### PR TITLE
feat(block): update Uzen headers to set zero blob gas fields

### DIFF
--- a/crates/block/src/assembler.rs
+++ b/crates/block/src/assembler.rs
@@ -100,8 +100,8 @@ where
             gas_used: *gas_used,
             extra_data: ctx.extra_data,
             parent_beacon_block_root: ctx.parent_beacon_block_root,
-            blob_gas_used: None,
-            excess_blob_gas: None,
+            blob_gas_used: ctx.is_uzen_active.then_some(0),
+            excess_blob_gas: ctx.is_uzen_active.then_some(0),
             requests_hash,
         };
 
@@ -236,6 +236,8 @@ mod test {
             .expect("Uzen block should assemble");
 
         assert_eq!(block.header.requests_hash, Some(EMPTY_REQUESTS_HASH));
+        assert_eq!(block.header.blob_gas_used, Some(0));
+        assert_eq!(block.header.excess_blob_gas, Some(0));
     }
 
     fn sample_transaction() -> TransactionSigned {

--- a/crates/rpc/src/engine/validator.rs
+++ b/crates/rpc/src/engine/validator.rs
@@ -142,6 +142,8 @@ where
             block.header.difficulty = header_difficulty;
         }
         block.header.parent_beacon_block_root = is_uzen_active.then_some(B256::ZERO);
+        block.header.blob_gas_used = is_uzen_active.then_some(0);
+        block.header.excess_blob_gas = is_uzen_active.then_some(0);
         block.header.requests_hash = is_uzen_active.then_some(EMPTY_REQUESTS_HASH);
         if !taiko_sidecar.tx_hash.is_zero() {
             block.header.transactions_root = taiko_sidecar.tx_hash;
@@ -307,6 +309,8 @@ mod tests {
 
         assert_eq!(sealed.hash(), payload.execution_payload.block_hash);
         assert_eq!(sealed.header().parent_beacon_block_root, Some(B256::ZERO));
+        assert_eq!(sealed.header().blob_gas_used, Some(0));
+        assert_eq!(sealed.header().excess_blob_gas, Some(0));
         assert_eq!(sealed.header().requests_hash, Some(EMPTY_REQUESTS_HASH));
     }
 
@@ -343,6 +347,8 @@ mod tests {
                 extra_data: Bytes::default(),
                 difficulty,
                 parent_beacon_block_root,
+                blob_gas_used: Some(0),
+                excess_blob_gas: Some(0),
                 requests_hash: Some(EMPTY_REQUESTS_HASH),
                 ..Default::default()
             },


### PR DESCRIPTION
## Summary
- set `blob_gas_used` and `excess_blob_gas` to `Some(0)` when assembling Uzen block headers
- normalize imported Uzen payloads to the same zero-valued blob gas fields in the engine validator
- extend Uzen tests to assert the pinned header values for both assembled and reconstructed blocks

## Testing
- `cargo test -p alethia-reth-block assembled_uzen_block_sets_requests_hash -- --nocapture`
- `cargo test -p alethia-reth-rpc accepts_uzen_payload_when_validator_infers_parent_beacon_block_root -- --nocapture`