### PR TITLE
feat(block): add derived block prover execution helper

### DIFF
--- a/crates/block/Cargo.toml
+++ b/crates/block/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["net"]
-prover = ["dep:alethia-reth-primitives"]
+prover = ["dep:alethia-reth-primitives", "dep:reth-storage-api", "dep:reth-trie-common"]
 test-utils = ["dep:reth-storage-api", "dep:reth-trie-common"]
 net = [
     "std",

--- a/crates/block/Cargo.toml
+++ b/crates/block/Cargo.toml
@@ -71,7 +71,7 @@ revm-database-interface = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 reth-storage-api = { workspace = true }
+reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 reth-trie-common = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }

--- a/crates/block/src/derived_block.rs
+++ b/crates/block/src/derived_block.rs
@@ -1,0 +1,222 @@
+//! Prover helpers for executing derived candidate blocks.
+
+use alloy_consensus::transaction::Recovered;
+use reth_ethereum_primitives::{Block, Receipt, TransactionSigned};
+use reth_evm::{
+    ConfigureEvm,
+    block::BlockExecutionError,
+    execute::{BlockAssembler, BlockAssemblerInput},
+};
+use reth_execution_types::BlockExecutionResult;
+use reth_primitives_traits::{RecoveredBlock, SealedHeader};
+use reth_revm::{
+    Database, State,
+    db::states::{BundleState, bundle_state::BundleRetention},
+};
+use reth_storage_api::noop::NoopProvider;
+use reth_trie_common::{HashedPostState, KeccakKeyHasher};
+
+use crate::{
+    config::{MissingBaseFee, TaikoEvmConfig, TaikoNextBlockEnvAttributes},
+    executor::TaikoBlockExecutor,
+    factory::TaikoBlockExecutorFactory,
+};
+
+/// Execution artifacts produced by prover-mode derived block execution.
+#[derive(Debug)]
+pub struct DerivedBlockExecutionOutcome {
+    /// Transactions that were actually committed by block execution.
+    pub committed_transactions: Vec<Recovered<TransactionSigned>>,
+    /// Execution result for the committed transactions.
+    pub execution_result: BlockExecutionResult<Receipt>,
+    /// Hashed post-state derived from the execution bundle.
+    pub hashed_state: HashedPostState,
+    /// Finalized zk gas accumulated by committed transactions.
+    pub finalized_block_zk_gas: u64,
+}
+
+/// Derives next-block environment attributes from a candidate derived block header.
+fn attributes_from_derived_block(
+    derived_block: &RecoveredBlock<Block>,
+) -> Result<TaikoNextBlockEnvAttributes, BlockExecutionError> {
+    let header = derived_block.header();
+    let base_fee_per_gas = header.base_fee_per_gas.ok_or_else(|| {
+        BlockExecutionError::other(MissingBaseFee { block_number: header.number })
+    })?;
+
+    Ok(TaikoNextBlockEnvAttributes {
+        timestamp: header.timestamp,
+        suggested_fee_recipient: header.beneficiary,
+        prev_randao: header.mix_hash,
+        gas_limit: header.gas_limit,
+        extra_data: header.extra_data.clone(),
+        base_fee_per_gas,
+    })
+}
+
+/// Executes a candidate derived block in prover mode.
+pub fn execute_derived_block<DB>(
+    evm_config: &TaikoEvmConfig,
+    parent_header: &SealedHeader,
+    derived_block: &RecoveredBlock<Block>,
+    db: DB,
+) -> Result<DerivedBlockExecutionOutcome, BlockExecutionError>
+where
+    DB: Database + std::fmt::Debug,
+{
+    let mut state = State::builder().with_database(db).with_bundle_update().build();
+    let attributes = attributes_from_derived_block(derived_block)?;
+    let evm_env =
+        evm_config.next_evm_env(parent_header, &attributes).map_err(BlockExecutionError::other)?;
+    let evm = evm_config.evm_with_env(&mut state, evm_env);
+    let execution_ctx = evm_config
+        .context_for_next_block(parent_header, attributes)
+        .map_err(BlockExecutionError::other)?;
+    let finalized_zk_gas = execution_ctx.finalized_block_zk_gas.clone();
+    let executor = TaikoBlockExecutor::new(
+        evm,
+        execution_ctx,
+        evm_config.executor_factory.spec().clone(),
+        evm_config.executor_factory.receipt_builder(),
+    );
+
+    let execution_outcome =
+        executor.execute_block_with_committed_transactions(derived_block.transactions_recovered())?;
+    state.merge_transitions(BundleRetention::Reverts);
+
+    let bundle_state = state.take_bundle();
+    let hashed_state = HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state());
+
+    Ok(DerivedBlockExecutionOutcome {
+        committed_transactions: execution_outcome.committed_transactions,
+        execution_result: execution_outcome.execution_result,
+        hashed_state,
+        finalized_block_zk_gas: finalized_zk_gas.load(std::sync::atomic::Ordering::Relaxed),
+    })
+}
+
+/// Assembles the filtered block produced by derived block execution.
+pub fn assemble_filtered_block(
+    evm_config: &TaikoEvmConfig,
+    parent_header: &SealedHeader,
+    derived_block: &RecoveredBlock<Block>,
+    committed_transactions: Vec<Recovered<TransactionSigned>>,
+    execution_result: &BlockExecutionResult<Receipt>,
+    finalized_block_zk_gas: u64,
+    state_root: alloy_primitives::B256,
+) -> Result<RecoveredBlock<Block>, BlockExecutionError> {
+    let attributes = attributes_from_derived_block(derived_block)?;
+    let evm_env =
+        evm_config.next_evm_env(parent_header, &attributes).map_err(BlockExecutionError::other)?;
+    let execution_ctx = evm_config
+        .context_for_next_block(parent_header, attributes)
+        .map_err(BlockExecutionError::other)?;
+    execution_ctx.set_finalized_block_zk_gas(finalized_block_zk_gas);
+    let bundle_state = BundleState::default();
+    let state_provider = NoopProvider::default();
+
+    let senders = committed_transactions.iter().map(Recovered::signer).collect();
+    let transactions = committed_transactions.into_iter().map(Recovered::into_inner).collect();
+
+    let block = evm_config.block_assembler.assemble_block(BlockAssemblerInput::<
+        TaikoBlockExecutorFactory,
+    >::new(
+        evm_env,
+        execution_ctx,
+        parent_header,
+        transactions,
+        execution_result,
+        &bundle_state,
+        &state_provider,
+        state_root,
+    ))?;
+
+    Ok(RecoveredBlock::new_unhashed(block, senders))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_consensus::{Header, Signed, TxLegacy, transaction::Recovered};
+    use alloy_primitives::{Address, B256, Bytes, ChainId, Signature, TxKind, U256};
+    use reth_ethereum_primitives::{Block, BlockBody};
+
+    use super::*;
+    use crate::{
+        config::TaikoEvmConfig,
+        testutil::{BENCH_SUCCESS_TARGET, db_with_contracts},
+    };
+    use alethia_reth_chainspec::spec::TaikoChainSpec;
+
+    const TEST_CALLER: Address = Address::with_last_byte(0x30);
+
+    fn test_tx(chain_id: u64, nonce: u64) -> Recovered<TransactionSigned> {
+        let tx = TxLegacy {
+            chain_id: Some(ChainId::from(chain_id)),
+            nonce,
+            gas_price: 1,
+            gas_limit: 5_000_000,
+            to: TxKind::Call(BENCH_SUCCESS_TARGET),
+            value: U256::ZERO,
+            input: Bytes::default(),
+        };
+        let signature = Signature::new(U256::from(1_u64), U256::from(2_u64), false);
+        Recovered::new_unchecked(
+            Signed::new_unchecked(tx, signature, B256::with_last_byte(TEST_CALLER.as_slice()[19]))
+                .into(),
+            TEST_CALLER,
+        )
+    }
+
+    #[test]
+    fn execute_derived_block_skips_invalid_nonce_transaction_and_records_committed_txs() {
+        let chain_spec = Arc::new(TaikoChainSpec::default());
+        let chain_id = chain_spec.inner.chain().id();
+        let config = TaikoEvmConfig::new(chain_spec);
+        let parent_header = SealedHeader::seal_slow(Header::default());
+        let anchor_tx = test_tx(chain_id, 0);
+        let valid_tx = test_tx(chain_id, 1);
+        let invalid_tx = test_tx(chain_id, 99);
+        let transactions =
+            vec![anchor_tx.clone_inner(), valid_tx.clone_inner(), invalid_tx.clone_inner()];
+        let senders = vec![anchor_tx.signer(), valid_tx.signer(), invalid_tx.signer()];
+        let derived_block = RecoveredBlock::new_unhashed(
+            Block {
+                header: Header {
+                    number: 1,
+                    timestamp: 1,
+                    gas_limit: 30_000_000,
+                    base_fee_per_gas: Some(0),
+                    parent_beacon_block_root: Some(B256::ZERO),
+                    ..Default::default()
+                },
+                body: BlockBody { transactions, ommers: Default::default(), withdrawals: None },
+            },
+            senders,
+        );
+
+        let outcome = execute_derived_block(
+            &config,
+            &parent_header,
+            &derived_block,
+            db_with_contracts(&[(TEST_CALLER, 0)]),
+        )
+        .expect("derived block execution should skip invalid nonce tx");
+
+        assert_eq!(outcome.committed_transactions.len(), 2);
+
+        let filtered_block = assemble_filtered_block(
+            &config,
+            &parent_header,
+            &derived_block,
+            outcome.committed_transactions,
+            &outcome.execution_result,
+            outcome.finalized_block_zk_gas,
+            B256::ZERO,
+        )
+        .expect("filtered block should assemble");
+
+        assert_eq!(filtered_block.body().transactions().count(), 2);
+    }
+}

