### PR TITLE
chore(auth): increase batch lookup window

### DIFF
--- a/crates/rpc/src/eth/auth/lookup.rs
+++ b/crates/rpc/src/eth/auth/lookup.rs
@@ -35,7 +35,7 @@ enum LastBlockSearchResult {
 }
 
 /// Maximum number of blocks to scan backwards when resolving a batch ID.
-pub(super) const MAX_BACKWARD_SCAN_BLOCKS: u64 = 192 * 21_600;
+pub(super) const MAX_BACKWARD_SCAN_BLOCKS: u64 = 768 * 21_600;
 #[cfg(test)]
 /// Shorter backward scan limit for test execution.
 const TEST_MAX_BACKWARD_SCAN_BLOCKS: u64 = 64;

--- a/crates/rpc/src/eth/auth/tests.rs
+++ b/crates/rpc/src/eth/auth/tests.rs
@@ -297,7 +297,7 @@ fn returns_uncertain_when_match_at_head_without_mapping() {
 #[test]
 /// Verifies the production lookback limit constant.
 fn uses_expected_lookback_limit_constant() {
-    assert_eq!(MAX_BACKWARD_SCAN_BLOCKS, 192 * 21_600);
+    assert_eq!(MAX_BACKWARD_SCAN_BLOCKS, 768 * 21_600);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Increase the production batch lookup scan window from `192 * 21_600` to `768 * 21_600`.
- Update the existing constant-value regression test to the new expected value.

## Test Plan
- `git diff --check`
- `rg -n "(MAX_BACKWARD_SCAN_BLOCKS).*768 \\* 21_600|768 \\* 21_600" crates/rpc/src/eth/auth/lookup.rs crates/rpc/src/eth/auth/tests.rs`

Note: `cargo test -p alethia-reth-rpc uses_expected_lookback_limit_constant -- --exact` was attempted twice, but local compilation stalled in `librocksdb-sys` build script with 0% CPU and had to be stopped.
