### PR TITLE
feat(rpc): return U256 from `setBatchToLastBlock` for taiko-geth parity

### DIFF
--- a/crates/rpc/src/eth/auth/mod.rs
+++ b/crates/rpc/src/eth/auth/mod.rs
@@ -69,7 +69,7 @@ pub trait TaikoAuthExtApi<T: RpcObject> {
     async fn set_l1_origin_signature(&self, id: U256, signature: Bytes) -> RpcResult<RpcL1Origin>;
     /// Stores an explicit batch-to-last-block mapping.
     #[method(name = "setBatchToLastBlock")]
-    async fn set_batch_to_last_block(&self, batch_id: U256, block_number: U256) -> RpcResult<u64>;
+    async fn set_batch_to_last_block(&self, batch_id: U256, block_number: U256) -> RpcResult<U256>;
     /// Returns the last L1 origin for a given batch ID.
     #[method(name = "lastL1OriginByBatchID")]
     async fn last_l1_origin_by_batch_id(&self, batch_id: U256) -> RpcResult<Option<RpcL1Origin>>;
@@ -129,6 +129,26 @@ impl<Pool, Eth, Evm, Provider: DatabaseProviderFactory> TaikoAuthExt<Pool, Eth, 
     pub fn new(provider: Provider, pool: Pool, tx_resp_builder: Eth, evm_config: Evm) -> Self {
         Self { provider, pool, tx_resp_builder, evm_config }
     }
+
+    /// Stores the current L1 head origin block id.
+    fn store_head_l1_origin(&self, id: U256) -> RpcResult<U256> {
+        let tx = self.provider.database_provider_rw().map_err(internal_eth_error)?.into_tx();
+
+        tx.put::<StoredL1HeadOriginTable>(STORED_L1_HEAD_ORIGIN_KEY, id.to::<u64>())
+            .map_err(internal_eth_error)?;
+
+        tx.commit().map_err(internal_eth_error)?;
+
+        Ok(id)
+    }
+
+    /// Stores the mapping from batch ID to its last block number.
+    fn store_batch_to_last_block(&self, batch_id: U256, block_number: U256) -> RpcResult<U256> {
+        let tx = self.provider.database_provider_rw().map_err(internal_eth_error)?.into_tx();
+        tx.put::<BatchToLastBlock>(batch_id.to(), block_number.to()).map_err(internal_eth_error)?;
+        tx.commit().map_err(internal_eth_error)?;
+        Ok(batch_id)
+    }
 }
 
 #[async_trait]
@@ -156,14 +176,7 @@ where
 {
     /// Sets the L1 head origin in the database.
     async fn set_head_l1_origin(&self, id: U256) -> RpcResult<U256> {
-        let tx = self.provider.database_provider_rw().map_err(internal_eth_error)?.into_tx();
-
-        tx.put::<StoredL1HeadOriginTable>(STORED_L1_HEAD_ORIGIN_KEY, id.to::<u64>())
-            .map_err(internal_eth_error)?;
-
-        tx.commit().map_err(internal_eth_error)?;
-
-        Ok(id)
+        self.store_head_l1_origin(id)
     }
 
     /// Sets the L1 origin signature in the database.
@@ -188,11 +201,8 @@ where
     }
 
     /// Sets the mapping from batch ID to its last block number in the database.
-    async fn set_batch_to_last_block(&self, batch_id: U256, block_number: U256) -> RpcResult<u64> {
-        let tx = self.provider.database_provider_rw().map_err(internal_eth_error)?.into_tx();
-        tx.put::<BatchToLastBlock>(batch_id.to(), block_number.to()).map_err(internal_eth_error)?;
-        tx.commit().map_err(internal_eth_error)?;
-        Ok(batch_id.to())
+    async fn set_batch_to_last_block(&self, batch_id: U256, block_number: U256) -> RpcResult<U256> {
+        self.store_batch_to_last_block(batch_id, block_number)
     }
 
     /// Updates the L1 origin in the database.

--- a/crates/rpc/src/eth/auth/tests.rs
+++ b/crates/rpc/src/eth/auth/tests.rs
@@ -628,3 +628,27 @@ fn skips_preconfirmation_blocks_when_scanning() {
     let block_id = api.resolve_last_block_number_by_batch_id(proposal_id).unwrap();
     assert_eq!(block_id, U256::from(1u64));
 }
+
+#[tokio::test]
+/// Returns a geth-compatible quantity when storing the batch-to-last-block mapping.
+async fn set_batch_to_last_block_returns_u256_quantity() {
+    let genesis_header = Header { number: 0, gas_limit: 1_000_000, ..Default::default() };
+    let (factory, provider_rw) = create_taiko_test_provider_factory_with_genesis();
+    provider_rw.commit().expect("commit");
+
+    let api = create_test_api(factory, genesis_header);
+
+    let batch_id = U256::from(7u64);
+    let block_id = U256::from(11u64);
+
+    let stored_batch_id = api
+        .store_batch_to_last_block(batch_id, block_id)
+        .expect("set batch mapping");
+
+    assert_eq!(stored_batch_id, batch_id);
+    assert_eq!(
+        api.read_cached_last_block_number_by_batch_id(batch_id)
+            .expect("read cached mapping"),
+        Some(block_id)
+    );
+}

--- a/crates/rpc/src/eth/auth/tests.rs
+++ b/crates/rpc/src/eth/auth/tests.rs
@@ -641,14 +641,12 @@ async fn set_batch_to_last_block_returns_u256_quantity() {
     let batch_id = U256::from(7u64);
     let block_id = U256::from(11u64);
 
-    let stored_batch_id = api
-        .store_batch_to_last_block(batch_id, block_id)
-        .expect("set batch mapping");
+    let stored_batch_id =
+        api.store_batch_to_last_block(batch_id, block_id).expect("set batch mapping");
 
     assert_eq!(stored_batch_id, batch_id);
     assert_eq!(
-        api.read_cached_last_block_number_by_batch_id(batch_id)
-            .expect("read cached mapping"),
+        api.read_cached_last_block_number_by_batch_id(batch_id).expect("read cached mapping"),
         Some(block_id)
     );
 }


### PR DESCRIPTION
## Summary

- Match taiko-geth's `*hexutil.Big` return on `setBatchToLastBlock` by returning `U256` instead of `u64`, so the response serializes as a hex quantity string (`"0x7"`) rather than a JSON number. Reference: [`taiko-geth/eth/taiko_api_backend.go:210-217`](https://github.com/taikoxyz/taiko-geth/blob/main/eth/taiko_api_backend.go#L210-L217).
- Extract the storage logic for `set_head_l1_origin` and `set_batch_to_last_block` into inherent helpers (`store_*`) so tests can exercise it synchronously.
- Add a unit test covering the batch-to-last-block helper.

## Notes

- Breaking JSON response-shape change on the auth namespace (driver-only). The new shape matches geth, so consumers already wired to taiko-geth should become *more* compatible, not less.
- Code review flagged one follow-up worth considering: the new test asserts the Rust return value but not the JSON wire shape — adding `assert_eq!(serde_json::to_value(stored_batch_id).unwrap(), json!("0x7"))` would guard the actual invariant being fixed.

## Test plan

- [ ] `just test`
- [ ] `just clippy`
- [ ] Verify driver (taiko-client) consumes the response correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)