### PR TITLE
chore(chainspec): set Hoodi Unzen fork time to `2026-05-21 13:00 UTC`

### DIFF
--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -82,7 +82,7 @@ pub static TAIKO_HOODI_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         (TaikoHardfork::Ontake.boxed(), ForkCondition::Block(0)),
         (TaikoHardfork::Pacaya.boxed(), ForkCondition::Block(0)),
         (TaikoHardfork::Shasta.boxed(), ForkCondition::Timestamp(1_770_296_400)),
-        (TaikoHardfork::Unzen.boxed(), ForkCondition::Never),
+        (TaikoHardfork::Unzen.boxed(), ForkCondition::Timestamp(1_779_368_400)),
     ]))
 });
 


### PR DESCRIPTION
## Summary
- Activate the Unzen hardfork on the Taiko Hoodi network at timestamp `1_779_368_400` (2026-05-21 13:00:00 UTC).
- Mirrors [#169](https://github.com/taikoxyz/alethia-reth/pull/169) which set the Masaya Unzen fork time.

## Test plan
- [ ] `cargo check -p alethia-reth-chainspec` passes
- [ ] `just test` (workspace nextest) passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)