--- a/crates/block/src/derived_block.rs
+++ b/crates/block/src/derived_block.rs
@@ -80,8 +80,8 @@ where
         evm_config.executor_factory.receipt_builder(),
     );
 
-    let execution_outcome =
-        executor.execute_block_with_committed_transactions(derived_block.transactions_recovered())?;
+    let execution_outcome = executor
+        .execute_block_with_committed_transactions(derived_block.transactions_recovered())?;
     state.merge_transitions(BundleRetention::Reverts);
 
     let bundle_state = state.take_bundle();
@@ -151,7 +151,7 @@ mod tests {
 
     const TEST_CALLER: Address = Address::with_last_byte(0x30);
 
-    fn test_tx(chain_id: u64, nonce: u64) -> Recovered<TransactionSigned> {
+    fn test_transaction(chain_id: u64, nonce: u64) -> Recovered<TransactionSigned> {
         let tx = TxLegacy {
             chain_id: Some(ChainId::from(chain_id)),
             nonce,
@@ -175,12 +175,19 @@ mod tests {
         let chain_id = chain_spec.inner.chain().id();
         let config = TaikoEvmConfig::new(chain_spec);
         let parent_header = SealedHeader::seal_slow(Header::default());
-        let anchor_tx = test_tx(chain_id, 0);
-        let valid_tx = test_tx(chain_id, 1);
-        let invalid_tx = test_tx(chain_id, 99);
-        let transactions =
-            vec![anchor_tx.clone_inner(), valid_tx.clone_inner(), invalid_tx.clone_inner()];
-        let senders = vec![anchor_tx.signer(), valid_tx.signer(), invalid_tx.signer()];
+        let anchor_transaction = test_transaction(chain_id, 0);
+        let valid_transaction = test_transaction(chain_id, 1);
+        let invalid_transaction = test_transaction(chain_id, 99);
+        let transactions = vec![
+            anchor_transaction.clone_inner(),
+            valid_transaction.clone_inner(),
+            invalid_transaction.clone_inner(),
+        ];
+        let senders = vec![
+            anchor_transaction.signer(),
+            valid_transaction.signer(),
+            invalid_transaction.signer(),
+        ];
         let derived_block = RecoveredBlock::new_unhashed(
             Block {
                 header: Header {

--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -212,21 +212,7 @@ where
             }
 
             let committed_tx = Recovered::new_unchecked((*tx.inner()).clone(), tx.signer());
-            let committed =
-                self.execute_transaction(tx).map(|_| true).or_else(|err| match err {
-                    // We don't allow anchor transaction to be discarded even if it exceeds the zk
-                    // gas limit, this should never happen in practice.
-                    err if is_zk_gas_limit_exceeded(&err) && !is_anchor_transaction => Ok(false),
-                    BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })
-                    | BlockExecutionError::Validation(
-                        BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
-                            ..
-                        },
-                    ) if !is_anchor_transaction => Ok(false),
-                    _ => Err(err),
-                })?;
-
-            if committed {
+            if self.try_execute_filtered(tx, is_anchor_transaction)? {
                 committed_transactions.push(committed_tx);
             }
             if self.zk_gas_exhausted {
@@ -236,6 +222,43 @@ where
 
         let execution_result = self.apply_post_execution_changes()?;
         Ok(CommittedBlockExecutionOutcome { execution_result, committed_transactions })
+    }
+}
+
+/// Shared prover-mode filter: executes a single transaction and classifies the failure.
+///
+/// Lives on the inherent impl so both [`Self::execute_block_with_committed_transactions`] and the
+/// trait-level [`BlockExecutor::execute_block`] route through one place — the filtering rules
+/// (zk gas truncation, invalid tx, gas-exceeds-block) cannot drift between the two prover entry
+/// points.
+#[cfg(feature = "prover")]
+impl<E, Spec, R> TaikoBlockExecutor<'_, E, Spec, R>
+where
+    E: Evm<
+            DB: StateDB + DatabaseCommit,
+            Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
+        > + TaikoZkGasEvm,
+    Spec: TaikoExecutorSpec + Clone,
+    R: ReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt<Log = Log>>,
+{
+    /// Executes `tx` and returns `Ok(true)` if it committed, `Ok(false)` if it was filtered as a
+    /// recoverable non-anchor failure, or `Err` for fatal / anchor errors.
+    fn try_execute_filtered(
+        &mut self,
+        tx: impl ExecutableTx<Self>,
+        is_anchor_transaction: bool,
+    ) -> Result<bool, BlockExecutionError> {
+        match self.execute_transaction(tx) {
+            Ok(_) => Ok(true),
+            // We don't allow anchor transaction to be discarded even if it exceeds the zk gas
+            // limit, this should never happen in practice.
+            Err(err) if is_zk_gas_limit_exceeded(&err) && !is_anchor_transaction => Ok(false),
+            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })) |
+            Err(BlockExecutionError::Validation(
+                BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. },
+            )) if !is_anchor_transaction => Ok(false),
+            Err(err) => Err(err),
+        }
     }
 }
 
