### PR TITLE
feat: raiko2 filtered block helper

### DIFF
--- a/crates/block/Cargo.toml
+++ b/crates/block/Cargo.toml
@@ -10,7 +10,11 @@ path = "src/lib.rs"
 
 [features]
 default = ["net"]
-prover = ["dep:alethia-reth-primitives"]
+prover = [
+    "dep:alethia-reth-primitives",
+    "dep:reth-storage-api",
+    "dep:reth-trie-common",
+]
 test-utils = ["dep:reth-storage-api", "dep:reth-trie-common"]
 net = [
     "std",

--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -386,8 +386,8 @@ where
                 // We don't allow anchor transaction to be discarded even if it exceeds the zk gas
                 // limit, this should never happen in practice.
                 err if is_zk_gas_limit_exceeded(&err) && !is_anchor_transaction => Ok(()),
-                BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. }) |
-                BlockExecutionError::Validation(
+                BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })
+                | BlockExecutionError::Validation(
                     BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. },
                 ) if !is_anchor_transaction => Ok(()),
                 _ => Err(err),
@@ -424,18 +424,19 @@ fn decode_post_ontake_extra_data(extradata: Bytes) -> u64 {
 mod test {
     use std::sync::Arc;
 
-    use alloy_consensus::{Signed, TxLegacy};
+    use alloy_consensus::{SignableTransaction, Signed, TxLegacy};
     use alloy_evm::EvmFactory;
     use alloy_primitives::{Address, B256, Bytes, ChainId, Signature, TxKind, U64, U256};
     use reth_ethereum_primitives::TransactionSigned;
     use reth_evm::{ConfigureEvm, block::BlockExecutor};
     use reth_evm_ethereum::RethReceiptBuilder;
-    use reth_primitives_traits::SignedTransaction;
+    use reth_primitives_traits::{SealedHeader, SignedTransaction};
     use reth_revm::{
         State,
         db::{CacheDB, EmptyDB},
         state::AccountInfo,
     };
+    use reth_storage_api::noop::NoopProvider;
 
     use alethia_reth_evm::{alloy::decode_anchor_system_call_data, factory::TaikoEvmFactory};
 
@@ -539,6 +540,51 @@ mod test {
         assert_eq!(result.receipts.len(), 1);
         assert!(result.gas_used > 0);
         assert!(ctx.finalized_block_zk_gas() > 0);
+    }
+
+    #[cfg(feature = "prover")]
+    #[test]
+    fn execute_and_filter_block_transactions_skips_invalid_nonce_transaction() {
+        let chain_spec = Arc::new(uzen_chain_spec());
+        let config = TaikoEvmConfig::new(chain_spec);
+        let parent = SealedHeader::seal_slow(alloy_consensus::Header {
+            number: 0,
+            timestamp: 0,
+            gas_limit: 30_000_000,
+            base_fee_per_gas: Some(1),
+            ..Default::default()
+        });
+        let invalid_tx: TransactionSigned = TxLegacy {
+            chain_id: Some(ChainId::from(167_u64)),
+            nonce: 1,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            input: Bytes::default(),
+        }
+        .into_signed(Signature::test_signature())
+        .into();
+
+        let outcome = crate::filtered_block::execute_and_filter_block_transactions(
+            &config,
+            &parent,
+            TaikoNextBlockEnvAttributes {
+                timestamp: 1,
+                suggested_fee_recipient: Address::ZERO,
+                prev_randao: B256::ZERO,
+                gas_limit: 30_000_000,
+                extra_data: Bytes::default(),
+                base_fee_per_gas: 1,
+            },
+            None,
+            vec![invalid_tx],
+            NoopProvider::default(),
+        )
+        .expect("invalid nonce transaction should be skipped");
+
+        assert_eq!(outcome.filtered_block.body().transactions().count(), 0);
+        assert!(outcome.execution_result.receipts.is_empty());
     }
 
     #[test]

--- a/crates/block/src/filtered_block.rs
+++ b/crates/block/src/filtered_block.rs
@@ -1,0 +1,103 @@
+//! Filtered block reconstruction helpers for txlist-driven proving paths.
+
+use alloy_consensus::transaction::Recovered;
+use reth_ethereum_primitives::{Block, EthPrimitives, Receipt, TransactionSigned};
+use reth_evm::{
+    ConfigureEvm,
+    block::{BlockExecutionError, BlockValidationError},
+    execute::{BlockBuilder, BlockBuilderOutcome},
+};
+use reth_execution_types::BlockExecutionResult;
+use reth_primitives_traits::{RecoveredBlock, SealedHeader, SignedTransaction};
+use reth_revm::{database::StateProviderDatabase, db::State};
+use reth_storage_api::StateProvider;
+use reth_trie_common::{HashedPostState, updates::TrieUpdates};
+
+use crate::config::{TaikoEvmConfig, TaikoNextBlockEnvAttributes};
+
+/// Filtered block execution artifacts returned by txlist-driven reconstruction.
+#[derive(Debug)]
+pub struct FilteredBlockExecutionOutcome {
+    /// The block assembled from transactions that were actually committed.
+    pub filtered_block: RecoveredBlock<Block>,
+    /// The execution result produced while building the filtered block.
+    pub execution_result: BlockExecutionResult<Receipt>,
+    /// The hashed post-state after execution.
+    pub hashed_state: HashedPostState,
+    /// Trie updates collected during state-root calculation.
+    pub trie_updates: TrieUpdates,
+}
+
+impl From<BlockBuilderOutcome<EthPrimitives>> for FilteredBlockExecutionOutcome {
+    fn from(outcome: BlockBuilderOutcome<EthPrimitives>) -> Self {
+        Self {
+            filtered_block: outcome.block,
+            execution_result: outcome.execution_result,
+            hashed_state: outcome.hashed_state,
+            trie_updates: outcome.trie_updates,
+        }
+    }
+}
+
+fn execute_candidate_transaction<B>(
+    builder: &mut B,
+    tx: TransactionSigned,
+) -> Result<(), BlockExecutionError>
+where
+    B: BlockBuilder<Primitives = EthPrimitives>,
+{
+    let recovered = match tx.try_into_recovered() {
+        Ok(recovered) => recovered,
+        Err(_) => return Ok(()),
+    };
+
+    match builder.execute_transaction(recovered) {
+        Ok(_) => Ok(()),
+        Err(
+            BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })
+            | BlockExecutionError::Validation(
+                BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. },
+            ),
+        ) => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+/// Executes `anchor + txlist` against the provided pre-state and assembles the filtered block.
+///
+/// The optional `anchor_tx` is always executed first and treated as fatal if execution fails. All
+/// non-anchor candidate transactions are processed in order; invalid-signature transactions are
+/// skipped before EVM execution, while nonce/balance/gas-invalid transactions are skipped when the
+/// builder rejects them.
+pub fn execute_and_filter_block_transactions<P>(
+    evm_config: &TaikoEvmConfig,
+    parent_header: &SealedHeader,
+    block_env: TaikoNextBlockEnvAttributes,
+    anchor_tx: Option<Recovered<TransactionSigned>>,
+    transactions: Vec<TransactionSigned>,
+    state_provider: P,
+) -> Result<FilteredBlockExecutionOutcome, BlockExecutionError>
+where
+    P: StateProvider + Clone,
+{
+    let mut db = State::builder()
+        .with_database(StateProviderDatabase::new(state_provider.clone()))
+        .with_bundle_update()
+        .build();
+
+    let mut builder = evm_config
+        .builder_for_next_block(&mut db, parent_header, block_env)
+        .map_err(BlockExecutionError::other)?;
+
+    builder.apply_pre_execution_changes()?;
+
+    if let Some(anchor_tx) = anchor_tx {
+        builder.execute_transaction(anchor_tx)?;
+    }
+
+    for tx in transactions {
+        execute_candidate_transaction(&mut builder, tx)?;
+    }
+
+    builder.finish(state_provider, None).map(Into::into)
+}

--- a/crates/block/src/lib.rs
+++ b/crates/block/src/lib.rs
@@ -9,6 +9,9 @@ pub mod config;
 pub mod executor;
 /// Executor factory wiring for Taiko block execution.
 pub mod factory;
+/// Filtered block reconstruction helper used by txlist-driven proving paths.
+#[cfg(feature = "prover")]
+pub mod filtered_block;
 /// Shared test utilities for zk gas integration tests.
 #[cfg(any(test, feature = "test-utils"))]
 pub mod testutil;


### PR DESCRIPTION
## Summary

  This PR adds a prover-only helper for txlist-driven block reconstruction.

  It introduces `filtered_block::execute_and_filter_block_transactions(...)`, which:

  - builds the next-block EVM context from a parent header + block env
  - executes the optional anchor transaction first
  - executes txlist-derived candidate transactions in order
  - skips invalid-signature transactions before EVM execution
  - skips builder-rejected non-anchor transactions for recoverable validity failures
    such as invalid nonce / insufficient balance / block gas-limit overflow
  - returns the filtered reconstructed block together with the execution artifacts
    needed by the proving path

  The returned outcome includes:

  - `filtered_block`
  - `execution_result`
  - `hashed_state`
  - `trie_updates`

  ## Motivation

  The proving path needs to reconstruct the canonical block from `anchor + derived txlist`,
  instead of trusting the externally provided block body as-is.

  That requires a reusable helper which:
  - uses the same block builder / execution machinery as normal block execution
  - preserves the "skip invalid non-anchor txs, continue building" behavior
  - produces both the filtered block body and the post-execution state artifacts

  Moving this into `alethia-reth-block` keeps the proving-specific reconstruction logic
  close to the execution layer and avoids duplicating lower-level builder handling in downstream code.

## Scope

  This change is gated behind the `prover` feature and does not affect the normal network path.

  It also extends the `prover` feature dependencies so the helper can finalize execution and
  compute trie-related outputs:
  - `reth-storage-api`
  - `reth-trie-common`

  ## Testing

  Ran:

  ```bash
  cargo test -p alethia-reth-block
  execute_and_filter_block_transactions_skips_invalid_nonce_transaction --features prover
