### PR TITLE
chore(chainspec): set Masaya Unzen fork time to `2026-05-07 13:00 UTC`

### DIFF
--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -102,7 +102,7 @@ pub static TAIKO_MASAYA_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         (TaikoHardfork::Ontake.boxed(), ForkCondition::Block(0)),
         (TaikoHardfork::Pacaya.boxed(), ForkCondition::Block(0)),
         (TaikoHardfork::Shasta.boxed(), ForkCondition::Timestamp(0)),
-        (TaikoHardfork::Unzen.boxed(), ForkCondition::Never),
+        (TaikoHardfork::Unzen.boxed(), ForkCondition::Timestamp(1_778_158_800)),
     ]))
 });
 


### PR DESCRIPTION
## Summary
- Activate Unzen on the Masaya network at timestamp `1_778_158_800` (2026-05-07 13:00:00 UTC), replacing `ForkCondition::Never`.
- Via `extend_with_shared_hardforks`, this also activates Cancun/Prague/Osaka at the same timestamp on Masaya, matching Unzen semantics.

## Test plan
- [x] `just fmt`
- [x] `just clippy`
- [x] `cargo nextest run -p alethia-reth-chainspec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)