### PR TITLE
feat(eth): gate batch lookup results by network

### DIFF
--- a/crates/rpc/src/eth/auth/lookup.rs
+++ b/crates/rpc/src/eth/auth/lookup.rs
@@ -4,13 +4,17 @@ use alloy_consensus::{BlockHeader as _, Transaction as _};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::U256;
 use jsonrpsee::core::RpcResult;
+use reth::chainspec::EthChainSpec;
 use reth_db_api::{DatabaseError, transaction::DbTx};
 use reth_node_api::Block;
 use reth_primitives_traits::BlockBody as _;
-use reth_provider::{BlockReaderIdExt, DBProvider, DatabaseProviderFactory};
+use reth_provider::{BlockReaderIdExt, ChainSpecProvider, DBProvider, DatabaseProviderFactory};
 use reth_rpc_eth_types::EthApiError;
 
 use crate::eth::error::{TaikoApiError, internal_eth_error};
+use alethia_reth_chainspec::{
+    TAIKO_DEVNET_CHAIN_ID, TAIKO_HOODI_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID, TAIKO_MASAYA_CHAIN_ID,
+};
 use alethia_reth_consensus::validation::ANCHOR_V4_SELECTOR;
 use alethia_reth_db::model::{BatchToLastBlock, StoredL1OriginTable};
 use alethia_reth_primitives::{decode_shasta_proposal_id, payload::attributes::RpcL1Origin};
@@ -36,6 +40,11 @@ pub(super) const MAX_BACKWARD_SCAN_BLOCKS: u64 = 192 * 21_600;
 /// Shorter backward scan limit for test execution.
 const TEST_MAX_BACKWARD_SCAN_BLOCKS: u64 = 64;
 