@@ -449,17 +472,7 @@ where
             if !is_anchor_transaction && *tx.signer() == Address::ZERO {
                 continue;
             }
-            // Execute transaction, if invalid, skip it directly.
-            self.execute_transaction((tx_env, tx)).map(|_| ()).or_else(|err| match err {
-                // We don't allow anchor transaction to be discarded even if it exceeds the zk gas
-                // limit, this should never happen in practice.
-                err if is_zk_gas_limit_exceeded(&err) && !is_anchor_transaction => Ok(()),
-                BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })
-                | BlockExecutionError::Validation(
-                    BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. },
-                ) if !is_anchor_transaction => Ok(()),
-                _ => Err(err),
-            })?;
+            self.try_execute_filtered((tx_env, tx), is_anchor_transaction)?;
             if self.zk_gas_exhausted {
                 break;
             }

--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -1,5 +1,5 @@
 //! Taiko block executor integrating anchor pre-execution and tx filtering.
-use alloy_consensus::{Transaction, TransactionEnvelope, TxReceipt};
+use alloy_consensus::{Transaction, TransactionEnvelope, TxReceipt, transaction::Recovered};
 use alloy_eips::{Encodable2718, eip7685::Requests};
 use alloy_evm::{
     FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
@@ -27,6 +27,16 @@ use alethia_reth_evm::{
     zk_gas::{adapter::ZK_GAS_LIMIT_ERR, meter::ZkGasOutcome},
 };
 use alethia_reth_primitives::decode_shasta_basefee_sharing_pctg;
+
+/// Block execution artifacts for transactions that were accepted by prover filtering.
+#[cfg(feature = "prover")]
+#[derive(Debug)]
+pub struct CommittedBlockExecutionOutcome<T, R> {
+    /// Execution result after applying all committed transactions.
+    pub execution_result: BlockExecutionResult<R>,
+    /// Transactions that were accepted by the executor and included in execution.
+    pub committed_transactions: Vec<Recovered<T>>,
+}
 
 /// Dedicated block-execution error raised when a block hits the zk gas limit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -168,6 +178,64 @@ where
         }
 
         Err(BlockExecutionError::other(ZkGasDifficultyMismatch { expected, got }))
