### PR TITLE
chore(deps-dev): sync Cargo.lock to 1.1.0 and drop redundant clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-bin"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alethia-reth-cli",
  "alethia-reth-node",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-block"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-evm",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-chainspec"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-cli"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alethia-reth-block",
  "alethia-reth-chainspec",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-consensus"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-evm",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-db"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-primitives",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-evm"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-primitives",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-network"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alethia-reth-chainspec",
  "eyre",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-node"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alethia-reth-block",
  "alethia-reth-chainspec",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-node-builder"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alethia-reth-block",
  "alethia-reth-chainspec",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-payload"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alethia-reth-block",
  "alethia-reth-chainspec",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-primitives"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-rpc"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alethia-reth-block",
  "alethia-reth-chainspec",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-rpc-types"
-version = "0.7.1"
+version = "1.1.0"
 dependencies = [
  "alloy-primitives",
  "serde",

--- a/crates/node/src/proof_history/init.rs
+++ b/crates/node/src/proof_history/init.rs
@@ -620,13 +620,13 @@ mod tests {
                 ]),
             ),
             trie_updates: TrieUpdatesSorted::new(
-                vec![(account_path.clone(), None)],
+                vec![(account_path, None)],
                 B256Map::from_iter([
                     (
                         storage,
                         StorageTrieUpdatesSorted {
                             is_deleted: false,
-                            storage_nodes: vec![(storage_path.clone(), Some(branch))],
+                            storage_nodes: vec![(storage_path, Some(branch))],
                         },
                     ),
                     (


### PR DESCRIPTION
## Summary
- Regenerate `Cargo.lock` so workspace crate versions match the 1.1.0 release (catches up after #141).
- Remove unnecessary `.clone()` calls in `proof_history/init.rs` tests flagged by clippy.

## Test plan
- [x] `just clippy`
- [x] `just test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)