### PR TITLE
fix(guest): avoid reth std feature leakage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,44 +75,42 @@ parity-scale-codec = "3.2.1"
 reth = { git = "https://github.com/paradigmxyz/reth", package = "reth", tag = "v2.0.0" }
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-codecs = { version = "0.1.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", package = "reth-ethereum-primitives", tag = "v2.0.0", default-features = false, features = [
-    "std",
-] }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", package = "reth-ethereum-primitives", tag = "v2.0.0", default-features = false }
 reth-primitives-traits = { version = "0.1.0", default-features = false }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
@@ -120,11 +118,11 @@ reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0
 reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0" }
 
 # revm

--- a/crates/block/Cargo.toml
+++ b/crates/block/Cargo.toml
@@ -17,6 +17,7 @@ net = [
     "alethia-reth-primitives?/net",
     "dep:reth-payload-primitives",
     "dep:reth-rpc-eth-api",
+    "dep:reth-transaction-pool",
 ]
 serde = ["dep:alethia-reth-primitives", "alethia-reth-primitives?/serde"]
 
@@ -45,12 +46,13 @@ reth-revm = { workspace = true }
 reth-rpc-eth-api = { workspace = true, optional = true }
 reth-storage-api = { workspace = true, optional = true }
 reth-storage-errors = { workspace = true }
-reth-transaction-pool = { workspace = true, features = ["test-utils"] }
+reth-transaction-pool = { workspace = true, optional = true }
 reth-trie-common = { workspace = true, optional = true }
 revm-database-interface = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 reth-storage-api = { workspace = true }
 reth-trie-common = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }

