### PR TITLE
feat(evm): add TX_INTRINSIC_ZK_GAS to Unzen zk gas accounting

### DIFF
--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -368,6 +368,19 @@ where
         }
 
         self.reset_current_transaction_zk_gas();
+
+        // Charge the per-transaction intrinsic zk gas before EVM execution begins, as required
+        // by the Unzen zk gas spec (taikoxyz/taiko-mono#21669). The intrinsic sits in the
+        // in-flight tx total so it is committed alongside opcode/precompile usage on success
+        // and discarded on revert/failure. A schedule with a zero intrinsic (Masaya) makes this
+        // a no-op. If the intrinsic alone would exceed the remaining block budget, mirror the
+        // mid-tx exhaustion path used by the inspector.
+        if let Err(ZkGasOutcome::LimitExceeded) = self.evm.charge_tx_intrinsic_zk_gas() {
+            self.zk_gas_exhausted = true;
+            self.reset_current_transaction_zk_gas();
+            return Err(Self::zk_gas_limit_error());
+        }
+
         let result = match self.evm.transact(tx_env) {
             Ok(result) => result,
             Err(err) if err.to_string() == ZK_GAS_LIMIT_ERR => {
@@ -520,14 +533,19 @@ mod test {
         state::AccountInfo,
     };
 
-    use alethia_reth_evm::{alloy::decode_anchor_system_call_data, factory::TaikoEvmFactory};
+    use alethia_reth_chainspec::TAIKO_MASAYA_CHAIN_ID;
+    use alethia_reth_evm::{
+        alloy::decode_anchor_system_call_data,
+        factory::TaikoEvmFactory,
+        zk_gas::unzen::{MASAYA_TX_INTRINSIC_ZK_GAS, TX_INTRINSIC_ZK_GAS},
+    };
 
     use super::*;
     use crate::{
         config::{TaikoEvmConfig, TaikoNextBlockEnvAttributes},
         testutil::{
             BENCH_LIMIT_TARGET, BENCH_SUCCESS_TARGET, db_with_contracts, recovered_tx,
-            unzen_chain_spec, unzen_evm_env, unzen_execution_ctx,
+            recovered_tx_with_chain_id, unzen_chain_spec, unzen_evm_env, unzen_execution_ctx,
         },
     };
     use alethia_reth_chainspec::spec::TaikoChainSpec;
@@ -597,6 +615,62 @@ mod test {
         let (_, result) = executor.finish().expect("executor should finish after truncation");
         assert_eq!(result.receipts.len(), 1);
         assert_eq!(result.gas_used, gas_used.tx_gas_used());
+    }
+
+    #[test]
+    fn executor_includes_tx_intrinsic_in_committed_block_zk_gas() {
+        let chain_spec = Arc::new(unzen_chain_spec());
+        let mut state = State::builder()
+            .with_database(db_with_contracts(&[(BENCH_CALLER, 0)]))
+            .with_bundle_update()
+            .build();
+        let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
+        let ctx = unzen_execution_ctx();
+        let mut executor =
+            TaikoBlockExecutor::new(evm, ctx.clone(), chain_spec, RethReceiptBuilder::default());
+
+        executor
+            .execute_transaction(recovered_tx(BENCH_CALLER, BENCH_SUCCESS_TARGET, 0, 1))
+            .expect("successful tx should commit");
+
+        let finalized = ctx.finalized_block_zk_gas();
+        assert!(
+            finalized >= TX_INTRINSIC_ZK_GAS,
+            "finalized block zk gas ({finalized}) must include the per-tx intrinsic charge ({TX_INTRINSIC_ZK_GAS})"
+        );
+    }
+
+    #[test]
+    fn executor_does_not_charge_tx_intrinsic_on_masaya_schedule() {
+        let chain_spec = Arc::new(unzen_chain_spec());
+        let mut state = State::builder()
+            .with_database(db_with_contracts(&[(BENCH_CALLER, 0)]))
+            .with_bundle_update()
+            .build();
+        let mut env = unzen_evm_env();
+        env.cfg_env.chain_id = TAIKO_MASAYA_CHAIN_ID;
+        let evm = TaikoEvmFactory.create_evm(&mut state, env);
+        let ctx = unzen_execution_ctx();
+        let mut executor =
+            TaikoBlockExecutor::new(evm, ctx.clone(), chain_spec, RethReceiptBuilder::default());
+
+        executor
+            .execute_transaction(recovered_tx_with_chain_id(
+                BENCH_CALLER,
+                BENCH_SUCCESS_TARGET,
+                0,
+                1,
+                TAIKO_MASAYA_CHAIN_ID,
+            ))
+            .expect("successful tx should commit on Masaya");
+
+        let finalized = ctx.finalized_block_zk_gas();
+        assert_eq!(MASAYA_TX_INTRINSIC_ZK_GAS, 0);
+        assert!(
+            finalized < TX_INTRINSIC_ZK_GAS,
+            "Masaya finalized block zk gas ({finalized}) must not include any per-tx intrinsic charge"
+        );
+        assert!(finalized > 0, "successful tx must still record opcode-driven zk gas (got 0)");
     }
 
     #[cfg(feature = "prover")]

--- a/crates/block/src/testutil.rs
+++ b/crates/block/src/testutil.rs
@@ -63,15 +63,28 @@ pub fn unzen_execution_ctx<'a>() -> TaikoBlockExecutionCtx<'a> {
     }
 }
 
-/// Builds a recovered legacy transaction targeting `to` from `caller`.
+/// Builds a recovered legacy transaction targeting `to` from `caller`, defaulting to the
+/// Devnet chain id (`167`).
 pub fn recovered_tx(
     caller: Address,
     to: Address,
     nonce: u64,
     gas_price: u64,
 ) -> Recovered<TransactionSigned> {
+    recovered_tx_with_chain_id(caller, to, nonce, gas_price, 167)
+}
+
+/// Builds a recovered legacy transaction targeting `to` from `caller` with an explicit chain id,
+/// so tests can submit transactions against the Masaya chain id (`167_011`) and others.
+pub fn recovered_tx_with_chain_id(
+    caller: Address,
+    to: Address,
+    nonce: u64,
+    gas_price: u64,
+    chain_id: u64,
+) -> Recovered<TransactionSigned> {
     let tx = TxLegacy {
-        chain_id: Some(ChainId::from(167_u64)),
+        chain_id: Some(ChainId::from(chain_id)),
         nonce,
         gas_price: gas_price.into(),
         gas_limit: 5_000_000,

--- a/crates/evm/src/alloy.rs
+++ b/crates/evm/src/alloy.rs
@@ -80,6 +80,11 @@ pub trait TaikoZkGasEvm {
 
     /// Returns the finalized block zk gas that has already been committed.
     fn block_zk_gas_used(&self) -> Option<u64>;
+
+    /// Charges the fixed per-transaction intrinsic zk gas defined by the active schedule.
+    ///
+    /// Returns `Ok(())` when the EVM has no shared meter installed (pre-Unzen specs).
+    fn charge_tx_intrinsic_zk_gas(&self) -> Result<(), ZkGasOutcome>;
 }
 
 impl<DB, I, P> TaikoZkGasEvm for TaikoEvmWrapper<DB, I, P>
@@ -108,6 +113,14 @@ where
     /// Returns the finalized block zk gas that has already been committed.
     fn block_zk_gas_used(&self) -> Option<u64> {
         self.shared_meter().map(|meter| lock_meter(&meter).block_zk_gas_used())
+    }
+
+    /// Charges the fixed per-transaction intrinsic zk gas through the shared meter.
+    fn charge_tx_intrinsic_zk_gas(&self) -> Result<(), ZkGasOutcome> {
+        let Some(meter) = self.shared_meter() else {
+            return Ok(());
+        };
+        lock_meter(&meter).charge_tx_intrinsic()
     }
 }
 

--- a/crates/evm/src/zk_gas/meter.rs
+++ b/crates/evm/src/zk_gas/meter.rs
@@ -74,6 +74,15 @@ impl<'a> ZkGasMeter<'a> {
         self.charge_amount(charge)
     }
 
+    /// Charges the fixed per-transaction intrinsic zk gas defined by the active schedule.
+    ///
+    /// Mirrors `TX_INTRINSIC_ZK_GAS` from the Unzen zk gas spec: the charge accumulates into the
+    /// in-flight transaction total and is only promoted into the block total when the transaction
+    /// commits. A schedule value of `0` (Masaya) makes this a no-op.
+    pub fn charge_tx_intrinsic(&mut self) -> Result<(), ZkGasOutcome> {
+        self.charge_amount(self.schedule.tx_intrinsic_zk_gas)
+    }
+
     /// Applies a checked zk gas charge against the current transaction and block budget.
     fn charge_amount(&mut self, charge: u64) -> Result<(), ZkGasOutcome> {
         let next_tx = self.tx_zk_gas_used.checked_add(charge).ok_or(ZkGasOutcome::LimitExceeded)?;

--- a/crates/evm/src/zk_gas/schedule.rs
+++ b/crates/evm/src/zk_gas/schedule.rs
@@ -28,6 +28,10 @@ pub struct SpawnEstimates {
 pub struct ZkGasSchedule {
     /// Maximum zk gas permitted across a single block.
     pub block_limit: u64,
+    /// Fixed zk gas charged once per block transaction before opcode or precompile
+    /// metering begins. Set to `0` on chains whose Unzen activation predates this
+    /// field, to preserve historical block consensus.
+    pub tx_intrinsic_zk_gas: u64,
     /// Per-opcode proving-cost multipliers indexed by opcode byte.
     pub opcode_multipliers: [u16; 256],
     /// Per-precompile proving-cost multipliers indexed by low-byte address.

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -144,6 +144,45 @@ fn meter_promotes_committed_tx_usage_into_block_usage() {
 }
 
 #[test]
+fn meter_charge_tx_intrinsic_adds_schedule_value_to_in_flight_tx() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let mut meter = ZkGasMeter::new(schedule);
+
+    meter.charge_tx_intrinsic().expect("intrinsic should fit");
+    assert_eq!(meter.tx_zk_gas_used(), schedule.tx_intrinsic_zk_gas);
+    assert_eq!(meter.block_zk_gas_used(), 0);
+
+    meter.commit_transaction().expect("commit");
+    assert_eq!(meter.block_zk_gas_used(), schedule.tx_intrinsic_zk_gas);
+}
+
+#[test]
+fn meter_charge_tx_intrinsic_is_noop_on_masaya_schedule() {
+    let schedule =
+        schedule_for(TaikoSpecId::UNZEN, TAIKO_MASAYA_CHAIN_ID).expect("Masaya Unzen schedule");
+    let mut meter = ZkGasMeter::new(schedule);
+
+    meter.charge_tx_intrinsic().expect("zero charge always fits");
+    assert_eq!(meter.tx_zk_gas_used(), 0);
+}
+
+#[test]
+fn meter_charge_tx_intrinsic_returns_limit_exceeded_when_remaining_budget_is_too_small() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let mut meter = ZkGasMeter::new(schedule);
+
+    // Fill the block budget to within (intrinsic - 1) of the limit so the next intrinsic
+    // charge alone would bust it. CREATE has a multiplier of 1, which makes the arithmetic
+    // trivial.
+    let prefill = schedule.block_limit - schedule.tx_intrinsic_zk_gas + 1;
+    assert_eq!(u64::from(schedule.opcode_multipliers[0xf0]), 1);
+    meter.charge_opcode(0xf0, prefill).expect("prefill");
+    meter.commit_transaction().expect("commit prefill");
+
+    assert!(matches!(meter.charge_tx_intrinsic(), Err(ZkGasOutcome::LimitExceeded)));
+}
+
+#[test]
 fn meter_treats_opcode_multiplication_overflow_as_limit_exceeded() {
     let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -380,6 +380,34 @@ fn factory_installs_default_schedule_when_chain_id_is_not_masaya() {
 }
 
 #[test]
+fn taiko_zk_gas_evm_charge_tx_intrinsic_adds_intrinsic_to_in_flight_tx() {
+    use crate::alloy::TaikoZkGasEvm;
+
+    let evm = TaikoEvmFactory.create_evm(
+        db_with_contract(staticcall_identity_bytecode()),
+        evm_env(TaikoSpecId::UNZEN),
+    );
+
+    evm.charge_tx_intrinsic_zk_gas().expect("intrinsic should fit");
+    let meter = evm.shared_meter().expect("Unzen schedule installs a meter");
+    let meter = meter.lock().expect("meter lock");
+    assert_eq!(meter.tx_zk_gas_used(), meter.schedule().tx_intrinsic_zk_gas);
+}
+
+#[test]
+fn taiko_zk_gas_evm_charge_tx_intrinsic_is_ok_when_metering_is_disabled() {
+    use crate::alloy::TaikoZkGasEvm;
+
+    let evm = TaikoEvmFactory.create_evm(
+        db_with_contract(staticcall_identity_bytecode()),
+        evm_env(TaikoSpecId::SHASTA),
+    );
+
+    assert!(evm.shared_meter().is_none());
+    evm.charge_tx_intrinsic_zk_gas().expect("disabled metering should be a no-op");
+}
+
+#[test]
 fn non_unzen_default_create_evm_path_keeps_metering_disabled() {
     let mut evm = TaikoEvmFactory.create_evm(
         db_with_contract(limit_exceeding_keccak_bytecode()),

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -21,7 +21,10 @@ use super::{
     adapter::ZK_GAS_LIMIT_ERR,
     meter::{ZkGasMeter, ZkGasOutcome},
     schedule::{TAIKO_MASAYA_CHAIN_ID, schedule_for},
-    unzen::{MASAYA_BLOCK_ZK_GAS_LIMIT, MASAYA_UNZEN_ZK_GAS_SCHEDULE, UNZEN_ZK_GAS_SCHEDULE},
+    unzen::{
+        MASAYA_BLOCK_ZK_GAS_LIMIT, MASAYA_TX_INTRINSIC_ZK_GAS, MASAYA_UNZEN_ZK_GAS_SCHEDULE,
+        TX_INTRINSIC_ZK_GAS, UNZEN_ZK_GAS_SCHEDULE,
+    },
 };
 
 #[test]
@@ -89,6 +92,18 @@ fn unzen_schedule_uses_spec_spawn_estimates() {
 fn masaya_unzen_schedule_uses_one_billion_block_limit() {
     assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.block_limit, 1_000_000_000);
     assert_eq!(MASAYA_BLOCK_ZK_GAS_LIMIT, 1_000_000_000);
+}
+
+#[test]
+fn unzen_schedule_pins_default_tx_intrinsic_zk_gas_at_243_000() {
+    assert_eq!(UNZEN_ZK_GAS_SCHEDULE.tx_intrinsic_zk_gas, 243_000);
+    assert_eq!(TX_INTRINSIC_ZK_GAS, 243_000);
+}
+
+#[test]
+fn masaya_unzen_schedule_pins_tx_intrinsic_zk_gas_at_zero() {
+    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.tx_intrinsic_zk_gas, 0);
+    assert_eq!(MASAYA_TX_INTRINSIC_ZK_GAS, 0);
 }
 
 #[test]

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -383,10 +383,8 @@ fn factory_installs_default_schedule_when_chain_id_is_not_masaya() {
 fn taiko_zk_gas_evm_charge_tx_intrinsic_adds_intrinsic_to_in_flight_tx() {
     use crate::alloy::TaikoZkGasEvm;
 
-    let evm = TaikoEvmFactory.create_evm(
-        db_with_contract(staticcall_identity_bytecode()),
-        evm_env(TaikoSpecId::UNZEN),
-    );
+    let evm = TaikoEvmFactory
+        .create_evm(db_with_contract(staticcall_identity_bytecode()), evm_env(TaikoSpecId::UNZEN));
 
     evm.charge_tx_intrinsic_zk_gas().expect("intrinsic should fit");
     let meter = evm.shared_meter().expect("Unzen schedule installs a meter");
@@ -398,10 +396,8 @@ fn taiko_zk_gas_evm_charge_tx_intrinsic_adds_intrinsic_to_in_flight_tx() {
 fn taiko_zk_gas_evm_charge_tx_intrinsic_is_ok_when_metering_is_disabled() {
     use crate::alloy::TaikoZkGasEvm;
 
-    let evm = TaikoEvmFactory.create_evm(
-        db_with_contract(staticcall_identity_bytecode()),
-        evm_env(TaikoSpecId::SHASTA),
-    );
+    let evm = TaikoEvmFactory
+        .create_evm(db_with_contract(staticcall_identity_bytecode()), evm_env(TaikoSpecId::SHASTA));
 
     assert!(evm.shared_meter().is_none());
     evm.charge_tx_intrinsic_zk_gas().expect("disabled metering should be a no-op");

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -11,15 +11,29 @@ pub const BLOCK_ZK_GAS_LIMIT: u64 = 100_000_000;
 /// Maximum zk gas permitted within a single Unzen block on the Taiko Masaya network.
 pub const MASAYA_BLOCK_ZK_GAS_LIMIT: u64 = 1_000_000_000;
 
+/// Fixed zk gas charged once per block transaction on Devnet, Hoodi, and Mainnet Unzen.
+///
+/// Value sourced from <https://github.com/taikoxyz/taiko-mono/pull/21669>; covers the proving
+/// cost of per-transaction sender ecrecovery.
+pub const TX_INTRINSIC_ZK_GAS: u64 = 243_000;
+
+/// Fixed zk gas charged once per block transaction on the Taiko Masaya network.
+///
+/// Pinned at `0` because Masaya activated Unzen before [taikoxyz/taiko-mono#21669] landed;
+/// adopting the non-zero value retroactively would break consensus on already-finalized
+/// blocks (their `difficulty` header equals the finalized block zk gas).
+pub const MASAYA_TX_INTRINSIC_ZK_GAS: u64 = 0;
+
 /// Fail-safe multiplier used for any opcode or precompile missing from the Unzen table.
 const FAILSAFE_MULTIPLIER: u16 = u16::MAX;
 
-/// Builds an Unzen-shaped zk gas schedule with the requested block limit. Opcode multipliers,
-/// precompile multipliers, and spawn estimates are identical across all networks; only the
-/// block budget differs.
-const fn unzen_schedule_with_block_limit(block_limit: u64) -> ZkGasSchedule {
+/// Builds an Unzen-shaped zk gas schedule with the requested block limit and per-transaction
+/// intrinsic charge. Opcode multipliers, precompile multipliers, and spawn estimates are
+/// identical across all networks; only the block budget and intrinsic charge differ.
+const fn unzen_schedule_with(block_limit: u64, tx_intrinsic_zk_gas: u64) -> ZkGasSchedule {
     ZkGasSchedule {
         block_limit,
+        tx_intrinsic_zk_gas,
         opcode_multipliers: unzen_opcode_multipliers(),
         precompile_multipliers: unzen_precompile_multipliers(),
         spawn_estimates: SpawnEstimates {
@@ -35,11 +49,12 @@ const fn unzen_schedule_with_block_limit(block_limit: u64) -> ZkGasSchedule {
 
 /// Default Unzen zk gas schedule used by Devnet, Hoodi, and Mainnet.
 pub static UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule =
-    unzen_schedule_with_block_limit(BLOCK_ZK_GAS_LIMIT);
+    unzen_schedule_with(BLOCK_ZK_GAS_LIMIT, TX_INTRINSIC_ZK_GAS);
 
-/// Unzen zk gas schedule used by the Taiko Masaya network with a 10× higher block budget.
+/// Unzen zk gas schedule used by the Taiko Masaya network with a 10× higher block budget and
+/// a zero intrinsic charge that preserves consensus on already-finalized blocks.
 pub static MASAYA_UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule =
-    unzen_schedule_with_block_limit(MASAYA_BLOCK_ZK_GAS_LIMIT);
+    unzen_schedule_with(MASAYA_BLOCK_ZK_GAS_LIMIT, MASAYA_TX_INTRINSIC_ZK_GAS);
 
 /// Returns the fixed Unzen opcode multiplier table with fail-safe defaults for unlisted opcodes.
 const fn unzen_opcode_multipliers() -> [u16; 256] {


### PR DESCRIPTION
## Summary

Ports [taikoxyz/taiko-mono#21669](https://github.com/taikoxyz/taiko-mono/pull/21669) — adds a fixed per-transaction intrinsic zk gas charge (`TX_INTRINSIC_ZK_GAS = 243_000`) to Unzen, charged once per block transaction (anchor included) before opcode/precompile metering begins. Primarily covers the proving cost of sender ecrecovery.

**Masaya is pinned at `0`** to preserve consensus on already-finalized blocks: Masaya activated Unzen before this constant landed, and its header `difficulty` equals the finalized block zk gas, so changing the charge retroactively would break replay of historical blocks. All other networks (Devnet, Hoodi, Mainnet) get the full `243_000`.

## Changes

- `ZkGasSchedule` gains a `tx_intrinsic_zk_gas: u64` field, threaded through the existing Masaya-vs-default schedule split in `crates/evm/src/zk_gas/`.
- `ZkGasMeter::charge_tx_intrinsic` charges the intrinsic into the in-flight tx total (committed on success, discarded on failure) and reuses the existing checked-arithmetic path.
- `TaikoZkGasEvm::charge_tx_intrinsic_zk_gas` exposes the operation through the EVM trait; returns `Ok(())` when no meter is installed (pre-Unzen specs).
- `TaikoBlockExecutor::execute_transaction_without_commit` calls the new method between the in-flight reset and the EVM dispatch. If the intrinsic alone busts the remaining block budget, it sets `zk_gas_exhausted = true` and returns the dedicated `ZkGasLimitExceeded` error — mirroring the existing inspector-driven exhaustion path. The prover-mode filter `try_execute_filtered` already routes this correctly (non-anchor → skip + truncate; anchor → fatal).

## Test plan

- [x] `cargo nextest run -p alethia-reth-evm zk_gas` — 31/31 zk gas tests pass.
- [x] `cargo nextest run -p alethia-reth-block` — 21/21 default + 23/23 `--features prover` pass.
- [x] `just fmt` — clean.
- [x] `just clippy` — zero warnings (warnings treated as errors).
- [x] `just test` — 171/171 workspace tests pass.

New tests added:
- Schedule pinning: default `243_000` and Masaya `0`.
- Meter: charges add to in-flight tx and promote on commit; no-op on Masaya; returns `LimitExceeded` when intrinsic alone exceeds remaining block budget.
- Trait: charge wires through to the meter; no-op when metering disabled.
- Executor: committed Unzen tx includes the intrinsic in finalized block zk gas; Masaya executor confirms zero charge while still recording opcode-derived zk gas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)