+    }
+}
+
+#[cfg(feature = "prover")]
+impl<E, Spec, R> TaikoBlockExecutor<'_, E, Spec, R>
+where
+    E: Evm<
+            DB: StateDB + DatabaseCommit,
+            Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
+        > + TaikoZkGasEvm,
+    Spec: TaikoExecutorSpec + Clone,
+    R: ReceiptBuilder<
+            Transaction: Transaction + Encodable2718 + Clone,
+            Receipt: TxReceipt<Log = Log>,
+        >,
+{
+    /// Executes a prover candidate block and returns the transactions that were actually committed.
+    pub fn execute_block_with_committed_transactions<'tx>(
+        mut self,
+        transactions: impl IntoIterator<Item = Recovered<&'tx R::Transaction>>,
+    ) -> Result<CommittedBlockExecutionOutcome<R::Transaction, R::Receipt>, BlockExecutionError>
+    where
+        R::Transaction: 'tx,
+    {
+        self.apply_pre_execution_changes()?;
+
+        let mut committed_transactions = Vec::new();
+        for (idx, tx) in transactions.into_iter().enumerate() {
+            let is_anchor_transaction = idx == 0;
+            if !is_anchor_transaction && tx.signer() == Address::ZERO {
+                continue;
+            }
+
+            let committed_tx = Recovered::new_unchecked((*tx.inner()).clone(), tx.signer());
+            let committed =
+                self.execute_transaction(tx).map(|_| true).or_else(|err| match err {
+                    // We don't allow anchor transaction to be discarded even if it exceeds the zk
+                    // gas limit, this should never happen in practice.
+                    err if is_zk_gas_limit_exceeded(&err) && !is_anchor_transaction => Ok(false),
+                    BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })
+                    | BlockExecutionError::Validation(
+                        BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                            ..
+                        },
+                    ) if !is_anchor_transaction => Ok(false),
+                    _ => Err(err),
+                })?;
+
+            if committed {
+                committed_transactions.push(committed_tx);
+            }
+            if self.zk_gas_exhausted {
+                break;
+            }
+        }
+
+        let execution_result = self.apply_post_execution_changes()?;
+        Ok(CommittedBlockExecutionOutcome { execution_result, committed_transactions })
     }
 }
 
