### PR TITLE
chore(consensus): rename fork to Unzen

### DIFF
--- a/crates/block/src/assembler.rs
+++ b/crates/block/src/assembler.rs
@@ -74,8 +74,8 @@ where
 
         let withdrawals = Some(Withdrawals::default());
         let withdrawals_root = Some(EMPTY_WITHDRAWALS);
-        let requests_hash = ctx.is_uzen_active.then_some(EMPTY_REQUESTS_HASH);
-        let difficulty = if ctx.is_uzen_active {
+        let requests_hash = ctx.is_unzen_active.then_some(EMPTY_REQUESTS_HASH);
+        let difficulty = if ctx.is_unzen_active {
             U256::from(ctx.finalized_block_zk_gas())
         } else {
             block_env.difficulty()
@@ -100,8 +100,8 @@ where
             gas_used: *gas_used,
             extra_data: ctx.extra_data,
             parent_beacon_block_root: ctx.parent_beacon_block_root,
-            blob_gas_used: ctx.is_uzen_active.then_some(0),
-            excess_blob_gas: ctx.is_uzen_active.then_some(0),
+            blob_gas_used: ctx.is_unzen_active.then_some(0),
+            excess_blob_gas: ctx.is_unzen_active.then_some(0),
             requests_hash,
             block_access_list_hash: None,
             slot_number: None,
@@ -143,10 +143,10 @@ mod test {
     }
 
     #[test]
-    fn assembled_uzen_block_uses_final_zk_gas_as_difficulty() {
+    fn assembled_unzen_block_uses_final_zk_gas_as_difficulty() {
         let assembler = TaikoBlockAssembler::new(Arc::new(TaikoChainSpec::default()));
         let mut evm_env: EvmEnv<TaikoSpecId> = EvmEnv::default();
-        evm_env.cfg_env.spec = TaikoSpecId::UZEN;
+        evm_env.cfg_env.spec = TaikoSpecId::UNZEN;
         evm_env.block_env.number = U256::from(1);
         evm_env.block_env.timestamp = U256::from(1);
         evm_env.block_env.gas_limit = 30_000_000;
@@ -159,7 +159,7 @@ mod test {
             withdrawals: None,
             basefee_per_gas: 0,
             extra_data: Bytes::default(),
-            is_uzen_active: true,
+            is_unzen_active: true,
             expected_difficulty: None,
             finalized_block_zk_gas: Default::default(),
         };
@@ -186,18 +186,18 @@ mod test {
                 &state_provider,
                 B256::ZERO,
             ))
-            .expect("Uzen block should assemble");
+            .expect("Unzen block should assemble");
 
         assert_eq!(block.header.difficulty, U256::from(42_u64));
     }
 
     #[test]
-    fn assembled_uzen_block_sets_requests_hash() {
+    fn assembled_unzen_block_sets_requests_hash() {
         let mut chain_spec = (*TAIKO_DEVNET).as_ref().clone();
-        chain_spec.inner.hardforks.insert(TaikoHardfork::Uzen, ForkCondition::Timestamp(0));
+        chain_spec.inner.hardforks.insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(0));
         let assembler = TaikoBlockAssembler::new(Arc::new(chain_spec));
         let mut evm_env: EvmEnv<TaikoSpecId> = EvmEnv::default();
-        evm_env.cfg_env.spec = TaikoSpecId::UZEN;
+        evm_env.cfg_env.spec = TaikoSpecId::UNZEN;
         evm_env.block_env.number = U256::from(1);
         evm_env.block_env.timestamp = U256::from(1);
         evm_env.block_env.gas_limit = 30_000_000;
@@ -209,7 +209,7 @@ mod test {
             withdrawals: None,
             basefee_per_gas: 0,
             extra_data: Bytes::default(),
-            is_uzen_active: true,
+            is_unzen_active: true,
             expected_difficulty: None,
             finalized_block_zk_gas: Default::default(),
         };
@@ -235,7 +235,7 @@ mod test {
                 &state_provider,
                 B256::ZERO,
             ))
-            .expect("Uzen block should assemble");
+            .expect("Unzen block should assemble");
 
         assert_eq!(block.header.requests_hash, Some(EMPTY_REQUESTS_HASH));
         assert_eq!(block.header.blob_gas_used, Some(0));

--- a/crates/block/src/config.rs
+++ b/crates/block/src/config.rs
@@ -105,16 +105,16 @@ fn taiko_blob_excess_gas_and_price(spec: TaikoSpecId) -> Option<BlobExcessGasAnd
         .then_some(BlobExcessGasAndPrice { excess_blob_gas: 0, blob_gasprice: 1 })
 }
 
-/// Normalizes the parent beacon block root for Uzen/Cancun execution contexts.
+/// Normalizes the parent beacon block root for Unzen/Cancun execution contexts.
 ///
-/// Uzen activates Cancun semantics, which require a parent beacon block root for block execution.
+/// Unzen activates Cancun semantics, which require a parent beacon block root for block execution.
 /// Imported payloads can supply an explicit value, but local next-block building falls back to the
-/// zero root when Uzen is active.
+/// zero root when Unzen is active.
 fn normalize_parent_beacon_block_root(
-    is_uzen_active: bool,
+    is_unzen_active: bool,
     parent_beacon_block_root: Option<B256>,
 ) -> Option<B256> {
-    if is_uzen_active { parent_beacon_block_root.or(Some(B256::ZERO)) } else { None }
+    if is_unzen_active { parent_beacon_block_root.or(Some(B256::ZERO)) } else { None }
 }
 
 impl ConfigureEvm for TaikoEvmConfig {
@@ -160,7 +160,7 @@ impl ConfigureEvm for TaikoEvmConfig {
             number: U256::from(header.number()),
             beneficiary: header.beneficiary(),
             timestamp: U256::from(header.timestamp()),
-            difficulty: if self.chain_spec().is_uzen_active(header.timestamp()) {
+            difficulty: if self.chain_spec().is_unzen_active(header.timestamp()) {
                 header.difficulty()
             } else {
                 U256::ZERO
@@ -218,7 +218,7 @@ impl ConfigureEvm for TaikoEvmConfig {
         &self,
         block: &'a SealedBlock<BlockTy<Self::Primitives>>,
     ) -> Result<reth_evm::ExecutionCtxFor<'a, Self>, Self::Error> {
-        let is_uzen_active = self.chain_spec().is_uzen_active(block.header().timestamp);
+        let is_unzen_active = self.chain_spec().is_unzen_active(block.header().timestamp);
         let basefee_per_gas = block
             .header()
             .base_fee_per_gas
@@ -230,8 +230,8 @@ impl ConfigureEvm for TaikoEvmConfig {
             withdrawals: Some(Cow::Owned(Withdrawals::new(vec![]))),
             basefee_per_gas,
             extra_data: block.header().extra_data.clone(),
-            is_uzen_active,
-            expected_difficulty: is_uzen_active.then_some(block.header().difficulty),
+            is_unzen_active,
+            expected_difficulty: is_unzen_active.then_some(block.header().difficulty),
             finalized_block_zk_gas: Default::default(),
         })
     }
@@ -243,15 +243,15 @@ impl ConfigureEvm for TaikoEvmConfig {
         parent: &SealedHeader,
         ctx: Self::NextBlockEnvCtx,
     ) -> Result<reth_evm::ExecutionCtxFor<'_, Self>, Self::Error> {
-        let is_uzen_active = self.chain_spec().is_uzen_active(ctx.timestamp);
+        let is_unzen_active = self.chain_spec().is_unzen_active(ctx.timestamp);
         Ok(TaikoBlockExecutionCtx {
             parent_hash: parent.hash(),
-            parent_beacon_block_root: normalize_parent_beacon_block_root(is_uzen_active, None),
+            parent_beacon_block_root: normalize_parent_beacon_block_root(is_unzen_active, None),
             ommers: &[],
             withdrawals: Some(Cow::Owned(Withdrawals::new(vec![]))),
             basefee_per_gas: ctx.base_fee_per_gas,
             extra_data: ctx.extra_data,
-            is_uzen_active,
+            is_unzen_active,
             expected_difficulty: None,
             finalized_block_zk_gas: Default::default(),
         })
@@ -305,18 +305,18 @@ impl ConfigureEngineEvm<TaikoExecutionData> for TaikoEvmConfig {
         &self,
         payload: &'a TaikoExecutionData,
     ) -> Result<ExecutionCtxFor<'a, Self>, Self::Error> {
-        let is_uzen_active = self.chain_spec().is_uzen_active(payload.timestamp());
+        let is_unzen_active = self.chain_spec().is_unzen_active(payload.timestamp());
         Ok(TaikoBlockExecutionCtx {
             parent_hash: payload.parent_hash(),
             parent_beacon_block_root: normalize_parent_beacon_block_root(
-                is_uzen_active,
+                is_unzen_active,
                 payload.parent_beacon_block_root(),
             ),
             ommers: &[],
             withdrawals: payload.withdrawals().map(|w| Cow::Owned(w.clone().into())),
             basefee_per_gas: payload.execution_payload.base_fee_per_gas.saturating_to(),
             extra_data: payload.execution_payload.extra_data.clone(),
-            is_uzen_active,
+            is_unzen_active,
             expected_difficulty: None,
             finalized_block_zk_gas: Default::default(),
         })
@@ -373,8 +373,8 @@ pub fn taiko_spec_by_timestamp_and_block_number<C>(
 where
     C: EthereumHardforks + EthChainSpec + Hardforks,
 {
-    if chain_spec.fork(TaikoHardfork::Uzen).active_at_timestamp(timestamp) {
-        TaikoSpecId::UZEN
+    if chain_spec.fork(TaikoHardfork::Unzen).active_at_timestamp(timestamp) {
+        TaikoSpecId::UNZEN
     } else if chain_spec.fork(TaikoHardfork::Shasta).active_at_timestamp(timestamp) {
         // London is on from genesis for Taiko, so Shasta reduces to the timestamp activation.
         TaikoSpecId::SHASTA
@@ -416,58 +416,58 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
-    fn uzen_takes_precedence_over_shasta() {
+    fn unzen_takes_precedence_over_shasta() {
         let mut chain_spec = (*TAIKO_DEVNET).as_ref().clone();
         chain_spec.inner.hardforks.insert(TaikoHardfork::Shasta, ForkCondition::Timestamp(0));
-        chain_spec.inner.hardforks.insert(TaikoHardfork::Uzen, ForkCondition::Timestamp(0));
+        chain_spec.inner.hardforks.insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(0));
 
         let selected = taiko_spec_by_timestamp_and_block_number(&chain_spec, 0, 1);
-        assert_eq!(selected, TaikoSpecId::UZEN);
+        assert_eq!(selected, TaikoSpecId::UNZEN);
     }
 
     #[test]
-    fn shasta_remains_active_before_uzen_timestamp() {
+    fn shasta_remains_active_before_unzen_timestamp() {
         let mut chain_spec = (*TAIKO_DEVNET).as_ref().clone();
         chain_spec.inner.hardforks.insert(TaikoHardfork::Shasta, ForkCondition::Timestamp(0));
-        chain_spec.inner.hardforks.insert(TaikoHardfork::Uzen, ForkCondition::Timestamp(10));
+        chain_spec.inner.hardforks.insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(10));
 
         let selected = taiko_spec_by_timestamp_and_block_number(&chain_spec, 0, 1);
         assert_eq!(selected, TaikoSpecId::SHASTA);
     }
 
     #[test]
-    fn uzen_evm_env_sets_zero_blob_excess_gas_and_price() {
+    fn unzen_evm_env_sets_zero_blob_excess_gas_and_price() {
         let mut chain_spec = (*TAIKO_DEVNET).as_ref().clone();
         chain_spec.inner.hardforks.insert(TaikoHardfork::Shasta, ForkCondition::Timestamp(0));
-        chain_spec.inner.hardforks.insert(TaikoHardfork::Uzen, ForkCondition::Timestamp(0));
+        chain_spec.inner.hardforks.insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(0));
 
         let config = TaikoEvmConfig::new(Arc::new(chain_spec));
         let header =
             Header { number: 1, timestamp: 0, base_fee_per_gas: Some(1), ..Header::default() };
 
-        let env = config.evm_env(&header).expect("uzen env should build");
+        let env = config.evm_env(&header).expect("unzen env should build");
         let blob_env = env
             .block_env
             .blob_excess_gas_and_price
-            .expect("uzen historical env should define blob gas pricing");
+            .expect("unzen historical env should define blob gas pricing");
 
         assert_eq!(blob_env.excess_blob_gas, 0);
         assert_eq!(blob_env.blob_gasprice, 1);
     }
 
     #[test]
-    fn pre_uzen_normalization_discards_supplied_parent_beacon_block_root() {
+    fn pre_unzen_normalization_discards_supplied_parent_beacon_block_root() {
         assert_eq!(normalize_parent_beacon_block_root(false, Some(B256::repeat_byte(0x11))), None);
     }
 
     #[test]
-    fn uzen_normalization_preserves_supplied_parent_beacon_block_root() {
+    fn unzen_normalization_preserves_supplied_parent_beacon_block_root() {
         let root = B256::repeat_byte(0x22);
         assert_eq!(normalize_parent_beacon_block_root(true, Some(root)), Some(root));
     }
 
     #[test]
-    fn uzen_normalization_falls_back_to_zero_root_when_missing() {
+    fn unzen_normalization_falls_back_to_zero_root_when_missing() {
         assert_eq!(normalize_parent_beacon_block_root(true, None), Some(B256::ZERO));
     }
 }

--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -525,7 +525,7 @@ mod test {
         config::{TaikoEvmConfig, TaikoNextBlockEnvAttributes},
         testutil::{
             BENCH_LIMIT_TARGET, BENCH_SUCCESS_TARGET, db_with_contracts, recovered_tx,
-            uzen_chain_spec, uzen_evm_env, uzen_execution_ctx,
+            unzen_chain_spec, unzen_evm_env, unzen_execution_ctx,
         },
     };
     use alethia_reth_chainspec::spec::TaikoChainSpec;
@@ -560,14 +560,14 @@ mod test {
 
     #[test]
     fn executor_discards_limit_exceeded_tx_and_stops_after_it() {
-        let chain_spec = Arc::new(uzen_chain_spec());
+        let chain_spec = Arc::new(unzen_chain_spec());
         let mut state = State::builder()
             .with_database(db_with_contracts(&[(BENCH_CALLER, 0)]))
             .with_bundle_update()
             .build();
-        let evm = TaikoEvmFactory.create_evm(&mut state, uzen_evm_env());
+        let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
         assert_eq!(evm.block_zk_gas_used(), Some(0));
-        let ctx = uzen_execution_ctx();
+        let ctx = unzen_execution_ctx();
         let mut executor = TaikoBlockExecutor::new(
             evm,
             ctx.clone(),
@@ -600,13 +600,13 @@ mod test {
     #[cfg(feature = "prover")]
     #[test]
     fn execute_block_stops_after_non_anchor_zk_gas_exhaustion() {
-        let chain_spec = Arc::new(uzen_chain_spec());
+        let chain_spec = Arc::new(unzen_chain_spec());
         let mut state = State::builder()
             .with_database(db_with_contracts(&[(BENCH_CALLER, 0)]))
             .with_bundle_update()
             .build();
-        let evm = TaikoEvmFactory.create_evm(&mut state, uzen_evm_env());
-        let ctx = uzen_execution_ctx();
+        let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
+        let ctx = unzen_execution_ctx();
         let executor =
             TaikoBlockExecutor::new(evm, ctx.clone(), chain_spec, RethReceiptBuilder::default());
 
@@ -623,14 +623,14 @@ mod test {
     }
 
     #[test]
-    fn executor_rejects_imported_uzen_block_when_difficulty_mismatches_finalized_zk_gas() {
-        let chain_spec = Arc::new(uzen_chain_spec());
+    fn executor_rejects_imported_unzen_block_when_difficulty_mismatches_finalized_zk_gas() {
+        let chain_spec = Arc::new(unzen_chain_spec());
         let mut state = State::builder()
             .with_database(db_with_contracts(&[(BENCH_CALLER, 0)]))
             .with_bundle_update()
             .build();
-        let evm = TaikoEvmFactory.create_evm(&mut state, uzen_evm_env());
-        let mut ctx = uzen_execution_ctx();
+        let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
+        let mut ctx = unzen_execution_ctx();
         ctx.expected_difficulty = Some(U256::ZERO);
         let mut executor =
             TaikoBlockExecutor::new(evm, ctx, chain_spec, RethReceiptBuilder::default());
@@ -640,7 +640,7 @@ mod test {
             .expect("transaction should execute successfully");
 
         let err: BlockExecutionError = match executor.finish() {
-            Ok(_) => panic!("imported Uzen blocks must reject difficulty mismatches"),
+            Ok(_) => panic!("imported Unzen blocks must reject difficulty mismatches"),
             Err(err) => err,
         };
         assert!(err.to_string().contains("difficulty"));
@@ -685,7 +685,7 @@ mod test {
                     withdrawals: None,
                     basefee_per_gas: 1,
                     extra_data: Bytes::new(),
-                    is_uzen_active: false,
+                    is_unzen_active: false,
                     expected_difficulty: None,
                     finalized_block_zk_gas: Default::default(),
                 },

--- a/crates/block/src/factory.rs
+++ b/crates/block/src/factory.rs
@@ -36,16 +36,16 @@ pub struct TaikoBlockExecutionCtx<'a> {
     pub basefee_per_gas: u64,
     /// Block extra data.
     pub extra_data: Bytes,
-    /// Whether Uzen-or-later zk gas rules are active for this block.
-    pub is_uzen_active: bool,
+    /// Whether Unzen-or-later zk gas rules are active for this block.
+    pub is_unzen_active: bool,
     /// Imported-header difficulty expected after recomputing finalized block zk gas.
     pub expected_difficulty: Option<U256>,
-    /// Finalized block zk gas accumulated from fully committed post Uzen transactions.
+    /// Finalized block zk gas accumulated from fully committed post Unzen transactions.
     pub finalized_block_zk_gas: Arc<AtomicU64>,
 }
 
 impl<'a> TaikoBlockExecutionCtx<'a> {
-    /// Stores the finalized block zk gas value that should be written into the Uzen header.
+    /// Stores the finalized block zk gas value that should be written into the Unzen header.
     pub fn set_finalized_block_zk_gas(&self, zk_gas: u64) {
         self.finalized_block_zk_gas.store(zk_gas, Ordering::Relaxed);
     }
@@ -55,7 +55,7 @@ impl<'a> TaikoBlockExecutionCtx<'a> {
         self.finalized_block_zk_gas.load(Ordering::Relaxed)
     }
 
-    /// Returns the imported-header difficulty expected during Uzen validation, if any.
+    /// Returns the imported-header difficulty expected during Unzen validation, if any.
     pub fn expected_difficulty(&self) -> Option<U256> {
         self.expected_difficulty
     }

--- a/crates/block/src/testutil.rs
+++ b/crates/block/src/testutil.rs
@@ -30,17 +30,17 @@ pub const BENCH_SUCCESS_TARGET: Address = Address::with_last_byte(0x21);
 /// Target address for contracts whose execution exceeds the zk gas limit.
 pub const BENCH_LIMIT_TARGET: Address = Address::with_last_byte(0x22);
 
-/// Returns a [`TaikoChainSpec`] with Uzen activated at timestamp 0.
-pub fn uzen_chain_spec() -> TaikoChainSpec {
+/// Returns a [`TaikoChainSpec`] with Unzen activated at timestamp 0.
+pub fn unzen_chain_spec() -> TaikoChainSpec {
     let mut chain_spec = (*TAIKO_DEVNET).as_ref().clone();
-    chain_spec.inner.hardforks.insert(TaikoHardfork::Uzen, ForkCondition::Timestamp(0));
+    chain_spec.inner.hardforks.insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(0));
     chain_spec
 }
 
-/// Returns an [`EvmEnv`] configured for Uzen execution.
-pub fn uzen_evm_env() -> EvmEnv<TaikoSpecId> {
+/// Returns an [`EvmEnv`] configured for Unzen execution.
+pub fn unzen_evm_env() -> EvmEnv<TaikoSpecId> {
     let mut env: EvmEnv<TaikoSpecId> = EvmEnv::default();
-    env.cfg_env.spec = TaikoSpecId::UZEN;
+    env.cfg_env.spec = TaikoSpecId::UNZEN;
     env.cfg_env.chain_id = 167;
     env.block_env.number = U256::from(1_u64);
     env.block_env.timestamp = U256::from(1_u64);
@@ -48,8 +48,8 @@ pub fn uzen_evm_env() -> EvmEnv<TaikoSpecId> {
     env
 }
 
-/// Returns a [`TaikoBlockExecutionCtx`] for Uzen test blocks.
-pub fn uzen_execution_ctx<'a>() -> TaikoBlockExecutionCtx<'a> {
+/// Returns a [`TaikoBlockExecutionCtx`] for Unzen test blocks.
+pub fn unzen_execution_ctx<'a>() -> TaikoBlockExecutionCtx<'a> {
     TaikoBlockExecutionCtx {
         parent_hash: B256::ZERO,
         parent_beacon_block_root: Some(B256::ZERO),
@@ -57,7 +57,7 @@ pub fn uzen_execution_ctx<'a>() -> TaikoBlockExecutionCtx<'a> {
         withdrawals: None,
         basefee_per_gas: 0,
         extra_data: Bytes::default(),
-        is_uzen_active: true,
+        is_unzen_active: true,
         expected_difficulty: None,
         finalized_block_zk_gas: Default::default(),
     }

--- a/crates/block/src/tx_selection/mod.rs
+++ b/crates/block/src/tx_selection/mod.rs
@@ -288,7 +288,7 @@ mod tests {
         executor::TaikoBlockExecutor,
         testutil::{
             BENCH_LIMIT_TARGET, BENCH_SUCCESS_TARGET, ExecutorBackedBuilder, db_with_contracts,
-            recovered_tx, uzen_chain_spec, uzen_evm_env, uzen_execution_ctx,
+            recovered_tx, unzen_chain_spec, unzen_evm_env, unzen_execution_ctx,
         },
     };
     use alethia_reth_evm::factory::TaikoEvmFactory;
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn tx_selection_breaks_on_zk_gas_error_but_keeps_skipping_invalid_txs() {
-        let chain_spec = Arc::new(uzen_chain_spec());
+        let chain_spec = Arc::new(unzen_chain_spec());
         let mut state = State::builder()
             .with_database(db_with_contracts(&[
                 (BENCH_INVALID_CALLER, 1),
@@ -310,10 +310,10 @@ mod tests {
             ]))
             .with_bundle_update()
             .build();
-        let evm = TaikoEvmFactory.create_evm(&mut state, uzen_evm_env());
+        let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
         let executor = TaikoBlockExecutor::new(
             evm,
-            uzen_execution_ctx(),
+            unzen_execution_ctx(),
             chain_spec,
             RethReceiptBuilder::default(),
         );

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -20,8 +20,8 @@ hardfork!(
       Pacaya,
       /// Shasta protocol upgrade.
       Shasta,
-      /// Uzen protocol upgrade.
-      Uzen,
+      /// Unzen protocol upgrade.
+      Unzen,
   }
 );
 
@@ -52,9 +52,9 @@ pub trait TaikoHardforks: EthereumHardforks {
         self.taiko_fork_activation(TaikoHardfork::Shasta).active_at_timestamp(timestamp)
     }
 
-    /// Convenience method to check if [`TaikoHardfork::Uzen`] is active at the given timestamp.
-    fn is_uzen_active(&self, timestamp: u64) -> bool {
-        self.taiko_fork_activation(TaikoHardfork::Uzen).active_at_timestamp(timestamp)
+    /// Convenience method to check if [`TaikoHardfork::Unzen`] is active at the given timestamp.
+    fn is_unzen_active(&self, timestamp: u64) -> bool {
+        self.taiko_fork_activation(TaikoHardfork::Unzen).active_at_timestamp(timestamp)
     }
 }
 
@@ -72,7 +72,7 @@ pub static TAIKO_MAINNET_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| 
         (TaikoHardfork::Ontake.boxed(), ForkCondition::Block(538_304)),
         (TaikoHardfork::Pacaya.boxed(), ForkCondition::Block(1_166_000)),
         (TaikoHardfork::Shasta.boxed(), ForkCondition::Timestamp(1_775_135_700)),
-        (TaikoHardfork::Uzen.boxed(), ForkCondition::Never),
+        (TaikoHardfork::Unzen.boxed(), ForkCondition::Never),
     ]))
 });
 
@@ -82,7 +82,7 @@ pub static TAIKO_HOODI_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         (TaikoHardfork::Ontake.boxed(), ForkCondition::Block(0)),
         (TaikoHardfork::Pacaya.boxed(), ForkCondition::Block(0)),
         (TaikoHardfork::Shasta.boxed(), ForkCondition::Timestamp(1_770_296_400)),
-        (TaikoHardfork::Uzen.boxed(), ForkCondition::Never),
+        (TaikoHardfork::Unzen.boxed(), ForkCondition::Never),
     ]))
 });
 
@@ -92,7 +92,7 @@ pub static TAIKO_DEVNET_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         (TaikoHardfork::Ontake.boxed(), ForkCondition::Block(0)),
         (TaikoHardfork::Pacaya.boxed(), ForkCondition::Block(0)),
         (TaikoHardfork::Shasta.boxed(), ForkCondition::Timestamp(0)),
-        (TaikoHardfork::Uzen.boxed(), ForkCondition::Timestamp(0)),
+        (TaikoHardfork::Unzen.boxed(), ForkCondition::Timestamp(0)),
     ]))
 });
 
@@ -102,7 +102,7 @@ pub static TAIKO_MASAYA_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         (TaikoHardfork::Ontake.boxed(), ForkCondition::Block(0)),
         (TaikoHardfork::Pacaya.boxed(), ForkCondition::Block(0)),
         (TaikoHardfork::Shasta.boxed(), ForkCondition::Timestamp(0)),
-        (TaikoHardfork::Uzen.boxed(), ForkCondition::Never),
+        (TaikoHardfork::Unzen.boxed(), ForkCondition::Never),
     ]))
 });
 
@@ -110,14 +110,14 @@ pub static TAIKO_MASAYA_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
 fn extend_with_shared_hardforks(
     hardforks: Vec<(Box<dyn Hardfork>, ForkCondition)>,
 ) -> Vec<(Box<dyn Hardfork>, ForkCondition)> {
-    // Determine the Ethereum fork activations implied by Uzen. Taiko executes Uzen with Osaka
+    // Determine the Ethereum fork activations implied by Unzen. Taiko executes Unzen with Osaka
     // semantics, and upstream validators still consult the predecessor Cancun/Prague fork flags
-    // for some transaction and payload checks. If Uzen is not present, default to
+    // for some transaction and payload checks. If Unzen is not present, default to
     // `ForkCondition::Never`.
-    let uzen_activation = hardforks
+    let unzen_activation = hardforks
         .iter()
         .find_map(|(fork, condition)| {
-            (fork.name() == TaikoHardfork::Uzen.name()).then_some(*condition)
+            (fork.name() == TaikoHardfork::Unzen.name()).then_some(*condition)
         })
         .unwrap_or(ForkCondition::Never);
 
@@ -144,9 +144,9 @@ fn extend_with_shared_hardforks(
             },
         ),
         (EthereumHardfork::Shanghai.boxed(), ForkCondition::Timestamp(0)),
-        (EthereumHardfork::Cancun.boxed(), uzen_activation),
-        (EthereumHardfork::Prague.boxed(), uzen_activation),
-        (EthereumHardfork::Osaka.boxed(), uzen_activation),
+        (EthereumHardfork::Cancun.boxed(), unzen_activation),
+        (EthereumHardfork::Prague.boxed(), unzen_activation),
+        (EthereumHardfork::Osaka.boxed(), unzen_activation),
     ];
 
     shared_hardforks.extend(hardforks);
@@ -169,10 +169,10 @@ mod test {
     }
 
     #[test]
-    fn test_extend_with_shared_hardforks_sets_osaka_from_uzen_activation() {
+    fn test_extend_with_shared_hardforks_sets_osaka_from_unzen_activation() {
         let forks = extend_with_shared_hardforks(vec![
             (TaikoHardfork::Ontake.boxed(), ForkCondition::Block(1)),
-            (TaikoHardfork::Uzen.boxed(), ForkCondition::Timestamp(123)),
+            (TaikoHardfork::Unzen.boxed(), ForkCondition::Timestamp(123)),
         ]);
 
         let osaka =
@@ -182,10 +182,10 @@ mod test {
     }
 
     #[test]
-    fn test_extend_with_shared_hardforks_sets_cancun_and_prague_from_uzen_activation() {
+    fn test_extend_with_shared_hardforks_sets_cancun_and_prague_from_unzen_activation() {
         let forks = extend_with_shared_hardforks(vec![
             (TaikoHardfork::Ontake.boxed(), ForkCondition::Block(1)),
-            (TaikoHardfork::Uzen.boxed(), ForkCondition::Timestamp(123)),
+            (TaikoHardfork::Unzen.boxed(), ForkCondition::Timestamp(123)),
         ]);
 
         let cancun =

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -21,12 +21,12 @@ pub mod hardfork;
 /// Taiko chain-spec wrapper traits and helper methods.
 pub mod spec;
 
-/// Genesis hash for the Taiko Devnet network when the default Uzen activation (Timestamp(0))
+/// Genesis hash for the Taiko Devnet network when the default Unzen activation (Timestamp(0))
 /// is in effect, which makes the genesis header an Osaka-era block.
 pub const TAIKO_DEVNET_GENESIS_HASH: B256 =
     b256!("0x0ab9db72570aa79341b50c888abaf2e64395d5ce31d3753b738b7e5abec132c4");
 
-/// Genesis hash for the Taiko Devnet network when `--devnet-uzen-timestamp` pushes the Uzen
+/// Genesis hash for the Taiko Devnet network when `--devnet-unzen-timestamp` pushes the Unzen
 /// activation past genesis, leaving genesis as a Shanghai-era block (no blob/requests fields).
 pub const TAIKO_DEVNET_GENESIS_HASH_SHANGHAI: B256 =
     b256!("0xc417ef878f13238b8c19696b2ef043149b423f8450cab1e0dd3ca845ee16688d");

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -169,18 +169,18 @@ impl TaikoExecutorSpec for TaikoChainSpec {
 
 /// Helper trait for applying Taiko devnet specific overrides.
 pub trait TaikoDevnetConfigExt {
-    /// Returns a cloned [`TaikoChainSpec`] with the Uzen hardfork activation timestamp updated
+    /// Returns a cloned [`TaikoChainSpec`] with the Unzen hardfork activation timestamp updated
     /// when the chainspec targets the Taiko devnet. Returns `None` for other networks.
-    fn clone_with_devnet_uzen_timestamp(&self, timestamp: u64) -> Option<Self>
+    fn clone_with_devnet_unzen_timestamp(&self, timestamp: u64) -> Option<Self>
     where
         Self: Sized;
 }
 
 impl TaikoDevnetConfigExt for TaikoChainSpec {
-    /// Returns a cloned [`TaikoChainSpec`] with the Uzen hardfork activation timestamp updated
+    /// Returns a cloned [`TaikoChainSpec`] with the Unzen hardfork activation timestamp updated
     /// when the chainspec targets the Taiko devnet. Returns `None` for other networks or when
-    /// `timestamp == 0` (the default devnet config already activates Uzen at genesis).
-    fn clone_with_devnet_uzen_timestamp(&self, timestamp: u64) -> Option<Self>
+    /// `timestamp == 0` (the default devnet config already activates Unzen at genesis).
+    fn clone_with_devnet_unzen_timestamp(&self, timestamp: u64) -> Option<Self>
     where
         Self: Sized,
     {
@@ -189,7 +189,7 @@ impl TaikoDevnetConfigExt for TaikoChainSpec {
         }
 
         let mut cloned = self.clone();
-        cloned.inner.hardforks.insert(TaikoHardfork::Uzen, ForkCondition::Timestamp(timestamp));
+        cloned.inner.hardforks.insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(timestamp));
         cloned
             .inner
             .hardforks
@@ -209,7 +209,7 @@ impl TaikoDevnetConfigExt for TaikoChainSpec {
         assert_eq!(
             cloned.genesis_hash(),
             TAIKO_DEVNET_GENESIS_HASH_SHANGHAI,
-            "unexpected Taiko devnet genesis hash after Uzen timestamp override",
+            "unexpected Taiko devnet genesis hash after Unzen timestamp override",
         );
 
         Some(cloned)
@@ -246,9 +246,9 @@ pub trait TaikoExecutorSpec: EthExecutorSpec {
         self.taiko_fork_activation(TaikoHardfork::Shasta).active_at_timestamp(timestamp)
     }
 
-    /// Checks if the `Uzen` hardfork is active at the given timestamp.
-    fn is_uzen_active(&self, timestamp: u64) -> bool {
-        self.taiko_fork_activation(TaikoHardfork::Uzen).active_at_timestamp(timestamp)
+    /// Checks if the `Unzen` hardfork is active at the given timestamp.
+    fn is_unzen_active(&self, timestamp: u64) -> bool {
+        self.taiko_fork_activation(TaikoHardfork::Unzen).active_at_timestamp(timestamp)
     }
 }
 
@@ -275,14 +275,14 @@ mod test {
     }
 
     #[test]
-    fn test_mainnet_blob_params_remain_unset_before_uzen() {
+    fn test_mainnet_blob_params_remain_unset_before_unzen() {
         let spec = TAIKO_MAINNET.as_ref();
 
         assert_eq!(spec.blob_params_at_timestamp(0), None);
     }
 
     #[test]
-    fn test_devnet_uzen_exposes_osaka_blob_params_and_blob_base_fee() {
+    fn test_devnet_unzen_exposes_osaka_blob_params_and_blob_base_fee() {
         let spec = TAIKO_DEVNET.as_ref();
         let header = Header {
             timestamp: 0,
@@ -300,14 +300,14 @@ mod test {
     }
 
     #[test]
-    fn test_clone_with_devnet_uzen_timestamp() {
+    fn test_clone_with_devnet_unzen_timestamp() {
         let devnet_spec = (*TAIKO_DEVNET).clone();
         let overridden = devnet_spec
             .as_ref()
-            .clone_with_devnet_uzen_timestamp(42)
+            .clone_with_devnet_unzen_timestamp(42)
             .expect("devnet override should succeed");
         assert_eq!(
-            overridden.taiko_fork_activation(TaikoHardfork::Uzen),
+            overridden.taiko_fork_activation(TaikoHardfork::Unzen),
             ForkCondition::Timestamp(42)
         );
         assert_eq!(
@@ -331,13 +331,13 @@ mod test {
         assert_eq!(overridden.genesis_header().requests_hash, None);
 
         assert!(
-            devnet_spec.as_ref().clone_with_devnet_uzen_timestamp(0).is_none(),
+            devnet_spec.as_ref().clone_with_devnet_unzen_timestamp(0).is_none(),
             "zero timestamp should skip the override"
         );
 
         let mainnet_spec = (*TAIKO_MAINNET).clone();
         assert!(
-            mainnet_spec.as_ref().clone_with_devnet_uzen_timestamp(1).is_none(),
+            mainnet_spec.as_ref().clone_with_devnet_unzen_timestamp(1).is_none(),
             "non-devnet overrides should be ignored"
         );
     }

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -15,21 +15,21 @@ use crate::{TaikoCliExtArgs, tables::TaikoTables};
 
 /// Trait implemented by CLI extensions that can tweak Taiko-specific runtime options.
 pub trait TaikoNodeExtArgs {
-    /// Returns the configured devnet Uzen activation timestamp override.
-    fn devnet_uzen_timestamp(&self) -> u64;
+    /// Returns the configured devnet Unzen activation timestamp override.
+    fn devnet_unzen_timestamp(&self) -> u64;
 }
 
 impl TaikoNodeExtArgs for NoArgs {
-    /// Returns the default devnet Uzen activation timestamp override.
-    fn devnet_uzen_timestamp(&self) -> u64 {
+    /// Returns the default devnet Unzen activation timestamp override.
+    fn devnet_unzen_timestamp(&self) -> u64 {
         0
     }
 }
 
 impl TaikoNodeExtArgs for TaikoCliExtArgs {
-    /// Returns the configured devnet Uzen activation timestamp override.
-    fn devnet_uzen_timestamp(&self) -> u64 {
-        self.devnet_uzen_timestamp
+    /// Returns the configured devnet Unzen activation timestamp override.
+    fn devnet_unzen_timestamp(&self) -> u64 {
+        self.devnet_unzen_timestamp
     }
 }
 
@@ -122,9 +122,11 @@ where
             storage,
         };
 
-        // Apply Taiko-specific devnet Uzen timestamp override if specified.
-        if let Some(overridden_chain) =
-            node_config.chain.as_ref().clone_with_devnet_uzen_timestamp(ext.devnet_uzen_timestamp())
+        // Apply Taiko-specific devnet Unzen timestamp override if specified.
+        if let Some(overridden_chain) = node_config
+            .chain
+            .as_ref()
+            .clone_with_devnet_unzen_timestamp(ext.devnet_unzen_timestamp())
         {
             node_config.chain = Arc::new(overridden_chain);
         }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -41,15 +41,15 @@ pub use parser::TaikoChainSpecParser;
 /// Additional Taiko CLI arguments layered on top of the base CLI.
 #[derive(Debug, clap::Args)]
 pub struct TaikoCliExtArgs {
-    /// Override the devnet Uzen hardfork activation timestamp (`0` keeps the embedded value).
+    /// Override the devnet Unzen hardfork activation timestamp (`0` keeps the embedded value).
     #[arg(
-        long = "devnet-uzen-timestamp",
-        env = "ALETHIA_RETH_DEVNET_UZEN_TIMESTAMP",
+        long = "devnet-unzen-timestamp",
+        env = "ALETHIA_RETH_DEVNET_UNZEN_TIMESTAMP",
         value_name = "TIMESTAMP",
         default_value_t = 0u64,
         help_heading = "Taiko"
     )]
-    pub devnet_uzen_timestamp: u64,
+    pub devnet_unzen_timestamp: u64,
 }
 
 /// The main alethia-reth cli interface.
@@ -221,38 +221,38 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_devnet_uzen_timestamp_flag() {
+    fn test_parse_devnet_unzen_timestamp_flag() {
         let _lock = env_lock();
-        unsafe { std::env::remove_var("ALETHIA_RETH_DEVNET_UZEN_TIMESTAMP") };
-        let cli = TestCli::try_parse_from(["alethia-reth", "--devnet-uzen-timestamp", "42"])
+        unsafe { std::env::remove_var("ALETHIA_RETH_DEVNET_UNZEN_TIMESTAMP") };
+        let cli = TestCli::try_parse_from(["alethia-reth", "--devnet-unzen-timestamp", "42"])
             .expect("flag should parse");
 
-        assert_eq!(cli.ext.devnet_uzen_timestamp, 42);
+        assert_eq!(cli.ext.devnet_unzen_timestamp, 42);
     }
 
     #[test]
-    fn test_parse_devnet_uzen_timestamp_default() {
+    fn test_parse_devnet_unzen_timestamp_default() {
         let _lock = env_lock();
-        unsafe { std::env::remove_var("ALETHIA_RETH_DEVNET_UZEN_TIMESTAMP") };
+        unsafe { std::env::remove_var("ALETHIA_RETH_DEVNET_UNZEN_TIMESTAMP") };
         let cli = TestCli::try_parse_from(["alethia-reth"]).expect("default args should parse");
 
-        assert_eq!(cli.ext.devnet_uzen_timestamp, 0);
+        assert_eq!(cli.ext.devnet_unzen_timestamp, 0);
     }
 
     #[test]
-    fn test_parse_devnet_uzen_timestamp_from_env() {
+    fn test_parse_devnet_unzen_timestamp_from_env() {
         let _lock = env_lock();
-        unsafe { std::env::set_var("ALETHIA_RETH_DEVNET_UZEN_TIMESTAMP", "42") };
+        unsafe { std::env::set_var("ALETHIA_RETH_DEVNET_UNZEN_TIMESTAMP", "42") };
         let cli = TestCli::try_parse_from(["alethia-reth"]).expect("env-backed args should parse");
-        unsafe { std::env::remove_var("ALETHIA_RETH_DEVNET_UZEN_TIMESTAMP") };
+        unsafe { std::env::remove_var("ALETHIA_RETH_DEVNET_UNZEN_TIMESTAMP") };
 
-        assert_eq!(cli.ext.devnet_uzen_timestamp, 42);
+        assert_eq!(cli.ext.devnet_unzen_timestamp, 42);
     }
 
     #[test]
     fn test_rejects_legacy_devnet_shasta_timestamp_flag() {
         let _lock = env_lock();
-        unsafe { std::env::remove_var("ALETHIA_RETH_DEVNET_UZEN_TIMESTAMP") };
+        unsafe { std::env::remove_var("ALETHIA_RETH_DEVNET_UNZEN_TIMESTAMP") };
         let err = TestCli::try_parse_from(["alethia-reth", "--devnet-shasta-timestamp", "42"])
             .expect_err("legacy flag should be rejected");
 

--- a/crates/consensus/src/validation/mod.rs
+++ b/crates/consensus/src/validation/mod.rs
@@ -139,7 +139,7 @@ where
     fn validate_header(&self, header: &SealedHeader<H>) -> Result<(), ConsensusError> {
         let header = header.header();
 
-        if !self.chain_spec.is_uzen_active(header.timestamp()) && !header.difficulty().is_zero() {
+        if !self.chain_spec.is_unzen_active(header.timestamp()) && !header.difficulty().is_zero() {
             return Err(ConsensusError::TheMergeDifficultyIsNotZero);
         }
 
@@ -232,13 +232,13 @@ fn validate_zk_gas_post_execution<B, R>(
 where
     B: Block,
 {
-    if !chain_spec.is_uzen_active(block.header().timestamp()) {
+    if !chain_spec.is_unzen_active(block.header().timestamp()) {
         return Ok(());
     }
 
     let body_transaction_count = block.body().transactions().len();
     let committed_receipt_count = receipts.len();
-    // Imported Uzen-or-later blocks are only valid when the canonical body ends exactly at the
+    // Imported Unzen-or-later blocks are only valid when the canonical body ends exactly at the
     // last transaction that execution committed. If zk gas truncated execution earlier, the
     // offending transaction and all later transactions must be absent from the body as well.
     if body_transaction_count == committed_receipt_count {
@@ -246,7 +246,7 @@ where
     }
 
     Err(ConsensusError::Other(format!(
-        "Uzen block body extends past zk gas truncation point: body has {body_transaction_count} transactions but execution committed {committed_receipt_count}"
+        "Unzen block body extends past zk gas truncation point: body has {body_transaction_count} transactions but execution committed {committed_receipt_count}"
     )))
 }
 

--- a/crates/consensus/src/validation/tests.rs
+++ b/crates/consensus/src/validation/tests.rs
@@ -156,19 +156,19 @@ fn test_validate_block_pre_execution_rejects_blob_transactions() {
 }
 
 #[test]
-fn pre_uzen_header_still_rejects_nonzero_difficulty() {
-    let consensus = test_consensus(pre_uzen_chain_spec());
+fn pre_unzen_header_still_rejects_nonzero_difficulty() {
+    let consensus = test_consensus(pre_unzen_chain_spec());
     let header = Header { difficulty: U256::from(1_u64), ..Default::default() };
 
     let err = consensus
         .validate_header(&SealedHeader::new_unhashed(header))
-        .expect_err("pre-Uzen headers must still reject nonzero difficulty");
+        .expect_err("pre-Unzen headers must still reject nonzero difficulty");
     assert!(matches!(err, ConsensusError::TheMergeDifficultyIsNotZero));
 }
 
 #[test]
-fn uzen_header_allows_nonzero_difficulty() {
-    let consensus = test_consensus(uzen_chain_spec());
+fn unzen_header_allows_nonzero_difficulty() {
+    let consensus = test_consensus(unzen_chain_spec());
     let header = Header {
         timestamp: 1,
         difficulty: U256::from(7_u64),
@@ -179,12 +179,12 @@ fn uzen_header_allows_nonzero_difficulty() {
 
     consensus
         .validate_header(&SealedHeader::new_unhashed(header))
-        .expect("Uzen headers should allow nonzero difficulty");
+        .expect("Unzen headers should allow nonzero difficulty");
 }
 
 #[test]
-fn uzen_post_execution_rejects_body_past_truncation_point() {
-    let consensus = test_consensus(uzen_chain_spec());
+fn unzen_post_execution_rejects_body_past_truncation_point() {
+    let consensus = test_consensus(unzen_chain_spec());
     let result = BlockExecutionResult::<Receipt>::default();
     let header = Header {
         timestamp: 1,
@@ -205,7 +205,7 @@ fn uzen_post_execution_rejects_body_past_truncation_point() {
         <TaikoBeaconConsensus as FullConsensus<EthPrimitives>>::validate_block_post_execution(
             &consensus, &recovered, &result, None,
         )
-        .expect_err("Uzen blocks must reject bodies that extend past the truncation point");
+        .expect_err("Unzen blocks must reject bodies that extend past the truncation point");
     assert!(matches!(err, ConsensusError::Other(_)));
     assert!(err.to_string().contains("truncation"));
 }
@@ -277,14 +277,14 @@ fn devnet_chain_spec() -> TaikoChainSpec {
     (*TAIKO_DEVNET).as_ref().clone()
 }
 
-fn pre_uzen_chain_spec() -> TaikoChainSpec {
+fn pre_unzen_chain_spec() -> TaikoChainSpec {
     let mut chain_spec = devnet_chain_spec();
-    chain_spec.inner.hardforks.insert(TaikoHardfork::Uzen, ForkCondition::Never);
+    chain_spec.inner.hardforks.insert(TaikoHardfork::Unzen, ForkCondition::Never);
     chain_spec
 }
 
-fn uzen_chain_spec() -> TaikoChainSpec {
+fn unzen_chain_spec() -> TaikoChainSpec {
     let mut chain_spec = devnet_chain_spec();
-    chain_spec.inner.hardforks.insert(TaikoHardfork::Uzen, ForkCondition::Timestamp(0));
+    chain_spec.inner.hardforks.insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(0));
     chain_spec
 }

--- a/crates/evm/src/alloy.rs
+++ b/crates/evm/src/alloy.rs
@@ -29,7 +29,7 @@ use crate::{
     },
 };
 
-/// Maximum transaction gas limit enforced once Osaka/Uzen semantics are active.
+/// Maximum transaction gas limit enforced once Osaka/Unzen semantics are active.
 const MAX_SYSTEM_CALL_GAS_LIMIT: u64 = 16_777_216;
 
 /// A wrapper around the Taiko EVM that implements the `Evm` trait in `alloy_evm`.

--- a/crates/evm/src/spec.rs
+++ b/crates/evm/src/spec.rs
@@ -17,8 +17,8 @@ pub enum TaikoSpecId {
     PACAYA,
     /// Shasta hard fork for the Taiko network
     SHASTA,
-    /// Uzen hard fork for the Taiko network
-    UZEN,
+    /// Unzen hard fork for the Taiko network
+    UNZEN,
 }
 
 impl TaikoSpecId {
@@ -26,7 +26,7 @@ impl TaikoSpecId {
     pub const fn into_eth_spec(self) -> SpecId {
         match self {
             Self::GENESIS | Self::ONTAKE | Self::PACAYA | Self::SHASTA => SpecId::SHANGHAI,
-            Self::UZEN => SpecId::OSAKA,
+            Self::UNZEN => SpecId::OSAKA,
         }
     }
 
@@ -52,7 +52,7 @@ impl FromStr for TaikoSpecId {
             name::ONTAKE => Ok(TaikoSpecId::ONTAKE),
             name::PACAYA => Ok(TaikoSpecId::PACAYA),
             name::SHASTA => Ok(TaikoSpecId::SHASTA),
-            name::UZEN => Ok(TaikoSpecId::UZEN),
+            name::UNZEN => Ok(TaikoSpecId::UNZEN),
             _ => Err(UnknownHardfork),
         }
     }
@@ -66,7 +66,7 @@ impl From<TaikoSpecId> for &'static str {
             TaikoSpecId::ONTAKE => name::ONTAKE,
             TaikoSpecId::PACAYA => name::PACAYA,
             TaikoSpecId::SHASTA => name::SHASTA,
-            TaikoSpecId::UZEN => name::UZEN,
+            TaikoSpecId::UNZEN => name::UNZEN,
         }
     }
 }
@@ -81,8 +81,8 @@ pub mod name {
     pub const PACAYA: &str = "Pacaya";
     /// String name for `TaikoSpecId::SHASTA`.
     pub const SHASTA: &str = "Shasta";
-    /// String name for `TaikoSpecId::UZEN`.
-    pub const UZEN: &str = "Uzen";
+    /// String name for `TaikoSpecId::UNZEN`.
+    pub const UNZEN: &str = "Unzen";
 }
 
 #[cfg(test)]
@@ -106,7 +106,7 @@ mod tests {
                 (TaikoSpecId::ONTAKE, true),
                 (TaikoSpecId::PACAYA, true),
                 (TaikoSpecId::SHASTA, false),
-                (TaikoSpecId::UZEN, false),
+                (TaikoSpecId::UNZEN, false),
             ],
         )];
 
@@ -138,9 +138,9 @@ mod tests {
     }
 
     #[test]
-    fn test_uzen_spec_id_mappings() {
-        assert_eq!(TaikoSpecId::from_str(name::UZEN).unwrap(), TaikoSpecId::UZEN);
-        assert_eq!(<&str>::from(TaikoSpecId::UZEN), name::UZEN);
-        assert_eq!(SpecId::from(TaikoSpecId::UZEN), SpecId::OSAKA);
+    fn test_unzen_spec_id_mappings() {
+        assert_eq!(TaikoSpecId::from_str(name::UNZEN).unwrap(), TaikoSpecId::UNZEN);
+        assert_eq!(<&str>::from(TaikoSpecId::UNZEN), name::UNZEN);
+        assert_eq!(SpecId::from(TaikoSpecId::UNZEN), SpecId::OSAKA);
     }
 }

--- a/crates/evm/src/zk_gas/adapter.rs
+++ b/crates/evm/src/zk_gas/adapter.rs
@@ -368,7 +368,7 @@ fn parent_step_depth(depth: usize) -> usize {
     depth.saturating_sub(1)
 }
 
-/// Returns the fixed spawn estimate for the provided Uzen opcode.
+/// Returns the fixed spawn estimate for the provided Unzen opcode.
 fn spawn_estimate(schedule: &'static ZkGasSchedule, opcode: u8) -> u64 {
     match opcode {
         0xf1 => schedule.spawn_estimates.call,
@@ -383,7 +383,7 @@ fn spawn_estimate(schedule: &'static ZkGasSchedule, opcode: u8) -> u64 {
 
 /// Returns the schedule backing a shared meter handle.
 fn meter_schedule(_meter: &SharedZkGasMeter) -> &'static ZkGasSchedule {
-    schedule_for(TaikoSpecId::UZEN).expect("Uzen schedule is available")
+    schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule is available")
 }
 
 /// Charges a completed opcode step against the shared meter.

--- a/crates/evm/src/zk_gas/mod.rs
+++ b/crates/evm/src/zk_gas/mod.rs
@@ -1,13 +1,13 @@
 //! Fork-scoped zk gas schedules for Taiko consensus.
 
-/// Inspector-side Uzen opcode metering and shared error definitions.
+/// Inspector-side Unzen opcode metering and shared error definitions.
 pub mod adapter;
-/// Checked zk gas accounting for a single Uzen block execution.
+/// Checked zk gas accounting for a single Unzen block execution.
 pub mod meter;
 /// Shared schedule types and fork selection helpers.
 pub mod schedule;
-/// Uzen-specific fixed zk gas schedule data.
-pub mod uzen;
+/// Unzen-specific fixed zk gas schedule data.
+pub mod unzen;
 
 #[cfg(test)]
 mod tests;

--- a/crates/evm/src/zk_gas/schedule.rs
+++ b/crates/evm/src/zk_gas/schedule.rs
@@ -2,7 +2,7 @@
 
 use crate::spec::TaikoSpecId;
 
-use super::uzen::UZEN_ZK_GAS_SCHEDULE;
+use super::unzen::UNZEN_ZK_GAS_SCHEDULE;
 
 /// Fixed raw-gas estimates for spawn opcodes.
 #[derive(Clone, Copy)]
@@ -37,7 +37,7 @@ pub struct ZkGasSchedule {
 /// Returns the consensus zk gas schedule for the active Taiko fork, when defined.
 pub const fn schedule_for(spec: TaikoSpecId) -> Option<&'static ZkGasSchedule> {
     match spec {
-        TaikoSpecId::UZEN => Some(&UZEN_ZK_GAS_SCHEDULE),
+        TaikoSpecId::UNZEN => Some(&UNZEN_ZK_GAS_SCHEDULE),
         _ => None,
     }
 }

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -24,20 +24,20 @@ use super::{
 };
 
 #[test]
-fn uzen_schedule_is_selected_only_for_uzen() {
-    assert!(schedule_for(TaikoSpecId::UZEN).is_some());
+fn unzen_schedule_is_selected_only_for_unzen() {
+    assert!(schedule_for(TaikoSpecId::UNZEN).is_some());
     assert!(schedule_for(TaikoSpecId::SHASTA).is_none());
 }
 
 #[test]
-fn uzen_schedule_uses_the_spec_block_limit() {
-    let schedule = schedule_for(TaikoSpecId::UZEN).expect("Uzen schedule");
+fn unzen_schedule_uses_the_spec_block_limit() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     assert_eq!(schedule.block_limit, 100_000_000);
 }
 
 #[test]
-fn uzen_schedule_uses_spec_opcode_and_precompile_multipliers() {
-    let schedule = schedule_for(TaikoSpecId::UZEN).expect("Uzen schedule");
+fn unzen_schedule_uses_spec_opcode_and_precompile_multipliers() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
 
     assert_eq!(schedule.opcode_multipliers[0x20], 85);
     assert_eq!(schedule.opcode_multipliers[0xf1], 25);
@@ -51,8 +51,8 @@ fn uzen_schedule_uses_spec_opcode_and_precompile_multipliers() {
 }
 
 #[test]
-fn uzen_schedule_uses_spec_spawn_estimates() {
-    let schedule = schedule_for(TaikoSpecId::UZEN).expect("Uzen schedule");
+fn unzen_schedule_uses_spec_spawn_estimates() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
 
     assert_eq!(schedule.spawn_estimates.call, 12_500);
     assert_eq!(schedule.spawn_estimates.callcode, 12_500);
@@ -64,7 +64,7 @@ fn uzen_schedule_uses_spec_spawn_estimates() {
 
 #[test]
 fn meter_promotes_committed_tx_usage_into_block_usage() {
-    let schedule = schedule_for(TaikoSpecId::UZEN).expect("Uzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
 
     meter.charge_opcode(0x01, 3).expect("charge");
@@ -75,7 +75,7 @@ fn meter_promotes_committed_tx_usage_into_block_usage() {
 
 #[test]
 fn meter_treats_opcode_multiplication_overflow_as_limit_exceeded() {
-    let schedule = schedule_for(TaikoSpecId::UZEN).expect("Uzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
     let raw_gas = (u64::MAX / u64::from(schedule.opcode_multipliers[0x01])) + 1;
 
@@ -84,7 +84,7 @@ fn meter_treats_opcode_multiplication_overflow_as_limit_exceeded() {
 
 #[test]
 fn meter_treats_precompile_multiplication_overflow_as_limit_exceeded() {
-    let schedule = schedule_for(TaikoSpecId::UZEN).expect("Uzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
     let raw_gas = (u64::MAX / u64::from(schedule.precompile_multipliers[0x01])) + 1;
 
@@ -93,7 +93,7 @@ fn meter_treats_precompile_multiplication_overflow_as_limit_exceeded() {
 
 #[test]
 fn meter_resets_transaction_usage_without_affecting_block_usage() {
-    let schedule = schedule_for(TaikoSpecId::UZEN).expect("Uzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
 
     meter.charge_opcode(0x01, 2).expect("charge");
@@ -105,7 +105,7 @@ fn meter_resets_transaction_usage_without_affecting_block_usage() {
 
 #[test]
 fn meter_allows_exactly_remaining_block_budget() {
-    let schedule = schedule_for(TaikoSpecId::UZEN).expect("Uzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
 
     meter.charge_opcode(0xf0, schedule.block_limit - 1).expect("prefill");
@@ -121,7 +121,7 @@ fn meter_allows_exactly_remaining_block_budget() {
 
 #[test]
 fn meter_rejects_block_budget_plus_one() {
-    let schedule = schedule_for(TaikoSpecId::UZEN).expect("Uzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
 
     meter.charge_opcode(0xf0, schedule.block_limit - 1).expect("prefill");
@@ -132,7 +132,7 @@ fn meter_rejects_block_budget_plus_one() {
 
 #[test]
 fn meter_returns_limit_exceeded_for_precompile_over_block_budget() {
-    let schedule = schedule_for(TaikoSpecId::UZEN).expect("Uzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
 
     assert!(matches!(
@@ -174,17 +174,17 @@ impl<CTX> Inspector<CTX, EthInterpreter> for StepGasProbeInspector {
 }
 
 #[test]
-fn uzen_adapter_uses_spawn_estimate_for_precompile_dispatch() {
-    let schedule = schedule_for(TaikoSpecId::UZEN).expect("Uzen schedule");
+fn unzen_adapter_uses_spawn_estimate_for_precompile_dispatch() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut evm = TaikoEvmFactory.create_evm_with_inspector(
         db_with_contract(staticcall_identity_bytecode()),
-        evm_env(TaikoSpecId::UZEN),
+        evm_env(TaikoSpecId::UNZEN),
         StepGasProbeInspector::default(),
     );
 
-    evm.transact(tx_env(100_000)).expect("Uzen tx should execute");
+    evm.transact(tx_env(100_000)).expect("Unzen tx should execute");
 
-    let meter = evm.shared_meter().expect("Uzen should install a shared meter");
+    let meter = evm.shared_meter().expect("Unzen should install a shared meter");
     let meter = meter.lock().expect("meter lock");
     let probe = evm.inspector();
     let precompile_gas_used = probe.precompile_gas_used.expect("precompile gas recorded");
@@ -212,13 +212,13 @@ fn uzen_adapter_uses_spawn_estimate_for_precompile_dispatch() {
 }
 
 #[test]
-fn uzen_adapter_raises_dedicated_error_when_limit_is_exceeded() {
+fn unzen_adapter_raises_dedicated_error_when_limit_is_exceeded() {
     let mut evm = TaikoEvmFactory.create_evm(
         db_with_contract(limit_exceeding_keccak_bytecode()),
-        evm_env(TaikoSpecId::UZEN),
+        evm_env(TaikoSpecId::UNZEN),
     );
 
-    let err = evm.transact(tx_env(5_000_000)).expect_err("Uzen tx should abort");
+    let err = evm.transact(tx_env(5_000_000)).expect_err("Unzen tx should abort");
 
     assert!(matches!(
         err,
@@ -229,10 +229,10 @@ fn uzen_adapter_raises_dedicated_error_when_limit_is_exceeded() {
 }
 
 #[test]
-fn uzen_default_create_evm_path_is_metered() {
+fn unzen_default_create_evm_path_is_metered() {
     let mut evm = TaikoEvmFactory.create_evm(
         db_with_contract(limit_exceeding_keccak_bytecode()),
-        evm_env(TaikoSpecId::UZEN),
+        evm_env(TaikoSpecId::UNZEN),
     );
 
     assert!(evm.shared_meter().is_some());
@@ -240,14 +240,14 @@ fn uzen_default_create_evm_path_is_metered() {
 }
 
 #[test]
-fn non_uzen_default_create_evm_path_keeps_metering_disabled() {
+fn non_unzen_default_create_evm_path_keeps_metering_disabled() {
     let mut evm = TaikoEvmFactory.create_evm(
         db_with_contract(limit_exceeding_keccak_bytecode()),
         evm_env(TaikoSpecId::SHASTA),
     );
 
     assert!(evm.shared_meter().is_none());
-    evm.transact(tx_env(5_000_000)).expect("non-Uzen tx should stay on the legacy path");
+    evm.transact(tx_env(5_000_000)).expect("non-Unzen tx should stay on the legacy path");
 }
 
 fn evm_env(spec: TaikoSpecId) -> EvmEnv<TaikoSpecId> {

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -1,21 +1,21 @@
-//! Fixed Uzen zk gas schedule constants copied from the approved protocol spec.
+//! Fixed Unzen zk gas schedule constants copied from the approved protocol spec.
 //!
 //! Source:
 //! <https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/zk_gas_spec.md>
 
 use super::schedule::{SpawnEstimates, ZkGasSchedule};
 
-/// Maximum zk gas permitted within a single Uzen block.
+/// Maximum zk gas permitted within a single Unzen block.
 pub const BLOCK_ZK_GAS_LIMIT: u64 = 100_000_000;
 
-/// Fail-safe multiplier used for any opcode or precompile missing from the Uzen table.
+/// Fail-safe multiplier used for any opcode or precompile missing from the Unzen table.
 const FAILSAFE_MULTIPLIER: u16 = u16::MAX;
 
-/// Fixed Uzen zk gas schedule used for consensus execution.
-pub const UZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = ZkGasSchedule {
+/// Fixed Unzen zk gas schedule used for consensus execution.
+pub const UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = ZkGasSchedule {
     block_limit: BLOCK_ZK_GAS_LIMIT,
-    opcode_multipliers: uzen_opcode_multipliers(),
-    precompile_multipliers: uzen_precompile_multipliers(),
+    opcode_multipliers: unzen_opcode_multipliers(),
+    precompile_multipliers: unzen_precompile_multipliers(),
     spawn_estimates: SpawnEstimates {
         call: 12_500,
         callcode: 12_500,
@@ -26,8 +26,8 @@ pub const UZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = ZkGasSchedule {
     },
 };
 
-/// Returns the fixed Uzen opcode multiplier table with fail-safe defaults for unlisted opcodes.
-const fn uzen_opcode_multipliers() -> [u16; 256] {
+/// Returns the fixed Unzen opcode multiplier table with fail-safe defaults for unlisted opcodes.
+const fn unzen_opcode_multipliers() -> [u16; 256] {
     let mut array = [FAILSAFE_MULTIPLIER; 256];
     array[0x09] = 152; // mulmod
     array[0x04] = 110; // div
@@ -181,8 +181,9 @@ const fn uzen_opcode_multipliers() -> [u16; 256] {
     array
 }
 
-/// Returns the fixed Uzen precompile multiplier table with fail-safe defaults for unlisted entries.
-const fn uzen_precompile_multipliers() -> [u16; 256] {
+/// Returns the fixed Unzen precompile multiplier table with fail-safe defaults for unlisted
+/// entries.
+const fn unzen_precompile_multipliers() -> [u16; 256] {
     let mut array = [FAILSAFE_MULTIPLIER; 256];
     array[0x05] = 1363; // modexp
     array[0x0a] = 398; // point_evaluation

--- a/crates/payload/src/builder/execution.rs
+++ b/crates/payload/src/builder/execution.rs
@@ -227,7 +227,7 @@ mod tests {
         executor::{TaikoBlockExecutor, ZkGasLimitExceeded},
         testutil::{
             BENCH_LIMIT_TARGET, BENCH_SUCCESS_TARGET, ExecutorBackedBuilder, db_with_contracts,
-            recovered_tx, uzen_chain_spec, uzen_evm_env, uzen_execution_ctx,
+            recovered_tx, unzen_chain_spec, unzen_evm_env, unzen_execution_ctx,
         },
     };
     use alethia_reth_chainspec::spec::TaikoChainSpec;
@@ -338,7 +338,7 @@ mod tests {
 
     #[test]
     fn execute_provided_transactions_stops_on_zk_gas_error() {
-        let chain_spec = Arc::new(uzen_chain_spec());
+        let chain_spec = Arc::new(unzen_chain_spec());
         let mut state = State::builder()
             .with_database(db_with_contracts(&[
                 (BENCH_SUCCESS_CALLER, 0),
@@ -347,10 +347,10 @@ mod tests {
             ]))
             .with_bundle_update()
             .build();
-        let evm = TaikoEvmFactory.create_evm(&mut state, uzen_evm_env());
+        let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
         let executor = TaikoBlockExecutor::new(
             evm,
-            uzen_execution_ctx(),
+            unzen_execution_ctx(),
             chain_spec,
             RethReceiptBuilder::default(),
         );
@@ -376,15 +376,15 @@ mod tests {
 
     #[test]
     fn execute_anchor_and_pool_transactions_errors_when_anchor_hits_zk_gas_limit() {
-        let chain_spec = Arc::new(uzen_chain_spec());
+        let chain_spec = Arc::new(unzen_chain_spec());
         let mut state = State::builder()
             .with_database(db_with_contracts(&[(Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS), 0)]))
             .with_bundle_update()
             .build();
-        let evm = TaikoEvmFactory.create_evm(&mut state, uzen_evm_env());
+        let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
         let executor = TaikoBlockExecutor::new(
             evm,
-            uzen_execution_ctx(),
+            unzen_execution_ctx(),
             chain_spec.clone(),
             RethReceiptBuilder::default(),
         );

--- a/crates/primitives/src/transaction.rs
+++ b/crates/primitives/src/transaction.rs
@@ -4,7 +4,7 @@ use reth_primitives_traits::SignedTransaction;
 
 /// Returns whether a transaction type is allowed inside a Taiko block.
 ///
-/// Taiko does not accept blob transactions, even when Osaka/Uzen-specific EVM rules are active.
+/// Taiko does not accept blob transactions, even when Osaka/Unzen-specific EVM rules are active.
 pub fn is_allowed_tx_type(tx: &impl SignedTransaction) -> bool {
     !tx.is_eip4844()
 }

--- a/crates/rpc/src/engine/api.rs
+++ b/crates/rpc/src/engine/api.rs
@@ -72,7 +72,7 @@ pub struct TaikoEngineApi<Provider, PayloadT: PayloadTypes, Pool, Validator, Cha
     inner: EngineApi<Provider, PayloadT, Pool, Validator, ChainSpec>,
     /// Provider used for DB reads/writes during L1-origin persistence.
     provider: Provider,
-    /// Taiko chain spec used to detect Uzen payloads when preparing `getPayloadV2` responses.
+    /// Taiko chain spec used to detect Unzen payloads when preparing `getPayloadV2` responses.
     chain_spec: Arc<TaikoChainSpec>,
     /// Payload store used to resolve built payloads by payload ID.
     payload_store: PayloadStore<PayloadT>,
@@ -126,7 +126,7 @@ where
     }
 
     /// Converts a built payload into the standard V2 envelope, preserving the builder fee unless
-    /// Uzen requires the hash-relevant header difficulty to be carried through `blockValue`.
+    /// Unzen requires the hash-relevant header difficulty to be carried through `blockValue`.
     fn convert_built_payload_to_execution_payload_envelope_v2(
         &self,
         built_payload: EthBuiltPayload,
@@ -271,19 +271,19 @@ where
 
 /// Converts a built payload into the standard V2 execution payload envelope.
 ///
-/// Uzen reuses `blockValue` to transport the hash-relevant header difficulty through the standard
+/// Unzen reuses `blockValue` to transport the hash-relevant header difficulty through the standard
 /// `getPayloadV2` response shape without adding a new wire field.
 fn convert_built_payload_to_execution_payload_envelope_v2(
     chain_spec: &TaikoChainSpec,
     built_payload: EthBuiltPayload,
 ) -> ExecutionPayloadEnvelopeV2 {
     let block = built_payload.block();
-    let is_uzen_active = chain_spec.is_uzen_active(block.header().timestamp);
+    let is_unzen_active = chain_spec.is_unzen_active(block.header().timestamp);
     let header_difficulty = block.header().difficulty;
     let mut envelope = ExecutionPayloadEnvelopeV2::from(built_payload);
 
-    if is_uzen_active {
-        // Consensus rule: Taiko Uzen round-trips the header difficulty through `blockValue` so
+    if is_unzen_active {
+        // Consensus rule: Taiko Unzen round-trips the header difficulty through `blockValue` so
         // the RPC response can carry the hash-relevant field without introducing a new wire field.
         envelope.block_value = header_difficulty;
     }
@@ -304,8 +304,8 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
-    fn uzen_payload_overwrites_block_value_with_header_difficulty() {
-        let chain_spec = uzen_chain_spec();
+    fn unzen_payload_overwrites_block_value_with_header_difficulty() {
+        let chain_spec = unzen_chain_spec();
         let built_payload = sample_built_payload(U256::from(7_u64), U256::from(1_u64), 1);
 
         let envelope = convert_built_payload_to_execution_payload_envelope_v2(
@@ -317,8 +317,8 @@ mod tests {
     }
 
     #[test]
-    fn pre_uzen_payload_preserves_original_block_value() {
-        let chain_spec = pre_uzen_chain_spec();
+    fn pre_unzen_payload_preserves_original_block_value() {
+        let chain_spec = pre_unzen_chain_spec();
         let built_payload = sample_built_payload(U256::from(7_u64), U256::from(1_u64), 1);
 
         let envelope = convert_built_payload_to_execution_payload_envelope_v2(
@@ -329,26 +329,26 @@ mod tests {
         assert_eq!(envelope.block_value, U256::from(1_u64));
     }
 
-    fn uzen_chain_spec() -> Arc<alethia_reth_chainspec::spec::TaikoChainSpec> {
+    fn unzen_chain_spec() -> Arc<alethia_reth_chainspec::spec::TaikoChainSpec> {
         let mut chain_spec = (*TAIKO_DEVNET).as_ref().clone();
-        chain_spec.inner.hardforks.insert(TaikoHardfork::Uzen, ForkCondition::Timestamp(0));
+        chain_spec.inner.hardforks.insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(0));
         Arc::new(chain_spec)
     }
 
-    fn pre_uzen_chain_spec() -> Arc<alethia_reth_chainspec::spec::TaikoChainSpec> {
+    fn pre_unzen_chain_spec() -> Arc<alethia_reth_chainspec::spec::TaikoChainSpec> {
         let mut chain_spec = (*TAIKO_DEVNET).as_ref().clone();
-        chain_spec.inner.hardforks.insert(TaikoHardfork::Uzen, ForkCondition::Timestamp(10));
+        chain_spec.inner.hardforks.insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(10));
         Arc::new(chain_spec)
     }
 
     fn sample_built_payload(difficulty: U256, fees: U256, timestamp: u64) -> EthBuiltPayload {
-        let block = sample_uzen_block(difficulty, timestamp);
+        let block = sample_unzen_block(difficulty, timestamp);
         let sealed_block = Arc::new(block.seal_slow());
 
         EthBuiltPayload::new(sealed_block, fees, None, None)
     }
 
-    fn sample_uzen_block(difficulty: U256, timestamp: u64) -> reth_ethereum::Block {
+    fn sample_unzen_block(difficulty: U256, timestamp: u64) -> reth_ethereum::Block {
         reth_ethereum::Block {
             header: Header {
                 parent_hash: B256::with_last_byte(0x11),

--- a/crates/rpc/src/engine/validator.rs
+++ b/crates/rpc/src/engine/validator.rs
@@ -36,9 +36,9 @@ enum TaikoPayloadValidationError {
     /// The payload contains blob transactions, which Taiko network never accepts.
     #[error("blob transactions are unsupported")]
     BlobTransactionsUnsupported,
-    /// Uzen payloads must carry the original header difficulty through the Taiko sidecar.
-    #[error("missing header difficulty for Uzen payload")]
-    MissingUzenHeaderDifficulty,
+    /// Unzen payloads must carry the original header difficulty through the Taiko sidecar.
+    #[error("missing header difficulty for Unzen payload")]
+    MissingUnzenHeaderDifficulty,
 }
 
 /// Builder for [`TaikoEngineValidator`].
@@ -128,11 +128,11 @@ where
         let TaikoExecutionData { execution_payload, taiko_sidecar } = payload;
 
         let expected_hash = execution_payload.block_hash;
-        let is_uzen_active = self.chain_spec.is_uzen_active(execution_payload.timestamp);
+        let is_unzen_active = self.chain_spec.is_unzen_active(execution_payload.timestamp);
 
-        if is_uzen_active && taiko_sidecar.header_difficulty.is_none() {
+        if is_unzen_active && taiko_sidecar.header_difficulty.is_none() {
             return Err(NewPayloadError::other(
-                TaikoPayloadValidationError::MissingUzenHeaderDifficulty,
+                TaikoPayloadValidationError::MissingUnzenHeaderDifficulty,
             ));
         }
 
@@ -141,10 +141,10 @@ where
         if let Some(header_difficulty) = taiko_sidecar.header_difficulty {
             block.header.difficulty = header_difficulty;
         }
-        block.header.parent_beacon_block_root = is_uzen_active.then_some(B256::ZERO);
-        block.header.blob_gas_used = is_uzen_active.then_some(0);
-        block.header.excess_blob_gas = is_uzen_active.then_some(0);
-        block.header.requests_hash = is_uzen_active.then_some(EMPTY_REQUESTS_HASH);
+        block.header.parent_beacon_block_root = is_unzen_active.then_some(B256::ZERO);
+        block.header.blob_gas_used = is_unzen_active.then_some(0);
+        block.header.excess_blob_gas = is_unzen_active.then_some(0);
+        block.header.requests_hash = is_unzen_active.then_some(EMPTY_REQUESTS_HASH);
         if !taiko_sidecar.tx_hash.is_zero() {
             block.header.transactions_root = taiko_sidecar.tx_hash;
         }
@@ -258,23 +258,23 @@ mod tests {
     }
 
     #[test]
-    fn rejects_uzen_payload_without_header_difficulty() {
-        let validator = TaikoEngineValidator::new(Arc::new(uzen_chain_spec()));
-        let payload = sample_uzen_execution_data(U256::from(7_u64), None, None);
+    fn rejects_unzen_payload_without_header_difficulty() {
+        let validator = TaikoEngineValidator::new(Arc::new(unzen_chain_spec()));
+        let payload = sample_unzen_execution_data(U256::from(7_u64), None, None);
 
         let err =
             <TaikoEngineValidator as PayloadValidator<TaikoEngineTypes>>::convert_payload_to_block(
                 &validator, payload,
             )
-            .expect_err("Uzen payloads must supply header difficulty explicitly");
+            .expect_err("Unzen payloads must supply header difficulty explicitly");
 
-        assert_eq!(err.to_string(), "missing header difficulty for Uzen payload");
+        assert_eq!(err.to_string(), "missing header difficulty for Unzen payload");
     }
 
     #[test]
-    fn accepts_uzen_payload_when_sidecar_supplies_header_difficulty() {
-        let validator = TaikoEngineValidator::new(Arc::new(uzen_chain_spec()));
-        let payload = sample_uzen_execution_data(
+    fn accepts_unzen_payload_when_sidecar_supplies_header_difficulty() {
+        let validator = TaikoEngineValidator::new(Arc::new(unzen_chain_spec()));
+        let payload = sample_unzen_execution_data(
             U256::from(7_u64),
             Some(U256::from(7_u64)),
             Some(B256::ZERO),
@@ -292,9 +292,9 @@ mod tests {
     }
 
     #[test]
-    fn accepts_uzen_payload_when_validator_infers_parent_beacon_block_root() {
-        let validator = TaikoEngineValidator::new(Arc::new(uzen_chain_spec()));
-        let payload = sample_uzen_execution_data(
+    fn accepts_unzen_payload_when_validator_infers_parent_beacon_block_root() {
+        let validator = TaikoEngineValidator::new(Arc::new(unzen_chain_spec()));
+        let payload = sample_unzen_execution_data(
             U256::from(7_u64),
             Some(U256::from(7_u64)),
             Some(B256::ZERO),
@@ -305,7 +305,7 @@ mod tests {
                 &validator,
                 payload.clone(),
             )
-            .expect("validator should infer parent beacon block root from Uzen activation");
+            .expect("validator should infer parent beacon block root from Unzen activation");
 
         assert_eq!(sealed.hash(), payload.execution_payload.block_hash);
         assert_eq!(sealed.header().parent_beacon_block_root, Some(B256::ZERO));
@@ -314,13 +314,13 @@ mod tests {
         assert_eq!(sealed.header().requests_hash, Some(EMPTY_REQUESTS_HASH));
     }
 
-    fn uzen_chain_spec() -> TaikoChainSpec {
+    fn unzen_chain_spec() -> TaikoChainSpec {
         let mut chain_spec = (*TAIKO_DEVNET).as_ref().clone();
-        chain_spec.inner.hardforks.insert(TaikoHardfork::Uzen, ForkCondition::Timestamp(0));
+        chain_spec.inner.hardforks.insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(0));
         chain_spec
     }
 
-    fn sample_uzen_execution_data(
+    fn sample_unzen_execution_data(
         difficulty: U256,
         header_difficulty: Option<U256>,
         parent_beacon_block_root: Option<B256>,


### PR DESCRIPTION
## Summary
- Rename the Taiko fork spelling from Uzen to Unzen across Rust APIs, tests, docs, CLI flag/env names, and messages.
- Rename the zk gas schedule module from `uzen.rs` to `unzen.rs`.
- Remove temporary `docs/superpowers` planning artifacts from the PR branch.

## Validation
- `just fmt && just clippy-fix && just test`
- `rg -n 'Uzen|uzen|UZEN' crates bin README.md Cargo.toml justfile AGENTS.md` returned no matches.\n\n## Notes\n- This is a hard rename because the fork is not in production yet; no compatibility aliases are included.