### PR TITLE
feat(evm): add `ZK_GAS_METERING_OVERHEAD` to Unzen zk gas accounting

### DIFF
--- a/crates/evm/src/zk_gas/meter.rs
+++ b/crates/evm/src/zk_gas/meter.rs
@@ -56,13 +56,23 @@ impl<'a> ZkGasMeter<'a> {
     }
 
     /// Charges zk gas for a single opcode execution.
+    ///
+    /// Adds the schedule's `zk_gas_metering_overhead` on top of `raw_gas * multiplier` so the
+    /// charge accounts for the proving cost of the metering hook itself. A schedule overhead
+    /// of `0` (Masaya) makes the addition a no-op.
     pub fn charge_opcode(&mut self, opcode: u8, raw_gas: u64) -> Result<(), ZkGasOutcome> {
         let multiplier = u64::from(self.schedule.opcode_multipliers[usize::from(opcode)]);
-        let charge = raw_gas.checked_mul(multiplier).ok_or(ZkGasOutcome::LimitExceeded)?;
+        let charge = raw_gas
+            .checked_mul(multiplier)
+            .and_then(|product| product.checked_add(self.schedule.zk_gas_metering_overhead))
+            .ok_or(ZkGasOutcome::LimitExceeded)?;
         self.charge_amount(charge)
     }
 
     /// Charges zk gas for a single precompile execution.