@@ -386,8 +454,8 @@ where
                 // We don't allow anchor transaction to be discarded even if it exceeds the zk gas
                 // limit, this should never happen in practice.
                 err if is_zk_gas_limit_exceeded(&err) && !is_anchor_transaction => Ok(()),
-                BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. }) |
-                BlockExecutionError::Validation(
+                BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })
+                | BlockExecutionError::Validation(
                     BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. },
                 ) if !is_anchor_transaction => Ok(()),
                 _ => Err(err),

--- a/crates/block/src/lib.rs
+++ b/crates/block/src/lib.rs
@@ -5,6 +5,9 @@
 pub mod assembler;
 /// EVM and block-construction configuration for Taiko execution.
 pub mod config;
+/// Prover helpers for executing derived candidate blocks.
+#[cfg(feature = "prover")]
+pub mod derived_block;
 /// Block execution strategy and anchor pre-execution logic.
 pub mod executor;
 /// Executor factory wiring for Taiko block execution.

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -11,11 +11,7 @@ path = "src/lib.rs"
 [features]
 default = ["std"]
 serde = ["dep:serde"]
-std = [
-    "alethia-reth-primitives/std",
-    "reth-evm/std",
-    "reth-revm/std",
-]
+std = ["alethia-reth-primitives/std", "reth-evm/std", "reth-revm/std"]
 
 [dependencies]
 alethia-reth-primitives = { path = "../primitives", default-features = false }

--- a/crates/payload/src/builder/execution.rs
+++ b/crates/payload/src/builder/execution.rs
@@ -211,7 +211,7 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes};
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
-    use reth::revm::{State, context::result::ExecutionResult};
+    use reth::revm::State;
     use reth_evm::{
         EvmFactory,
         block::{BlockExecutionError, BlockExecutor, CommitChanges},


### PR DESCRIPTION
  ## Summary

  - Add prover helpers for executing a derived candidate block, recording only committed transactions, and assembling the filtered final
  block.
  - Reuse Taiko executor invalid non-anchor transaction filtering for nonce, balance, gas, zk-gas, and invalid-signature placeholders.
  - Make the `prover` feature self-contained for no-default-features builds.

  ## Test Plan

  - `cargo test -p alethia-reth-block --no-default-features --features prover`
  - `cargo test -p alethia-reth-block --features prover`
  - `cargo clippy -p alethia-reth-block --no-default-features --features prover -- -D warnings`
  - `git diff --check`