### PR TITLE
fix(rpc): use on-disk tip for historical init target

### DIFF
--- a/crates/node/src/proof_history/exex.rs
+++ b/crates/node/src/proof_history/exex.rs
@@ -239,7 +239,11 @@ where
         &self,
     ) -> eyre::Result<ProofHistoryInitializationAction> {
         let finalized_block = finalized_block_number(self.ctx.provider())?;
-        let executed_head = self.ctx.provider().best_block_number()?;
+        // Use the on-disk best block as `executed_head` so that the historical-init target header
+        // and reverse changesets are guaranteed to be persisted. The in-memory canonical tip from
+        // `provider().best_block_number()` can outpace disk by up to `engine.persistence-threshold`
+        // blocks, which previously caused the historical init to panic on a missing target header.
+        let executed_head = self.ctx.provider().database_provider_ro()?.best_block_number()?;
 
         match delayed_proof_history_start(
             finalized_block,


### PR DESCRIPTION
## Summary
- Fix a startup race in the `proofs-history` ExEx that crashed `alethia-reth` with `ExEx proofs-history crashed: missing proof-history target header N` on the `l2-node-reth-go-driver-0` mainnet pod.
- The `MissedStart` branch used `provider().best_block_number()` (in-memory canonical tip) as `target_block`, but `initialize_historical_proof_history_storage` reads the target header and reverse changesets through `database_provider_ro()`. With `--engine.persistence-threshold 128` the in-memory tip can lead disk by up to 128 blocks, so the disk-side `sealed_header(target_block)` returned `None` and the critical ExEx task panicked.
- Read `executed_head` from `database_provider_ro().best_block_number()` so the target is always a persisted block. `delayed_proof_history_start` now yields `WaitForExecution` until disk catches up, instead of `MissedStart` against an unpersisted block.

## Repro / evidence
- Pod: `l2-node-reth-go-driver-0` (mainnet), image `sha-a78d361`.
- Crash log:
  ```
  INFO exex{id="proofs-history"}: empty proof-history storage missed the finalized window start;
       building historical proof-history anchor finalized_block=Some(6088021)
       executed_head=6088856 start_block=5483221
  thread 'tokio-rt' panicked at .../launch/exex.rs:130:41:
  ExEx proofs-history crashed: missing proof-history target header 6088856
  ```
- Canonical chain logs in the same window were ~22 blocks behind on disk (committed `6088834`), confirming the in-memory/disk tip mismatch.

## Test plan
- [x] `just fmt`
- [x] `just clippy-fix` (clean)
- [x] `cargo check -p alethia-reth-node`
- [ ] Roll updated image into `l2-node-reth-go-driver-0` and confirm proof-history initializes without panic when restarted mid-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)