+    ///
+    /// Adds the schedule's `zk_gas_metering_overhead` on top of `gas_used * multiplier` for the
+    /// same reason as `charge_opcode`.
     pub fn charge_precompile(
         &mut self,
         address_low_byte: u8,
@@ -70,7 +80,10 @@ impl<'a> ZkGasMeter<'a> {
     ) -> Result<(), ZkGasOutcome> {
         let multiplier =
             u64::from(self.schedule.precompile_multipliers[usize::from(address_low_byte)]);
-        let charge = gas_used.checked_mul(multiplier).ok_or(ZkGasOutcome::LimitExceeded)?;
+        let charge = gas_used
+            .checked_mul(multiplier)
+            .and_then(|product| product.checked_add(self.schedule.zk_gas_metering_overhead))
+            .ok_or(ZkGasOutcome::LimitExceeded)?;
         self.charge_amount(charge)
     }
 

--- a/crates/evm/src/zk_gas/schedule.rs
+++ b/crates/evm/src/zk_gas/schedule.rs
@@ -32,6 +32,11 @@ pub struct ZkGasSchedule {
     /// metering begins. Set to `0` on chains whose Unzen activation predates this
     /// field, to preserve historical block consensus.
     pub tx_intrinsic_zk_gas: u64,
+    /// Fixed zk gas charged on every opcode execution and every precompile call, on top of
+    /// `raw_gas * multiplier`. Covers the proving cost of the zk gas metering hook itself.
+    /// Set to `0` on chains whose Unzen activation predates this field, to preserve
+    /// historical block consensus.
+    pub zk_gas_metering_overhead: u64,
     /// Per-opcode proving-cost multipliers indexed by opcode byte.
     pub opcode_multipliers: [u16; 256],
     /// Per-precompile proving-cost multipliers indexed by low-byte address.

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -23,7 +23,8 @@ use super::{
     schedule::{TAIKO_MASAYA_CHAIN_ID, schedule_for},
     unzen::{
         MASAYA_BLOCK_ZK_GAS_LIMIT, MASAYA_TX_INTRINSIC_ZK_GAS, MASAYA_UNZEN_ZK_GAS_SCHEDULE,
-        TX_INTRINSIC_ZK_GAS, UNZEN_ZK_GAS_SCHEDULE,
+        MASAYA_ZK_GAS_METERING_OVERHEAD, TX_INTRINSIC_ZK_GAS, UNZEN_ZK_GAS_SCHEDULE,
+        ZK_GAS_METERING_OVERHEAD,
     },
 };
 
@@ -107,6 +108,18 @@ fn masaya_unzen_schedule_pins_tx_intrinsic_zk_gas_at_zero() {
 }
 
 #[test]
+fn unzen_schedule_pins_default_zk_gas_metering_overhead_at_90() {
+    assert_eq!(UNZEN_ZK_GAS_SCHEDULE.zk_gas_metering_overhead, 90);
+    assert_eq!(ZK_GAS_METERING_OVERHEAD, 90);
+}
+
+#[test]
+fn masaya_unzen_schedule_pins_zk_gas_metering_overhead_at_zero() {
+    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.zk_gas_metering_overhead, 0);
+    assert_eq!(MASAYA_ZK_GAS_METERING_OVERHEAD, 0);
+}
+
+#[test]
 fn masaya_and_default_unzen_schedules_share_opcode_and_precompile_tables() {
     assert_eq!(
         UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers,
@@ -140,7 +153,58 @@ fn meter_promotes_committed_tx_usage_into_block_usage() {
     meter.charge_opcode(0x01, 3).expect("charge");
     meter.commit_transaction().expect("commit");
 
-    assert_eq!(meter.block_zk_gas_used(), 3 * u64::from(schedule.opcode_multipliers[0x01]));
+    assert_eq!(
+        meter.block_zk_gas_used(),
+        3 * u64::from(schedule.opcode_multipliers[0x01]) + schedule.zk_gas_metering_overhead
+    );
+}
+
+#[test]
+fn meter_charge_opcode_adds_metering_overhead_on_default_unzen() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let mut meter = ZkGasMeter::new(schedule);
+
+    meter.charge_opcode(0x01, 3).expect("charge");
+
+    assert_eq!(
+        meter.tx_zk_gas_used(),
+        3 * u64::from(schedule.opcode_multipliers[0x01]) + ZK_GAS_METERING_OVERHEAD
+    );
+}
+
+#[test]
+fn meter_charge_opcode_has_no_metering_overhead_on_masaya() {
+    let schedule =
+        schedule_for(TaikoSpecId::UNZEN, TAIKO_MASAYA_CHAIN_ID).expect("Masaya Unzen schedule");
+    let mut meter = ZkGasMeter::new(schedule);
+
+    meter.charge_opcode(0x01, 3).expect("charge");
+
+    assert_eq!(meter.tx_zk_gas_used(), 3 * u64::from(schedule.opcode_multipliers[0x01]));
+}
+
+#[test]
+fn meter_charge_precompile_adds_metering_overhead_on_default_unzen() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let mut meter = ZkGasMeter::new(schedule);
+
+    meter.charge_precompile(0x04, 18).expect("charge");
+
+    assert_eq!(
+        meter.tx_zk_gas_used(),
+        18 * u64::from(schedule.precompile_multipliers[0x04]) + ZK_GAS_METERING_OVERHEAD
+    );
+}
+
+#[test]
+fn meter_charge_precompile_has_no_metering_overhead_on_masaya() {
+    let schedule =
+        schedule_for(TaikoSpecId::UNZEN, TAIKO_MASAYA_CHAIN_ID).expect("Masaya Unzen schedule");
+    let mut meter = ZkGasMeter::new(schedule);
+
+    meter.charge_precompile(0x04, 18).expect("charge");
+
+    assert_eq!(meter.tx_zk_gas_used(), 18 * u64::from(schedule.precompile_multipliers[0x04]));
 }
 
 #[test]
@@ -172,11 +236,12 @@ fn meter_charge_tx_intrinsic_returns_limit_exceeded_when_remaining_budget_is_too
     let mut meter = ZkGasMeter::new(schedule);
 
     // Fill the block budget to within (intrinsic - 1) of the limit so the next intrinsic
-    // charge alone would bust it. CREATE has a multiplier of 1, which makes the arithmetic
-    // trivial.
-    let prefill = schedule.block_limit - schedule.tx_intrinsic_zk_gas + 1;
+    // charge alone would bust it. CREATE has a multiplier of 1, so `charge_opcode(0xf0, raw)`
+    // charges `raw + overhead` against the budget.
     assert_eq!(u64::from(schedule.opcode_multipliers[0xf0]), 1);
-    meter.charge_opcode(0xf0, prefill).expect("prefill");
+    let prefill_raw =
+        schedule.block_limit - schedule.tx_intrinsic_zk_gas + 1 - schedule.zk_gas_metering_overhead;
+    meter.charge_opcode(0xf0, prefill_raw).expect("prefill");
     meter.commit_transaction().expect("commit prefill");
 
     assert!(matches!(meter.charge_tx_intrinsic(), Err(ZkGasOutcome::LimitExceeded)));
@@ -216,13 +281,19 @@ fn meter_resets_transaction_usage_without_affecting_block_usage() {
 fn meter_allows_exactly_remaining_block_budget() {
     let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
+    let overhead = schedule.zk_gas_metering_overhead;
 
-    meter.charge_opcode(0xf0, schedule.block_limit - 1).expect("prefill");
+    // CREATE has multiplier=1, so `charge_opcode(0xf0, raw)` charges `raw + overhead`. Land
+    // exactly one `overhead`-sized charge short of the block limit so a second call can fill
+    // the remainder without leftover bytes the overhead can't reach.
+    assert_eq!(u64::from(schedule.opcode_multipliers[0xf0]), 1);
+    let first_raw = schedule.block_limit - overhead.checked_mul(2).expect("non-overflowing");
+    meter.charge_opcode(0xf0, first_raw).expect("prefill");
     meter.commit_transaction().expect("commit");
 
-    assert_eq!(meter.block_zk_gas_used(), schedule.block_limit - 1);
+    assert_eq!(meter.block_zk_gas_used(), schedule.block_limit - overhead);
 
-    meter.charge_opcode(0xf0, 1).expect("remaining budget");
+    meter.charge_opcode(0xf0, 0).expect("remaining budget");
     meter.commit_transaction().expect("commit");
 
     assert_eq!(meter.block_zk_gas_used(), schedule.block_limit);
@@ -232,8 +303,12 @@ fn meter_allows_exactly_remaining_block_budget() {
 fn meter_rejects_block_budget_plus_one() {
     let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
+    let overhead = schedule.zk_gas_metering_overhead;
 
-    meter.charge_opcode(0xf0, schedule.block_limit - 1).expect("prefill");
+    // Pre-fill to block_limit - 1 zk gas; `charge_opcode(0xf0, raw)` charges `raw + overhead`.
+    assert_eq!(u64::from(schedule.opcode_multipliers[0xf0]), 1);
+    let prefill_raw = schedule.block_limit - 1 - overhead;
+    meter.charge_opcode(0xf0, prefill_raw).expect("prefill");
     meter.commit_transaction().expect("commit");
 
     assert!(matches!(meter.charge_opcode(0xf0, 2), Err(ZkGasOutcome::LimitExceeded)));
@@ -305,23 +380,21 @@ fn unzen_adapter_uses_spawn_estimate_for_precompile_dispatch() {
     let probe = evm.inspector();
     let precompile_gas_used = probe.precompile_gas_used.expect("precompile gas recorded");
 
-    let expected = probe.step_costs.iter().fold(
-        u64::from(schedule.precompile_multipliers[0x04]) * precompile_gas_used,
-        |acc, (opcode, step_gas)| {
-            let raw_gas = if *opcode == opcode::STATICCALL {
-                schedule.spawn_estimates.staticcall
-            } else {
-                *step_gas
-            };
-            acc + raw_gas * u64::from(schedule.opcode_multipliers[*opcode as usize])
-        },
-    );
-    let naive_expected = probe.step_costs.iter().fold(
-        u64::from(schedule.precompile_multipliers[0x04]) * precompile_gas_used,
-        |acc, (opcode, step_gas)| {
-            acc + (*step_gas * u64::from(schedule.opcode_multipliers[*opcode as usize]))
-        },
-    );
+    let overhead = schedule.zk_gas_metering_overhead;
+    let precompile_charge =
+        u64::from(schedule.precompile_multipliers[0x04]) * precompile_gas_used + overhead;
+    let expected = probe.step_costs.iter().fold(precompile_charge, |acc, (opcode, step_gas)| {
+        let raw_gas = if *opcode == opcode::STATICCALL {
+            schedule.spawn_estimates.staticcall
+        } else {
+            *step_gas
+        };
+        acc + raw_gas * u64::from(schedule.opcode_multipliers[*opcode as usize]) + overhead
+    });
+    let naive_expected =
+        probe.step_costs.iter().fold(precompile_charge, |acc, (opcode, step_gas)| {
+            acc + (*step_gas * u64::from(schedule.opcode_multipliers[*opcode as usize])) + overhead
+        });
 
     assert_eq!(meter.tx_zk_gas_used(), expected);
     assert_ne!(meter.tx_zk_gas_used(), naive_expected);

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -24,16 +24,37 @@ pub const TX_INTRINSIC_ZK_GAS: u64 = 243_000;
 /// blocks (their `difficulty` header equals the finalized block zk gas).
 pub const MASAYA_TX_INTRINSIC_ZK_GAS: u64 = 0;
 
+/// Fixed zk gas charged once per opcode execution and once per precompile call on Devnet,
+/// Hoodi, and Mainnet Unzen.
+///
+/// Value sourced from <https://github.com/taikoxyz/taiko-mono/pull/21695>; covers the proving
+/// cost of the zk gas metering hook itself.
+pub const ZK_GAS_METERING_OVERHEAD: u64 = 90;
+
+/// Fixed zk gas charged once per opcode execution and once per precompile call on the Taiko
+/// Masaya network.
+///
+/// Pinned at `0` because Masaya activated Unzen before [taikoxyz/taiko-mono#21695] landed;
+/// adopting the non-zero value retroactively would break consensus on already-finalized
+/// blocks (their `difficulty` header equals the finalized block zk gas).
+pub const MASAYA_ZK_GAS_METERING_OVERHEAD: u64 = 0;
+
 /// Fail-safe multiplier used for any opcode or precompile missing from the Unzen table.
 const FAILSAFE_MULTIPLIER: u16 = u16::MAX;
 
-/// Builds an Unzen-shaped zk gas schedule with the requested block limit and per-transaction
-/// intrinsic charge. Opcode multipliers, precompile multipliers, and spawn estimates are
-/// identical across all networks; only the block budget and intrinsic charge differ.
-const fn unzen_schedule_with(block_limit: u64, tx_intrinsic_zk_gas: u64) -> ZkGasSchedule {
+/// Builds an Unzen-shaped zk gas schedule with the requested block limit, per-transaction
+/// intrinsic charge, and per-metering-hook overhead. Opcode multipliers, precompile
+/// multipliers, and spawn estimates are identical across all networks; only the block budget,
+/// intrinsic charge, and metering overhead differ.
+const fn unzen_schedule_with(
+    block_limit: u64,
+    tx_intrinsic_zk_gas: u64,
+    zk_gas_metering_overhead: u64,
+) -> ZkGasSchedule {
     ZkGasSchedule {
         block_limit,
         tx_intrinsic_zk_gas,
+        zk_gas_metering_overhead,
         opcode_multipliers: unzen_opcode_multipliers(),
         precompile_multipliers: unzen_precompile_multipliers(),
         spawn_estimates: SpawnEstimates {
@@ -49,12 +70,16 @@ const fn unzen_schedule_with(block_limit: u64, tx_intrinsic_zk_gas: u64) -> ZkGa
 
 /// Default Unzen zk gas schedule used by Devnet, Hoodi, and Mainnet.
 pub static UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule =
-    unzen_schedule_with(BLOCK_ZK_GAS_LIMIT, TX_INTRINSIC_ZK_GAS);
+    unzen_schedule_with(BLOCK_ZK_GAS_LIMIT, TX_INTRINSIC_ZK_GAS, ZK_GAS_METERING_OVERHEAD);
 
-/// Unzen zk gas schedule used by the Taiko Masaya network with a 10× higher block budget and
-/// a zero intrinsic charge that preserves consensus on already-finalized blocks.
-pub static MASAYA_UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule =
-    unzen_schedule_with(MASAYA_BLOCK_ZK_GAS_LIMIT, MASAYA_TX_INTRINSIC_ZK_GAS);
+/// Unzen zk gas schedule used by the Taiko Masaya network with a 10× higher block budget, a
+/// zero intrinsic charge, and a zero metering overhead — all of which preserve consensus on
+/// already-finalized blocks.
+pub static MASAYA_UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = unzen_schedule_with(
+    MASAYA_BLOCK_ZK_GAS_LIMIT,
+    MASAYA_TX_INTRINSIC_ZK_GAS,
+    MASAYA_ZK_GAS_METERING_OVERHEAD,
+);
 
 /// Returns the fixed Unzen opcode multiplier table with fail-safe defaults for unlisted opcodes.
 const fn unzen_opcode_multipliers() -> [u16; 256] {


### PR DESCRIPTION
## Summary

Mirrors [taikoxyz/taiko-mono#21695](https://github.com/taikoxyz/taiko-mono/pull/21695): adds a flat `ZK_GAS_METERING_OVERHEAD = 90` zk gas to every opcode execution and every precompile call, on top of the existing `raw_gas * multiplier` charge. This accounts for the proving cost of the zk gas metering hook itself.

Per-tx behaviour now matches the updated spec:

- `tx_zk_gas_used += raw_gas * opcode_multiplier[opcode] + ZK_GAS_METERING_OVERHEAD`
- `tx_zk_gas_used += gas_used * precompile_multiplier[addr] + ZK_GAS_METERING_OVERHEAD`

### Masaya

Pinned at `MASAYA_ZK_GAS_METERING_OVERHEAD = 0`, mirroring `MASAYA_TX_INTRINSIC_ZK_GAS`. Masaya activated Unzen before this change landed, so adopting the non-zero value retroactively would break consensus on already-finalized blocks (their `difficulty` header equals the finalized block zk gas).

### Changes

- `crates/evm/src/zk_gas/unzen.rs` — new `ZK_GAS_METERING_OVERHEAD` / `MASAYA_ZK_GAS_METERING_OVERHEAD` constants, wired through `unzen_schedule_with`.
- `crates/evm/src/zk_gas/schedule.rs` — new `zk_gas_metering_overhead: u64` field on `ZkGasSchedule`.
- `crates/evm/src/zk_gas/meter.rs` — `charge_opcode` / `charge_precompile` add the overhead via `checked_add` after the multiplier step (single overflow-safe path).
- `crates/evm/src/zk_gas/tests.rs` — new constant/per-call tests on both schedules; existing limit-boundary tests reworked to keep their boundary semantics under the `raw + overhead` charge shape; inspector adapter test updated to expect `+ overhead` per opcode call plus once for the precompile dispatch.

No executor / `alloy.rs` changes — the overhead lives entirely inside the existing opcode/precompile charge functions.

## Test plan

- [x] `just fmt`
- [x] `just clippy` (clean — `-D warnings -D missing_docs`)
- [x] `just test` — 177/177 passing
- [ ] Reviewer sanity check on Masaya consensus preservation (zero overhead on the Masaya schedule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)