--- a/crates/block/Cargo.toml
+++ b/crates/block/Cargo.toml
@@ -13,6 +13,7 @@ default = ["net"]
 prover = ["dep:alethia-reth-primitives"]
 test-utils = ["dep:reth-storage-api", "dep:reth-trie-common"]
 net = [
+    "std",
     "dep:alethia-reth-primitives",
     "alethia-reth-primitives?/net",
     "dep:reth-payload-primitives",
@@ -20,10 +21,28 @@ net = [
     "dep:reth-transaction-pool",
 ]
 serde = ["dep:alethia-reth-primitives", "alethia-reth-primitives?/serde"]
+std = [
+    "alethia-reth-chainspec/std",
+    "alethia-reth-evm/std",
+    "alethia-reth-primitives?/std",
+    "reth-chainspec/std",
+    "reth-ethereum-forks/std",
+    "reth-ethereum-primitives/std",
+    "reth-evm/std",
+    "reth-evm-ethereum/std",
+    "reth-execution-types/std",
+    "reth-payload-primitives?/std",
+    "reth-primitives-traits/std",
+    "reth-revm/std",
+    "reth-rpc-eth-api?/client",
+    "reth-storage-api?/std",
+    "reth-storage-errors/std",
+    "reth-trie-common?/std",
+]
 
 [dependencies]
 alethia-reth-chainspec = { path = "../chainspec", default-features = false }
-alethia-reth-evm = { path = "../evm" }
+alethia-reth-evm = { path = "../evm", default-features = false }
 alethia-reth-primitives = { path = "../primitives", default-features = false, optional = true }
 alloy-consensus = { workspace = true }
 alloy-eips = { workspace = true }
@@ -34,20 +53,20 @@ alloy-rlp = { workspace = true }
 alloy-rpc-types-eth = { workspace = true }
 flate2 = { workspace = true }
 op-alloy-flz = { workspace = true }
-reth-chainspec = { workspace = true }
-reth-ethereum-forks = { workspace = true }
-reth-ethereum-primitives = { workspace = true }
-reth-evm = { workspace = true }
-reth-evm-ethereum = { workspace = true }
-reth-execution-types = { workspace = true }
-reth-payload-primitives = { workspace = true, optional = true }
+reth-chainspec = { workspace = true, default-features = false }
+reth-ethereum-forks = { workspace = true, default-features = false }
+reth-ethereum-primitives = { workspace = true, default-features = false }
+reth-evm = { workspace = true, default-features = false }
+reth-evm-ethereum = { workspace = true, default-features = false }
+reth-execution-types = { workspace = true, default-features = false }
+reth-payload-primitives = { workspace = true, default-features = false, optional = true }
 reth-primitives-traits = { workspace = true }
-reth-revm = { workspace = true }
+reth-revm = { workspace = true, default-features = false }
 reth-rpc-eth-api = { workspace = true, optional = true }
-reth-storage-api = { workspace = true, optional = true }
-reth-storage-errors = { workspace = true }
+reth-storage-api = { workspace = true, default-features = false, optional = true }
+reth-storage-errors = { workspace = true, default-features = false }
 reth-transaction-pool = { workspace = true, optional = true }
-reth-trie-common = { workspace = true, optional = true }
+reth-trie-common = { workspace = true, default-features = false, optional = true }
 revm-database-interface = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/block/Cargo.toml
+++ b/crates/block/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["net"]
-prover = []
+prover = ["dep:alethia-reth-primitives"]
 test-utils = ["dep:reth-storage-api", "dep:reth-trie-common"]
 net = [
     "dep:alethia-reth-primitives",

--- a/crates/block/src/config.rs
+++ b/crates/block/src/config.rs
@@ -2,6 +2,7 @@
 use std::{borrow::Cow, sync::Arc};
 
 use alloy_consensus::{BlockHeader, Header};
+#[cfg(feature = "net")]
 use alloy_eips::Decodable2718;
 use alloy_hardforks::EthereumHardforks;
 use alloy_primitives::Bytes;
@@ -11,17 +12,21 @@ use reth_ethereum_forks::Hardforks;
 use reth_ethereum_primitives::EthPrimitives;
 #[cfg(feature = "net")]
 use reth_evm::ConfigureEngineEvm;
-use reth_evm::{ConfigureEvm, EvmEnv, EvmEnvFor, ExecutableTxIterator, ExecutionCtxFor};
+use reth_evm::{ConfigureEvm, EvmEnv, EvmEnvFor};
+#[cfg(feature = "net")]
+use reth_evm::{ExecutableTxIterator, ExecutionCtxFor};
 use reth_evm_ethereum::RethReceiptBuilder;
 #[cfg(feature = "net")]
 use reth_payload_primitives::ExecutionPayload;
 use reth_primitives_traits::{
-    BlockTy, SealedBlock, SealedHeader, SignedTransaction, TxTy, constants::MAX_TX_GAS_LIMIT_OSAKA,
+    constants::MAX_TX_GAS_LIMIT_OSAKA, BlockTy, SealedBlock, SealedHeader,
 };
+#[cfg(feature = "net")]
+use reth_primitives_traits::{SignedTransaction, TxTy};
 use reth_revm::{
     context::{BlockEnv, CfgEnv},
     context_interface::block::BlobExcessGasAndPrice,
-    primitives::{Address, B256, U256, hardfork::SpecId},
+    primitives::{hardfork::SpecId, Address, B256, U256},
 };
 #[cfg(feature = "net")]
 use reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv;
@@ -109,7 +114,11 @@ fn normalize_parent_beacon_block_root(
     is_uzen_active: bool,
     parent_beacon_block_root: Option<B256>,
 ) -> Option<B256> {
-    if is_uzen_active { parent_beacon_block_root.or(Some(B256::ZERO)) } else { None }
+    if is_uzen_active {
+        parent_beacon_block_root.or(Some(B256::ZERO))
+    } else {
+        None
+    }
 }
 
 impl ConfigureEvm for TaikoEvmConfig {
@@ -406,7 +415,7 @@ impl BuildPendingEnv<Header> for TaikoNextBlockEnvAttributes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alethia_reth_chainspec::{TAIKO_DEVNET, hardfork::TaikoHardfork};
+    use alethia_reth_chainspec::{hardfork::TaikoHardfork, TAIKO_DEVNET};
     use alloy_hardforks::ForkCondition;
     use std::sync::Arc;
 

--- a/crates/block/src/lib.rs
+++ b/crates/block/src/lib.rs
@@ -13,4 +13,5 @@ pub mod factory;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod testutil;
 /// Shared transaction-selection primitives used by block and RPC flows.
+#[cfg(any(test, feature = "net"))]
 pub mod tx_selection;

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -9,8 +9,17 @@ license.workspace = true
 path = "src/lib.rs"
 
 [features]
-default = []
+default = ["std"]
 serde = ["dep:serde", "alloy-hardforks/serde"]
+std = [
+    "reth-chainspec/std",
+    "reth-ethereum-forks/std",
+    "reth-evm/std",
+    "reth-network-peers/std",
+    "reth-primitives/std",
+    "reth-primitives-traits/std",
+    "reth-revm/std",
+]
 
 [dependencies]
 alloy-chains = { workspace = true }
@@ -20,12 +29,12 @@ alloy-genesis = { workspace = true }
 alloy-hardforks = { workspace = true }
 alloy-primitives = { workspace = true }
 auto_impl = { workspace = true }
-reth-chainspec = { workspace = true }
-reth-ethereum-forks = { workspace = true }
-reth-evm = { workspace = true }
-reth-network-peers = { workspace = true }
+reth-chainspec = { workspace = true, default-features = false }
+reth-ethereum-forks = { workspace = true, default-features = false }
+reth-evm = { workspace = true, default-features = false }
+reth-network-peers = { workspace = true, default-features = false }
 reth-primitives = { workspace = true }
 reth-primitives-traits = { workspace = true }
-reth-revm = { workspace = true }
+reth-revm = { workspace = true, default-features = false }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 path = "src/lib.rs"
 
 [features]
-default = ["full"]
+default = ["full", "std"]
 full = [
     "dep:alethia-reth-chainspec",
     "dep:alethia-reth-evm",
@@ -20,6 +20,18 @@ full = [
     "dep:reth-ethereum-consensus",
     "dep:reth-ethereum-primitives",
     "dep:reth-execution-types",
+]
+std = [
+    "alethia-reth-chainspec?/std",
+    "alethia-reth-evm?/std",
+    "alethia-reth-primitives/std",
+    "reth-chainspec?/std",
+    "reth-consensus?/std",
+    "reth-consensus-common?/std",
+    "reth-ethereum-consensus?/std",
+    "reth-ethereum-primitives?/std",
+    "reth-execution-types?/std",
+    "reth-primitives-traits/std",
 ]
 
 [dependencies]
@@ -32,11 +44,11 @@ reth-primitives-traits = { workspace = true }
 
 # Only with "full"
 alethia-reth-chainspec = { path = "../chainspec", default-features = false, optional = true }
-alethia-reth-evm = { path = "../evm", optional = true }
+alethia-reth-evm = { path = "../evm", default-features = false, optional = true }
 alloy-hardforks = { workspace = true, optional = true }
-reth-chainspec = { workspace = true, optional = true }
-reth-consensus = { workspace = true, optional = true }
-reth-consensus-common = { workspace = true, optional = true }
-reth-ethereum-consensus = { workspace = true, optional = true }
-reth-ethereum-primitives = { workspace = true, optional = true }
-reth-execution-types = { workspace = true, optional = true }
+reth-chainspec = { workspace = true, default-features = false, optional = true }
+reth-consensus = { workspace = true, default-features = false, optional = true }
+reth-consensus-common = { workspace = true, default-features = false, optional = true }
+reth-ethereum-consensus = { workspace = true, default-features = false, optional = true }
+reth-ethereum-primitives = { workspace = true, default-features = false, optional = true }
+reth-execution-types = { workspace = true, default-features = false, optional = true }

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -9,15 +9,20 @@ license.workspace = true
 path = "src/lib.rs"
 
 [features]
-default = []
+default = ["std"]
 serde = ["dep:serde"]
+std = [
+    "alethia-reth-primitives/std",
+    "reth-evm/std",
+    "reth-revm/std",
+]
 
 [dependencies]
 alethia-reth-primitives = { path = "../primitives", default-features = false }
 alloy-evm = { workspace = true }
 alloy-primitives = { workspace = true }
-reth-evm = { workspace = true }
-reth-revm = { workspace = true }
+reth-evm = { workspace = true, default-features = false }
+reth-revm = { workspace = true, default-features = false }
 revm-database-interface = { workspace = true }
 serde = { workspace = true, optional = true }
 tracing = { workspace = true }

--- a/crates/evm/src/alloy.rs
+++ b/crates/evm/src/alloy.rs
@@ -223,14 +223,20 @@ where
                 .ok_or(EVMError::Custom("invalid encoded anchor system call data".to_string()))?;
             debug!(target: "taiko_evm", "Anchor system call detected: base_fee_share_pctg = {}, caller_nonce = {}", base_fee_share_pctg, caller_nonce);
 
+            // Set the Anchor transaction information for the later EVM execution.
+            self.inner.with_extra_execution_context(base_fee_share_pctg, caller, caller_nonce);
+
             // Load the system accounts through the journal so witness generation can include the
             // same pre-execution dependencies that stateless validation will read later.
+            //
+            // Commit the synthetic pre-execution load immediately afterwards. This keeps the
+            // loaded accounts in state for witness generation, but advances the journal
+            // transaction id so the first real anchor transaction still pays normal cold-access
+            // costs and preserves mainline gas accounting.
             let journal = self.ctx_mut().journal_mut();
             journal.load_account(caller)?;
             journal.load_account(contract)?;
-
-            // Set the Anchor transaction information for the later EVM execution.
-            self.inner.with_extra_execution_context(base_fee_share_pctg, caller, caller_nonce);
+            journal.commit_tx();
 
             // Return a dummy execution result and state to avoid further processing.
             return Ok(ResultAndState {
@@ -373,7 +379,7 @@ mod tests {
     }
 
     #[test]
-    fn anchor_system_call_touches_system_accounts_for_witness_generation() {
+    fn anchor_system_call_records_witness_accounts_without_warming_next_tx() {
         let golden_touch = Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS);
         let chain_id = 167_000;
         let treasury = get_treasury_address(chain_id);
@@ -395,7 +401,8 @@ mod tests {
         evm.transact_system_call(golden_touch, treasury, encode_anchor_system_call_data(25, 7))
             .expect("anchor system call should short-circuit successfully");
 
-        let witness_state = &evm.ctx().journal().state;
+        let journal = evm.ctx().journal();
+        let witness_state = &journal.state;
         assert!(
             witness_state.contains_key(&golden_touch),
             "golden touch must be recorded in journal state for witness generation"
@@ -403,6 +410,24 @@ mod tests {
         assert!(
             witness_state.contains_key(&treasury),
             "treasury must be recorded in journal state for witness generation"
+        );
+
+        let next_tx_id = journal.transaction_id;
+        assert_eq!(next_tx_id, 1, "synthetic pre-execution load should advance tx id");
+
+        let golden_touch_account = witness_state
+            .get(&golden_touch)
+            .expect("golden touch account must stay in witness state");
+        assert!(
+            golden_touch_account.is_cold_transaction_id(next_tx_id),
+            "golden touch must be cold again for the first real transaction"
+        );
+
+        let treasury_account =
+            witness_state.get(&treasury).expect("treasury account must stay in witness state");
+        assert!(
+            treasury_account.is_cold_transaction_id(next_tx_id),
+            "treasury must be cold again for the first real transaction"
         );
     }
 }

--- a/crates/evm/src/alloy.rs
+++ b/crates/evm/src/alloy.rs
@@ -216,8 +216,8 @@ where
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         // NOTE: we use this workaround to mark the Anchor transaction and base fee share percentage
         // in this block.
-        if caller == Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS)
-            && contract == get_treasury_address(self.chain_id())
+        if caller == Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS) &&
+            contract == get_treasury_address(self.chain_id())
         {
             let (base_fee_share_pctg, caller_nonce) = decode_anchor_system_call_data(&data)
                 .ok_or(EVMError::Custom("invalid encoded anchor system call data".to_string()))?;

--- a/crates/evm/src/alloy.rs
+++ b/crates/evm/src/alloy.rs
@@ -1,23 +1,21 @@
 //! Alloy EVM trait adapter for Taiko execution semantics.
-use std::{
-    collections::HashMap,
-    ops::{Deref, DerefMut},
-};
+use std::ops::{Deref, DerefMut};
 
 use alloy_evm::{Database, Evm, EvmEnv};
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 // Re-export from primitives so downstream consumers can use the lighter crate.
 pub use alethia_reth_primitives::addresses::TAIKO_GOLDEN_TOUCH_ADDRESS;
 use reth_revm::{
-    Context, ExecuteEvm, InspectEvm, Inspector,
     context::{
-        BlockEnv, CfgEnv, ContextTr, JournalTr, TxEnv,
         result::{
             EVMError, ExecutionResult, HaltReason, Output, ResultAndState, ResultGas, SuccessReason,
         },
+        BlockEnv, CfgEnv, ContextTr, JournalTr, TxEnv,
     },
     handler::PrecompileProvider,
     interpreter::InterpreterResult,
+    state::EvmState,
+    Context, ExecuteEvm, InspectEvm, Inspector,
 };
 use tracing::debug;
 
@@ -26,7 +24,7 @@ use crate::{
     handler::get_treasury_address,
     spec::TaikoSpecId,
     zk_gas::{
-        adapter::{SharedZkGasMeter, ZkGasInspector, lock_meter},
+        adapter::{lock_meter, SharedZkGasMeter, ZkGasInspector},
         meter::ZkGasOutcome,
     },
 };
@@ -198,7 +196,11 @@ where
         &mut self,
         tx: Self::Tx,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        if self.inspect { self.inner.inspect_tx(tx) } else { self.inner.transact(tx) }
+        if self.inspect {
+            self.inner.inspect_tx(tx)
+        } else {
+            self.inner.transact(tx)
+        }
     }
 
     /// Executes a system call.
@@ -216,8 +218,8 @@ where
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         // NOTE: we use this workaround to mark the Anchor transaction and base fee share percentage
         // in this block.
-        if caller == Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS) &&
-            contract == get_treasury_address(self.chain_id())
+        if caller == Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS)
+            && contract == get_treasury_address(self.chain_id())
         {
             let (base_fee_share_pctg, caller_nonce) = decode_anchor_system_call_data(&data)
                 .ok_or(EVMError::Custom("invalid encoded anchor system call data".to_string()))?;
@@ -246,7 +248,7 @@ where
                     logs: vec![],
                     output: Output::Call(Bytes::new()),
                 },
-                state: HashMap::default(),
+                state: EvmState::default(),
             });
         }
 

--- a/crates/evm/src/alloy.rs
+++ b/crates/evm/src/alloy.rs
@@ -11,7 +11,7 @@ pub use alethia_reth_primitives::addresses::TAIKO_GOLDEN_TOUCH_ADDRESS;
 use reth_revm::{
     Context, ExecuteEvm, InspectEvm, Inspector,
     context::{
-        BlockEnv, CfgEnv, TxEnv,
+        BlockEnv, CfgEnv, ContextTr, JournalTr, TxEnv,
         result::{
             EVMError, ExecutionResult, HaltReason, Output, ResultAndState, ResultGas, SuccessReason,
         },
@@ -216,12 +216,18 @@ where
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         // NOTE: we use this workaround to mark the Anchor transaction and base fee share percentage
         // in this block.
-        if caller == Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS) &&
-            contract == get_treasury_address(self.chain_id())
+        if caller == Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS)
+            && contract == get_treasury_address(self.chain_id())
         {
             let (base_fee_share_pctg, caller_nonce) = decode_anchor_system_call_data(&data)
                 .ok_or(EVMError::Custom("invalid encoded anchor system call data".to_string()))?;
             debug!(target: "taiko_evm", "Anchor system call detected: base_fee_share_pctg = {}, caller_nonce = {}", base_fee_share_pctg, caller_nonce);
+
+            // Load the system accounts through the journal so witness generation can include the
+            // same pre-execution dependencies that stateless validation will read later.
+            let journal = self.ctx_mut().journal_mut();
+            journal.load_account(caller)?;
+            journal.load_account(contract)?;
 
             // Set the Anchor transaction information for the later EVM execution.
             self.inner.with_extra_execution_context(base_fee_share_pctg, caller, caller_nonce);
@@ -348,4 +354,55 @@ pub fn decode_anchor_system_call_data(bytes: &Bytes) -> Option<(u64, u64)> {
     let base_fee_share_pctg = u64::from_be_bytes(bytes[0..8].try_into().ok()?);
     let caller_nonce = u64::from_be_bytes(bytes[8..16].try_into().ok()?);
     Some((base_fee_share_pctg, caller_nonce))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_evm::{Evm, EvmEnv, EvmFactory};
+    use alloy_primitives::U256;
+    use reth_revm::{context::ContextTr, db::InMemoryDB, state::AccountInfo};
+
+    use super::*;
+    use crate::{factory::TaikoEvmFactory, spec::TaikoSpecId};
+
+    fn encode_anchor_system_call_data(base_fee_share_pctg: u64, caller_nonce: u64) -> Bytes {
+        let mut bytes = Vec::with_capacity(16);
+        bytes.extend_from_slice(&base_fee_share_pctg.to_be_bytes());
+        bytes.extend_from_slice(&caller_nonce.to_be_bytes());
+        bytes.into()
+    }
+
+    #[test]
+    fn anchor_system_call_touches_system_accounts_for_witness_generation() {
+        let golden_touch = Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS);
+        let chain_id = 167_000;
+        let treasury = get_treasury_address(chain_id);
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            golden_touch,
+            AccountInfo { nonce: 7, balance: U256::ZERO, ..Default::default() },
+        );
+        db.insert_account_info(
+            treasury,
+            AccountInfo { nonce: 0, balance: U256::ZERO, ..Default::default() },
+        );
+
+        let mut env: EvmEnv<TaikoSpecId> = EvmEnv::default();
+        env.cfg_env.chain_id = chain_id;
+        let mut evm = TaikoEvmFactory.create_evm(db, env);
+
+        evm.transact_system_call(golden_touch, treasury, encode_anchor_system_call_data(25, 7))
+            .expect("anchor system call should short-circuit successfully");
+
+        let witness_state = &evm.ctx().journal().state;
+        assert!(
+            witness_state.contains_key(&golden_touch),
+            "golden touch must be recorded in journal state for witness generation"
+        );
+        assert!(
+            witness_state.contains_key(&treasury),
+            "treasury must be recorded in journal state for witness generation"
+        );
+    }
 }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -17,7 +17,23 @@ serde = [
     "alloy-rpc-types-eth/serde",
 ]
 