+/// Mainnet block number of the last Pacaya block accepted by batch lookup RPCs.
+const TAIKO_MAINNET_LAST_PACAYA_BATCH_LOOKUP_BLOCK: u64 = 4_990_434;
+/// Hoodi block number of the last Pacaya block accepted by batch lookup RPCs.
+const TAIKO_HOODI_LAST_PACAYA_BATCH_LOOKUP_BLOCK: u64 = 3_951_005;
+
 /// Returns the scan limit, using the test override when enabled.
 pub(super) fn max_backward_scan_blocks() -> u64 {
     #[cfg(test)]
@@ -50,7 +59,7 @@ pub(super) fn max_backward_scan_blocks() -> u64 {
 
 impl<Pool, Eth, Evm, Provider> TaikoAuthExt<Pool, Eth, Evm, Provider>
 where
-    Provider: DatabaseProviderFactory + BlockReaderIdExt,
+    Provider: DatabaseProviderFactory + BlockReaderIdExt + ChainSpecProvider,
 {
     /// Reads the cached last block number for a batch ID from the database mapping only.
     pub(super) fn read_cached_last_block_number_by_batch_id(
@@ -62,8 +71,8 @@ where
         if let Ok(Some(block_number)) = batch_lookup {
             return Ok(Some(U256::from(block_number)));
         }
-        if let Err(error) = batch_lookup &&
-            !Self::is_missing_table_error(&error)
+        if let Err(error) = batch_lookup
+            && !Self::is_missing_table_error(&error)
         {
             return Err(internal_eth_error(error).into());
         }
@@ -71,12 +80,32 @@ where
         Ok(None)
     }
 
+    /// Removes resolved block numbers below this network's last Pacaya block threshold.
+    pub(super) fn filter_batch_lookup_block_number(
+        &self,
+        block_number: Option<U256>,
+    ) -> Option<U256> {
+        block_number.filter(|block_number| {
+            !self.batch_lookup_result_below_last_pacaya_block_id(*block_number)
+        })
+    }
+
+    /// Returns `true` when a resolved batch lookup block is before the network threshold.
+    fn batch_lookup_result_below_last_pacaya_block_id(&self, block_number: U256) -> bool {
+        let chain_id = self.provider.chain_spec().chain().id();
+        let Some(threshold) = batch_lookup_last_pacaya_block_threshold(chain_id) else {
+            return false;
+        };
+
+        block_number < threshold
+    }
+
     /// Checks if a database error indicates a missing table or key.
     fn is_missing_table_error(error: &DatabaseError) -> bool {
         match error {
             DatabaseError::Open(info) | DatabaseError::Read(info) => {
-                info.code == -30798 ||
-                    info.message.as_ref().contains("no matching key/data pair found")
+                info.code == -30798
+                    || info.message.as_ref().contains("no matching key/data pair found")
             }
             _ => false,
         }
@@ -223,5 +252,15 @@ where
             .get::<StoredL1OriginTable>(block_id.to())
             .map_err(internal_eth_error)?
             .map(|origin| origin.into_rpc()))
+    }
+}
+
+/// Returns the last Pacaya block threshold for networks that need batch lookup filtering.
+fn batch_lookup_last_pacaya_block_threshold(chain_id: u64) -> Option<U256> {
+    match chain_id {
+        TAIKO_MAINNET_CHAIN_ID => Some(U256::from(TAIKO_MAINNET_LAST_PACAYA_BATCH_LOOKUP_BLOCK)),
+        TAIKO_HOODI_CHAIN_ID => Some(U256::from(TAIKO_HOODI_LAST_PACAYA_BATCH_LOOKUP_BLOCK)),
+        TAIKO_DEVNET_CHAIN_ID | TAIKO_MASAYA_CHAIN_ID => None,
+        _ => None,
     }
 }

--- a/crates/rpc/src/eth/auth/lookup.rs
+++ b/crates/rpc/src/eth/auth/lookup.rs
@@ -71,8 +71,8 @@ where
         if let Ok(Some(block_number)) = batch_lookup {
             return Ok(Some(U256::from(block_number)));
         }
-        if let Err(error) = batch_lookup
-            && !Self::is_missing_table_error(&error)
+        if let Err(error) = batch_lookup &&
+            !Self::is_missing_table_error(&error)
         {
             return Err(internal_eth_error(error).into());
         }
@@ -104,8 +104,8 @@ where
     fn is_missing_table_error(error: &DatabaseError) -> bool {
         match error {
             DatabaseError::Open(info) | DatabaseError::Read(info) => {
-                info.code == -30798
-                    || info.message.as_ref().contains("no matching key/data pair found")
+                info.code == -30798 ||
+                    info.message.as_ref().contains("no matching key/data pair found")
             }
             _ => false,
         }

--- a/crates/rpc/src/eth/auth/mod.rs
+++ b/crates/rpc/src/eth/auth/mod.rs
@@ -17,7 +17,9 @@ use reth_ethereum::{EthPrimitives, TransactionSigned};
 use reth_evm::ConfigureEngineEvm;
 use reth_evm_ethereum::RethReceiptBuilder;
 use reth_node_api::{Block, NodePrimitives};
-use reth_provider::{BlockReaderIdExt, DBProvider, DatabaseProviderFactory, StateProviderFactory};
+use reth_provider::{
+    BlockReaderIdExt, ChainSpecProvider, DBProvider, DatabaseProviderFactory, StateProviderFactory,
+};
 use reth_revm::{State, database::StateProviderDatabase};
 use reth_rpc_eth_api::{RpcConvert, RpcTransaction};
 use reth_rpc_eth_types::EthApiError;
@@ -159,6 +161,7 @@ where
     Eth: RpcConvert<Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Pool>>> + 'static,
     Provider: DatabaseProviderFactory
         + BlockReaderIdExt<Header = alloy_consensus::Header>
+        + ChainSpecProvider
         + StateProviderFactory
         + 'static,
     Evm: ConfigureEngineEvm<
@@ -219,19 +222,27 @@ where
 
     /// Retrieves the last L1 origin for the given batch ID.
     async fn last_l1_origin_by_batch_id(&self, batch_id: U256) -> RpcResult<Option<RpcL1Origin>> {
-        let block_id = self.resolve_last_block_number_by_batch_id(batch_id)?;
+        let Some(block_id) = self.filter_batch_lookup_block_number(Some(
+            self.resolve_last_block_number_by_batch_id(batch_id)?,
+        )) else {
+            return Ok(None);
+        };
 
         self.read_l1_origin_by_block_id(block_id)
     }
 
     /// Retrieves the last block ID for the given batch ID.
     async fn last_block_id_by_batch_id(&self, batch_id: U256) -> RpcResult<Option<U256>> {
-        Ok(Some(self.resolve_last_block_number_by_batch_id(batch_id)?))
+        Ok(self.filter_batch_lookup_block_number(Some(
+            self.resolve_last_block_number_by_batch_id(batch_id)?,
+        )))
     }
 
     /// Retrieves the cached last block ID for the given batch ID without fallback scanning.
     async fn last_certain_block_id_by_batch_id(&self, batch_id: U256) -> RpcResult<Option<U256>> {
-        self.read_cached_last_block_number_by_batch_id(batch_id)
+        Ok(self.filter_batch_lookup_block_number(
+            self.read_cached_last_block_number_by_batch_id(batch_id)?,
+        ))
     }
 
     /// Retrieves the cached L1 origin for the given batch ID without fallback scanning.
@@ -240,6 +251,9 @@ where
         batch_id: U256,
     ) -> RpcResult<Option<RpcL1Origin>> {
         let Some(block_id) = self.read_cached_last_block_number_by_batch_id(batch_id)? else {
+            return Ok(None);
+        };
+        let Some(block_id) = self.filter_batch_lookup_block_number(Some(block_id)) else {
             return Ok(None);
         };
 

--- a/crates/rpc/src/eth/auth/tests.rs
+++ b/crates/rpc/src/eth/auth/tests.rs
@@ -2,6 +2,7 @@ use super::{
     lookup::{MAX_BACKWARD_SCAN_BLOCKS, max_backward_scan_blocks},
     *,
 };
+use alethia_reth_chainspec::TAIKO_MAINNET;
 use alethia_reth_consensus::validation::ANCHOR_V4_SELECTOR;
 use alethia_reth_db::model::{
     BatchToLastBlock, STORED_L1_HEAD_ORIGIN_KEY, StoredL1HeadOriginTable, StoredL1Origin,
@@ -56,6 +57,13 @@ fn anchor_v4_input() -> Bytes {
 
 /// Builds a ProviderFactory wired with both reth and Taiko tables for lookup tests.
 fn create_taiko_test_provider_factory() -> ProviderFactory<MockNodeTypesWithDB> {
+    create_taiko_test_provider_factory_with_chain_spec(MAINNET.clone())
+}
+
+/// Builds a ProviderFactory wired with both reth and Taiko tables for the provided chain spec.
+fn create_taiko_test_provider_factory_with_chain_spec(
+    chain_spec: Arc<reth_ethereum::chainspec::ChainSpec>,
+) -> ProviderFactory<MockNodeTypesWithDB> {
     struct TaikoTables;
 
     impl TableSet for TaikoTables {
@@ -81,7 +89,7 @@ fn create_taiko_test_provider_factory() -> ProviderFactory<MockNodeTypesWithDB> 
     let db = Arc::new(TempDatabase::new(db, path));
     ProviderFactory::new(
         db,
-        MAINNET.clone(),
+        chain_spec,
         StaticFileProvider::read_write(static_dir.keep()).expect("static file provider"),
         RocksDBBuilder::new(&rocksdb_dir)
             .with_default_tables()
@@ -501,6 +509,32 @@ fn returns_last_certain_l1_origin_from_mapping() {
         .expect("l1 origin should exist");
     assert_eq!(resolved.block_id, block_id);
     assert_eq!(resolved.l1_block_height, Some(U256::from(3u64)));
+}
+
+#[test]
+/// Filters batch lookup results when the block is before the network threshold.
+fn filters_batch_lookup_results_below_network_threshold() {
+    let batch_id = U256::from(1u64);
+    let block_id = U256::from(2u64);
+    let genesis_header = Header { number: 0, gas_limit: 1_000_000, ..Default::default() };
+
+    let factory =
+        create_taiko_test_provider_factory_with_chain_spec(Arc::new(TAIKO_MAINNET.inner.clone()));
+    let mut provider_rw = factory.provider_rw().expect("provider rw");
+    let genesis_block = genesis_header.clone().into_block(BlockBody::default());
+    let genesis_recovered = RecoveredBlock::new_unhashed(genesis_block, vec![]);
+    provider_rw.insert_block(&genesis_recovered).expect("insert genesis block");
+    {
+        let tx = provider_rw.tx_mut();
+        tx.put::<BatchToLastBlock>(batch_id.to(), block_id.to()).expect("insert batch mapping");
+    }
+    provider_rw.commit().expect("commit");
+
+    let api = create_test_api(factory, genesis_header);
+    let raw_resolved = api.read_cached_last_block_number_by_batch_id(batch_id).unwrap();
+
+    assert_eq!(raw_resolved, Some(block_id));
+    assert_eq!(api.filter_batch_lookup_block_number(raw_resolved), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds Taiko network thresholds for batch lookup results using the last Pacaya block IDs for Mainnet and Hoodi.
- Filters all public batch lookup RPC return paths so blocks below the network threshold return `None`/JSON `null`.
- Adds a regression test covering threshold filtering while preserving raw cached lookup behavior.

## Test Plan
- `cargo test -p alethia-reth-rpc filters_batch_lookup_results_below_network_threshold -- --nocapture`
- `cargo test -p alethia-reth-rpc eth::auth::tests -- --nocapture`
- `cargo fmt -p alethia-reth-rpc --check`
- `cargo clippy -p alethia-reth-rpc --all-targets -- -D warnings`

Based on taikoxyz/taiko-geth#558.
