### PR TITLE
ci(repo): publish taiko-reth alongside alethia-reth

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - arc-runner-set
+    - arc-runner-set-arm64

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,7 +7,8 @@ on:
     types: [published]
 
 env:
-  REGISTRY_IMAGE: us-docker.pkg.dev/evmchain/images/alethia-reth
+  REGISTRY_IMAGE_ALETHIA: us-docker.pkg.dev/evmchain/images/alethia-reth
+  REGISTRY_IMAGE_TAIKO: us-docker.pkg.dev/evmchain/images/taiko-reth
 
 permissions:
   contents: read
@@ -42,7 +43,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: |
+            ${{ env.REGISTRY_IMAGE_ALETHIA }}
+            ${{ env.REGISTRY_IMAGE_TAIKO }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -59,7 +62,8 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: |
+            type=image,"name=${{ env.REGISTRY_IMAGE_ALETHIA }},${{ env.REGISTRY_IMAGE_TAIKO }}",push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -69,8 +73,8 @@ jobs:
 
       - name: Prepare platform pair
         run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
@@ -106,7 +110,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: |
+            ${{ env.REGISTRY_IMAGE_ALETHIA }}
+            ${{ env.REGISTRY_IMAGE_TAIKO }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -117,8 +123,37 @@ jobs:
             type=raw,value=nightly,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
-      - name: Create manifest list and push
+      - name: Create manifest lists and push
         working-directory: /tmp/digests
+        env:
+          IMAGES: |-
+            ${{ env.REGISTRY_IMAGE_ALETHIA }}
+            ${{ env.REGISTRY_IMAGE_TAIKO }}
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+          set -euo pipefail
+          shopt -s nullglob
+          digests=( * )
+          shopt -u nullglob
+          if [ ${#digests[@]} -eq 0 ]; then
+            echo "No digest files found in /tmp/digests; cannot compose manifest lists." >&2
+            exit 1
+          fi
+          while IFS= read -r image; do
+            [ -z "$image" ] && continue
+            tags=$(jq -cr --arg img "$image" \
+              '.tags | map(select(startswith($img + ":"))) | map("-t " + .) | join(" ")' \
+              <<< "$DOCKER_METADATA_OUTPUT_JSON")
+            if [ -z "$tags" ]; then
+              echo "No tags resolved for $image; skipping." >&2
+              continue
+            fi
+            sources=""
+            for d in "${digests[@]}"; do
+              sources+="${image}@sha256:${d} "
+            done
+            echo "Composing manifest list for ${image}:"
+            echo "  tags:    $tags"
+            echo "  sources: $sources"
+            # shellcheck disable=SC2086
+            docker buildx imagetools create $tags $sources
+          done <<< "$IMAGES"


### PR DESCRIPTION
## Summary

Extend the docker-build workflow to publish a byte-identical second image under `us-docker.pkg.dev/evmchain/images/taiko-reth` alongside the existing `alethia-reth`. Single build, dual push.

- `docker/metadata-action` is given both image names in `images:` (build and merge jobs), so the existing tag rules fan out across both images automatically.
- `docker/build-push-action` exporter's `outputs.name=` is now a quoted comma-separated list of both image names, so buildx pushes each per-arch manifest to both repos in one shot.
- The merge step iterates over the two image names and runs `imagetools create` once per image, with each manifest list sourcing per-arch digests from its own repo. Pre-loop check guards against an empty `/tmp/digests` and the source list is built via a for-loop (avoids format-string-from-variable).
- Adds `.github/actionlint.yaml` to declare the existing self-hosted runner labels (`arc-runner-set`, `arc-runner-set-arm64`) so `actionlint` runs clean on this workflow; quotes `${{ matrix.platform }}` and `$GITHUB_ENV` in the existing "Prepare platform pair" step (pre-existing SC2086).

Verified with `actionlint` (`rhysd/actionlint:latest` via Docker) — clean run.

## Prerequisite

The `GAR_JSON_KEY` service account must have `roles/artifactregistry.writer` on the `images` Docker repo (or project-level). Since `alethia-reth` already pushes there under the same SA and `taiko-reth` is a sibling image in the same repo, no IAM changes should be required — GAR auto-creates new image paths on first push under a Docker repo. Worth a sanity check before merging.

## Test plan

- [ ] CI run on this PR produces both `alethia-reth:pr-<N>` and `taiko-reth:pr-<N>` with matching `linux/amd64` and `linux/arm64` per-arch digests
- [ ] After merge, `nightly` tag is updated on both images and the per-arch digests match across the two image names
- [ ] On next release, matching `latest`, `vX.Y.Z`, and `vX.Y` tags appear on both images

After CI succeeds, verify with:

```bash
docker buildx imagetools inspect us-docker.pkg.dev/evmchain/images/alethia-reth:pr-<N>
docker buildx imagetools inspect us-docker.pkg.dev/evmchain/images/taiko-reth:pr-<N>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)