-net = ["dep:reth-engine-local", "serde"]
+net = [
+    "std",
+    "dep:reth-chainspec",
+    "dep:reth-engine-local",
+    "dep:reth-engine-primitives",
+    "dep:reth-ethereum-engine-primitives",
+    "dep:reth-payload-primitives",
+    "serde",
+]
+std = [
+    "reth-chainspec?/std",
+    "reth-engine-primitives?/std",
+    "reth-ethereum-engine-primitives?/std",
+    "reth-ethereum-primitives/std",
+    "reth-payload-primitives?/std",
+    "reth-primitives-traits/std",
+]
 
 [dependencies]
 alloy-consensus = { workspace = true }
@@ -26,12 +42,12 @@ alloy-rlp = { workspace = true }
 alloy-rpc-types-engine = { workspace = true }
 alloy-rpc-types-eth = { workspace = true }
 alloy-serde = { workspace = true }
-reth-chainspec = { workspace = true }
-reth-engine-local = { workspace = true, optional = true }
-reth-engine-primitives = { workspace = true }
-reth-ethereum-engine-primitives = { workspace = true }
-reth-ethereum-primitives = { workspace = true }
-reth-payload-primitives = { workspace = true }
+reth-chainspec = { workspace = true, default-features = false, optional = true }
+reth-engine-local = { workspace = true, default-features = false, optional = true }
+reth-engine-primitives = { workspace = true, default-features = false, optional = true }
+reth-ethereum-engine-primitives = { workspace = true, default-features = false, optional = true }
+reth-ethereum-primitives = { workspace = true, default-features = false }
+reth-payload-primitives = { workspace = true, default-features = false, optional = true }
 reth-primitives-traits = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_with = { workspace = true, features = ["base64"] }


### PR DESCRIPTION
## Why
- Keep prover/guest consumers from enabling reth std features that pull quanta into zkVM builds.
- Preserve existing default node behavior by making std explicit on default/net features.

## How
- Adds explicit std feature wiring for Alethia crates while keeping no-default prover paths no-std.
- Makes engine/payload-only primitive dependencies optional behind net.
- Gates net-only EVM payload iterator imports and uses revm EvmState for no-std-compatible result state.

## Tests
- cargo check --manifest-path /tmp/alethia-consumer.tztvZM/Cargo.toml
- cargo tree --manifest-path /tmp/alethia-consumer.tztvZM/Cargo.toml -e features -i quanta (quanta absent)
- cargo check -p alethia-reth-primitives
- cargo check -p alethia-reth-evm
- cargo check -p alethia-reth-block
- cargo check -p alethia-reth-consensus