### PR TITLE
perf(evm): zk gas hot-path cleanups (tx_budget + flag-gated flush + single-slot pending)

### DIFF
--- a/crates/evm/src/zk_gas/adapter.rs
+++ b/crates/evm/src/zk_gas/adapter.rs
@@ -243,8 +243,10 @@ where
 struct ZkGasMeteringState {
     /// Owned checked meter that holds the schedule and accumulated usage.
     meter: ZkGasMeter<'static>,
-    /// Per-frame in-flight opcode step state keyed by journal depth.
-    pending_steps: [Option<PendingStep>; MAX_CALL_DEPTH],
+    /// In-flight opcode step state. Only one slot is live at a time because REVM
+    /// executes one opcode per `step` → `step_end` window. The tuple's first
+    /// element is the journal depth at which the pending step was captured.
+    pending: Option<(usize, PendingStep)>,
     /// Completed CALL/CREATE-family steps waiting for spawn information before charging.
     deferred_steps: [Option<FinishedStep>; MAX_CALL_DEPTH],
     /// `true` when at least one slot in `deferred_steps` is `Some`. Lets `step()`
@@ -263,7 +265,7 @@ impl ZkGasMeteringState {
     fn new(schedule: &'static ZkGasSchedule) -> Self {
         Self {
             meter: ZkGasMeter::new(schedule),
-            pending_steps: [const { None }; MAX_CALL_DEPTH],
+            pending: None,
             deferred_steps: [const { None }; MAX_CALL_DEPTH],
             has_deferred_work: false,
             max_active_depth: 0,
@@ -272,8 +274,16 @@ impl ZkGasMeteringState {
 
     /// Records the opcode and gas snapshot for the current frame depth.
     fn begin_step(&mut self, depth: usize, opcode: u8, gas_remaining: u64) {
-        // Any previous pending step at this depth must already have been consumed by `step_end`.
-        self.pending_steps[depth] = Some(PendingStep { opcode, gas_remaining, spawned: false });
+        // By the single-slot invariant: when `step` fires, the previous
+        // opcode's `step_end` must have already cleared `pending`. If this
+        // assertion ever fires in debug builds, REVM has changed its inspector
+        // callback ordering — pause and re-audit.
+        debug_assert!(
+            self.pending.is_none(),
+            "pending step from depth={:?} was not consumed by previous step_end",
+            self.pending.as_ref().map(|(d, _)| *d),
+        );
+        self.pending = Some((depth, PendingStep { opcode, gas_remaining, spawned: false }));
         if depth > self.max_active_depth {
             self.max_active_depth = depth;
         }
@@ -296,7 +306,13 @@ impl ZkGasMeteringState {
 
     /// Finalizes the current step state and returns the completed metering record.
     fn finish_step(&mut self, depth: usize, gas_remaining: u64) -> Option<FinishedStep> {
-        let pending = self.pending_steps.get_mut(depth)?.take()?;
+        let (pending_depth, pending) = self.pending.take()?;
+        if pending_depth != depth {
+            // Unreachable under REVM's documented callback contract — discard
+            // rather than mischarge if the invariant ever breaks.
+            debug_assert!(false, "pending depth {pending_depth} != step_end depth {depth}",);
+            return None;
+        }
         Some(FinishedStep {
             // The schedule is stored on the finished record so later deferred charging does not
             // have to rediscover it from surrounding callback context.
@@ -348,7 +364,8 @@ impl ZkGasMeteringState {
 
     /// Marks pending or deferred spawn steps when the opcode matches the expected family.
     fn mark_spawn(&mut self, depth: usize, predicate: fn(u8) -> bool) {
-        if let Some(Some(pending)) = self.pending_steps.get_mut(depth) &&
+        if let Some((pending_depth, pending)) = &mut self.pending &&
+            *pending_depth == depth &&
             predicate(pending.opcode)
         {
             pending.spawned = true;
@@ -445,6 +462,10 @@ pub(crate) mod test_helpers {
             self.0.has_deferred_work
         }
 
+        pub(crate) fn has_pending(&self) -> bool {
+            self.0.pending.is_some()
+        }
+
         /// Inserts a synthetic deferred step at the given depth. The opcode byte
         /// determines whether the matching `mark_*` predicate would mark it.
         pub(crate) fn defer_call_at_depth(&mut self, depth: usize, opcode: u8) {
@@ -457,6 +478,21 @@ pub(crate) mod test_helpers {
                     spawned: true,
                 },
             );
+        }
+
+        pub(crate) fn begin_step_for_test(&mut self, depth: usize, opcode: u8, gas: u64) {
+            self.0.begin_step(depth, opcode, gas);
+        }
+
+        /// Returns `(opcode, step_gas)` for the finished step at `depth`, or
+        /// `None` if no pending step matches. Avoids exposing the private
+        /// `FinishedStep` type to the sibling `tests` module.
+        pub(crate) fn finish_step_for_test(
+            &mut self,
+            depth: usize,
+            gas_remaining: u64,
+        ) -> Option<(u8, u64)> {
+            self.0.finish_step(depth, gas_remaining).map(|s| (s.opcode, s.step_gas))
         }
 
         pub(crate) fn flush_for_test(&mut self) -> Result<(), ZkGasOutcome> {

--- a/crates/evm/src/zk_gas/adapter.rs
+++ b/crates/evm/src/zk_gas/adapter.rs
@@ -97,12 +97,17 @@ where
         context: &mut TaikoEvmContext<DB>,
     ) {
         if let Some(metering) = &mut self.metering {
-            // Spawn opcodes are charged one callback later, once the runtime tells us whether
-            // they actually opened a child frame or hit a precompile.
-            if let Err(ZkGasOutcome::LimitExceeded) = metering.flush_deferred_steps() {
-                set_custom_error(context);
-                interp.halt_fatal();
-                return;
+            // Skip the per-opcode flush scan when no spawn is pending — by the
+            // `has_deferred_work` invariant this is equivalent to running the
+            // loop and finding all-None slots.
+            if metering.has_deferred_work {
+                // Spawn opcodes are charged one callback later, once the runtime tells us
+                // whether they actually opened a child frame or hit a precompile.
+                if let Err(ZkGasOutcome::LimitExceeded) = metering.flush_deferred_steps() {
+                    set_custom_error(context);
+                    interp.halt_fatal();
+                    return;
+                }
             }
             // Snapshot the opcode and remaining gas before the interpreter mutates frame state.
             metering.begin_step(
@@ -242,6 +247,11 @@ struct ZkGasMeteringState {
     pending_steps: [Option<PendingStep>; MAX_CALL_DEPTH],
     /// Completed CALL/CREATE-family steps waiting for spawn information before charging.
     deferred_steps: [Option<FinishedStep>; MAX_CALL_DEPTH],
+    /// `true` when at least one slot in `deferred_steps` is `Some`. Lets `step()`
+    /// skip the per-opcode `flush_deferred_steps` scan when no spawn is pending.
+    /// Invariant maintained by `defer_step` (sets) and `flush_deferred_steps`
+    /// (clears on full-drain Ok).
+    has_deferred_work: bool,
     /// Highest journal depth ever observed in this state's lifetime.
     /// Bounds the work done by `flush_deferred_steps` so it stays proportional to
     /// the actual call depth a transaction reaches, not the array capacity.
@@ -255,6 +265,7 @@ impl ZkGasMeteringState {
             meter: ZkGasMeter::new(schedule),
             pending_steps: [const { None }; MAX_CALL_DEPTH],
             deferred_steps: [const { None }; MAX_CALL_DEPTH],
+            has_deferred_work: false,
             max_active_depth: 0,
         }
     }
@@ -301,12 +312,19 @@ impl ZkGasMeteringState {
     fn defer_step(&mut self, depth: usize, step: FinishedStep) {
         // There should be at most one unresolved spawn step per frame depth at a time.
         self.deferred_steps[depth] = Some(step);
+        self.has_deferred_work = true;
         if depth > self.max_active_depth {
             self.max_active_depth = depth;
         }
     }
 
     /// Charges and clears every deferred spawn opcode.
+    ///
+    /// On `Err(LimitExceeded)`, the loop exits early via `?` *before* clearing
+    /// the flag — leftover `Some` slots remain tracked. The inspector halts the
+    /// transaction immediately after, so the residual state is observable only
+    /// to the next transaction, which will see `has_deferred_work == true` and
+    /// re-run flush (matching pre-change behavior).
     fn flush_deferred_steps(&mut self) -> Result<(), ZkGasOutcome> {
         for index in 0..=self.max_active_depth {
             if let Some(step) = self.deferred_steps[index].take() {
@@ -315,6 +333,7 @@ impl ZkGasMeteringState {
                 self.charge_finished_step(step)?;
             }
         }
+        self.has_deferred_work = false;
         Ok(())
     }
 
@@ -406,5 +425,42 @@ fn set_custom_error<CTX: ContextTr>(context: &mut CTX) {
     let err_slot = context.error();
     if err_slot.is_ok() {
         *err_slot = Err(ContextError::Custom(ZK_GAS_LIMIT_ERR.to_string()));
+    }
+}
+
+/// Test-only helpers for `ZkGasMeteringState` so unit tests can exercise the
+/// invariants without going through the full REVM execution machinery.
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use super::*;
+
+    pub(crate) struct TestableMeteringState(ZkGasMeteringState);
+
+    impl TestableMeteringState {
+        pub(crate) fn new(schedule: &'static ZkGasSchedule) -> Self {
+            Self(ZkGasMeteringState::new(schedule))
+        }
+
+        pub(crate) fn has_deferred_work(&self) -> bool {
+            self.0.has_deferred_work
+        }
+
+        /// Inserts a synthetic deferred step at the given depth. The opcode byte
+        /// determines whether the matching `mark_*` predicate would mark it.
+        pub(crate) fn defer_call_at_depth(&mut self, depth: usize, opcode: u8) {
+            self.0.defer_step(
+                depth,
+                FinishedStep {
+                    schedule: self.0.meter.schedule(),
+                    opcode,
+                    step_gas: 0,
+                    spawned: true,
+                },
+            );
+        }
+
+        pub(crate) fn flush_for_test(&mut self) -> Result<(), ZkGasOutcome> {
+            self.0.flush_deferred_steps()
+        }
     }
 }

--- a/crates/evm/src/zk_gas/meter.rs
+++ b/crates/evm/src/zk_gas/meter.rs
@@ -17,26 +17,45 @@ pub struct ZkGasMeter<'a> {
     block_zk_gas_used: u64,
     /// In-flight zk gas accumulated for the currently executing transaction.
     tx_zk_gas_used: u64,
+    /// Remaining zk gas budget for the current transaction.
+    ///
+    /// Equals `schedule.block_limit - block_zk_gas_used` and is refreshed by
+    /// `reset_transaction` and `commit_transaction`. Lets `charge_amount`
+    /// short-circuit the three-checked-add liveness check used previously.
+    tx_budget: u64,
 }
 
 impl<'a> ZkGasMeter<'a> {
     /// Creates a new meter for the provided consensus schedule.
     pub const fn new(schedule: &'a ZkGasSchedule) -> Self {
-        Self { schedule, block_zk_gas_used: 0, tx_zk_gas_used: 0 }
+        Self { schedule, block_zk_gas_used: 0, tx_zk_gas_used: 0, tx_budget: schedule.block_limit }
     }
 
-    /// Resets the in-flight zk gas for the current transaction.
+    /// Resets the in-flight zk gas for the current transaction and refreshes
+    /// the cached `tx_budget` from the current finalized block usage.
     pub fn reset_transaction(&mut self) {
         self.tx_zk_gas_used = 0;
+        self.tx_budget = self.schedule.block_limit.saturating_sub(self.block_zk_gas_used);
     }
 
-    /// Promotes the current transaction's zk gas into the finalized block total.
+    /// Promotes the current transaction's zk gas into the finalized block total
+    /// and refreshes the cached `tx_budget`.
     pub fn commit_transaction(&mut self) -> Result<(), ZkGasOutcome> {
         self.block_zk_gas_used = self
             .block_zk_gas_used
             .checked_add(self.tx_zk_gas_used)
             .ok_or(ZkGasOutcome::LimitExceeded)?;
+        debug_assert!(
+            self.block_zk_gas_used <= self.schedule.block_limit,
+            "block_zk_gas_used={} exceeded schedule.block_limit={} after promoting tx={}; \
+             charge_amount enforces the per-tx upper bound, so this can only fire if a \
+             caller mutated block state outside the meter API",
+            self.block_zk_gas_used,
+            self.schedule.block_limit,
+            self.tx_zk_gas_used,
+        );
         self.tx_zk_gas_used = 0;
+        self.tx_budget = self.schedule.block_limit.saturating_sub(self.block_zk_gas_used);
         Ok(())
     }
 
@@ -53,6 +72,11 @@ impl<'a> ZkGasMeter<'a> {
     /// Returns the in-flight zk gas accumulated for the current transaction.
     pub const fn tx_zk_gas_used(&self) -> u64 {
         self.tx_zk_gas_used
+    }
+
+    /// Returns the zk gas budget remaining for the current transaction.
+    pub const fn tx_budget(&self) -> u64 {
+        self.tx_budget
     }
 
     /// Charges zk gas for a single opcode execution.
@@ -83,15 +107,45 @@ impl<'a> ZkGasMeter<'a> {
         self.charge_amount(self.schedule.tx_intrinsic_zk_gas)
     }
 
-    /// Applies a checked zk gas charge against the current transaction and block budget.
+    /// Applies a checked zk gas charge against the current transaction budget.
+    ///
+    /// `tx_budget` is refreshed by `reset_transaction` and `commit_transaction`
+    /// to equal `block_limit - block_zk_gas_used`. Saturating-add handles the
+    /// `u64` overflow case: if the sum would overflow, it caps at `u64::MAX`,
+    /// which is always greater than `tx_budget` (block limits are far below
+    /// `u64::MAX`), so the comparison still rejects.
     fn charge_amount(&mut self, charge: u64) -> Result<(), ZkGasOutcome> {
-        let next_tx = self.tx_zk_gas_used.checked_add(charge).ok_or(ZkGasOutcome::LimitExceeded)?;
-        let projected_block_zk_gas_used =
-            self.block_zk_gas_used.checked_add(next_tx).ok_or(ZkGasOutcome::LimitExceeded)?;
-        if projected_block_zk_gas_used > self.schedule.block_limit {
+        let next_tx = self.tx_zk_gas_used.saturating_add(charge);
+        if next_tx > self.tx_budget {
             return Err(ZkGasOutcome::LimitExceeded);
         }
         self.tx_zk_gas_used = next_tx;
+        // Tripwire: catches `tx_budget` drifting out of sync with the live
+        // `block_zk_gas_used` value. Runs only in debug builds.
+        debug_assert!(
+            self.block_zk_gas_used.saturating_add(self.tx_zk_gas_used) <= self.schedule.block_limit,
+            "tx_budget drifted: block={} tx={} limit={}",
+            self.block_zk_gas_used,
+            self.tx_zk_gas_used,
+            self.schedule.block_limit,
+        );
         Ok(())
+    }
+
+    /// Test-only: forces the meter into an arbitrary `(block, tx)` state without
+    /// running it through `commit_transaction`. Used by the `charge_amount`
+    /// equivalence test to probe invariant-breaking combinations.
+    #[cfg(test)]
+    pub(crate) fn force_state_for_test(&mut self, block_zk_gas_used: u64, tx_zk_gas_used: u64) {
+        self.block_zk_gas_used = block_zk_gas_used;
+        self.tx_zk_gas_used = tx_zk_gas_used;
+        self.tx_budget = self.schedule.block_limit.saturating_sub(block_zk_gas_used);
+    }
+
+    /// Test-only: exposes `charge_amount` directly so equivalence tests do not
+    /// need to round-trip through `charge_opcode`'s multiplier lookup.
+    #[cfg(test)]
+    pub(crate) fn charge_amount_for_test(&mut self, charge: u64) -> Result<(), ZkGasOutcome> {
+        self.charge_amount(charge)
     }
 }

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -516,6 +516,31 @@ fn meter_commit_transaction_refreshes_tx_budget() {
 }
 
 #[test]
+fn metering_state_has_deferred_work_tracks_deferred_slot_occupancy() {
+    use super::adapter::test_helpers::TestableMeteringState;
+
+    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let mut state = TestableMeteringState::new(schedule);
+
+    // Initial: no deferred work.
+    assert!(!state.has_deferred_work());
+
+    // After defer_step at depth 0: flag is true.
+    state.defer_call_at_depth(0, 0xf1); // 0xf1 = CALL
+    assert!(state.has_deferred_work());
+
+    // After flush_deferred_steps drains successfully: flag is false again.
+    state.flush_for_test().expect("flush ok");
+    assert!(!state.has_deferred_work());
+
+    // Defer at a deeper frame and verify it still tracks correctly.
+    state.defer_call_at_depth(3, 0xf0); // 0xf0 = CREATE
+    assert!(state.has_deferred_work());
+    state.flush_for_test().expect("flush ok");
+    assert!(!state.has_deferred_work());
+}
+
+#[test]
 fn meter_charge_amount_matches_reference_oracle_across_edge_cases() {
     // Reference oracle: literal transcription of the pre-D charge_amount semantics.
     // Returns the same (Result, post-state tx_zk_gas_used) tuple the new impl must produce.

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -480,3 +480,95 @@ fn limit_exceeding_keccak_bytecode() -> Bytecode {
         opcode::STOP,
     ]))
 }
+
+#[test]
+fn meter_initial_tx_budget_equals_schedule_block_limit() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let meter = ZkGasMeter::new(schedule);
+
+    assert_eq!(meter.tx_budget(), schedule.block_limit);
+}
+
+#[test]
+fn meter_reset_transaction_refreshes_tx_budget() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let mut meter = ZkGasMeter::new(schedule);
+
+    meter.charge_opcode(0x01, 2).expect("charge add");
+    meter.commit_transaction().expect("commit");
+
+    let committed = meter.block_zk_gas_used();
+    meter.reset_transaction();
+
+    assert_eq!(meter.tx_budget(), schedule.block_limit - committed);
+}
+
+#[test]
+fn meter_commit_transaction_refreshes_tx_budget() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let mut meter = ZkGasMeter::new(schedule);
+
+    // ADD: opcode 0x01, multiplier 12 ⇒ raw_gas=5 charges 60 zk gas.
+    meter.charge_opcode(0x01, 5).expect("charge add");
+    meter.commit_transaction().expect("commit");
+
+    assert_eq!(meter.tx_budget(), schedule.block_limit - 60);
+}
+
+#[test]
+fn meter_charge_amount_matches_reference_oracle_across_edge_cases() {
+    // Reference oracle: literal transcription of the pre-D charge_amount semantics.
+    // Returns the same (Result, post-state tx_zk_gas_used) tuple the new impl must produce.
+    fn reference_charge(
+        block_zk_gas_used: u64,
+        tx_zk_gas_used: u64,
+        block_limit: u64,
+        charge: u64,
+    ) -> (Result<(), ZkGasOutcome>, u64) {
+        let Some(next_tx) = tx_zk_gas_used.checked_add(charge) else {
+            return (Err(ZkGasOutcome::LimitExceeded), tx_zk_gas_used);
+        };
+        let Some(projected) = block_zk_gas_used.checked_add(next_tx) else {
+            return (Err(ZkGasOutcome::LimitExceeded), tx_zk_gas_used);
+        };
+        if projected > block_limit {
+            return (Err(ZkGasOutcome::LimitExceeded), tx_zk_gas_used);
+        }
+        (Ok(()), next_tx)
+    }
+
+    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let block_limit = schedule.block_limit;
+
+    let cases: &[(u64, u64, u64)] = &[
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 0, block_limit),
+        (0, 0, block_limit + 1),
+        (0, 0, u64::MAX),
+        (0, u64::MAX - 1, 100),
+        (0, u64::MAX, 1),
+        (block_limit, 0, u64::MAX - block_limit + 1),
+        (block_limit / 2, block_limit / 2, 1),
+        (block_limit - 1, 0, 2),
+        (block_limit / 4, block_limit / 4, block_limit / 4),
+        (0, 0, block_limit - 1),
+        (10, 90, block_limit - 100),
+    ];
+
+    for &(b, t, c) in cases {
+        let (expected_result, expected_tx) = reference_charge(b, t, block_limit, c);
+
+        let mut meter = ZkGasMeter::new(schedule);
+        meter.force_state_for_test(b, t);
+
+        let actual_result = meter.charge_amount_for_test(c);
+        let actual_tx = meter.tx_zk_gas_used();
+
+        assert_eq!(
+            (actual_result, actual_tx),
+            (expected_result, expected_tx),
+            "mismatch for (b={b}, t={t}, c={c})",
+        );
+    }
+}

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -541,6 +541,52 @@ fn metering_state_has_deferred_work_tracks_deferred_slot_occupancy() {
 }
 
 #[test]
+fn metering_state_pending_returns_to_none_after_each_finish_step() {
+    use super::adapter::test_helpers::TestableMeteringState;
+
+    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let mut state = TestableMeteringState::new(schedule);
+
+    assert!(!state.has_pending());
+
+    // Begin a step at depth 0, finish it — pending must be cleared.
+    state.begin_step_for_test(0, 0x01, 1_000); // ADD, 1000 gas remaining
+    assert!(state.has_pending());
+    let (opcode, step_gas) = state.finish_step_for_test(0, 997).expect("step pair");
+    assert_eq!(opcode, 0x01);
+    assert_eq!(step_gas, 3);
+    assert!(!state.has_pending());
+
+    // Begin a step at depth 5 — pending tracks the depth.
+    state.begin_step_for_test(5, 0x60, 500); // PUSH1
+    assert!(state.has_pending());
+    let (_opcode, step_gas) = state.finish_step_for_test(5, 497).expect("step pair at depth 5");
+    assert_eq!(step_gas, 3);
+    assert!(!state.has_pending());
+}
+
+#[test]
+fn metering_state_finish_step_at_mismatched_depth_returns_none_or_panics() {
+    use super::adapter::test_helpers::TestableMeteringState;
+
+    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let mut state = TestableMeteringState::new(schedule);
+
+    state.begin_step_for_test(2, 0x01, 1_000);
+    // Defensive path: in debug builds the assertion fires (panic), in release
+    // it returns None. Both behaviors are acceptable — the only requirement is
+    // that no `FinishedStep` is returned for a depth mismatch.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        state.finish_step_for_test(3, 997)
+    }));
+    match result {
+        Ok(None) => {} // release-build path
+        Err(_) => {}   // debug-build panic path
+        Ok(Some(_)) => panic!("mismatched depth must not yield a FinishedStep"),
+    }
+}
+
+#[test]
 fn meter_charge_amount_matches_reference_oracle_across_edge_cases() {
     // Reference oracle: literal transcription of the pre-D charge_amount semantics.
     // Returns the same (Result, post-state tx_zk_gas_used) tuple the new impl must produce.


### PR DESCRIPTION
## Summary

Three consensus-identical performance cleanups to the per-opcode `ZkGasInspector` hot path. Block hashes are unchanged — every change is a pure refactor of how the meter computes its identical outputs.

### What changes

- **`perf(evm): precompute tx_budget…`** — `ZkGasMeter` caches `block_limit - block_zk_gas_used` in a new `tx_budget` field, refreshed in `reset_transaction` and `commit_transaction`. The per-opcode `charge_amount` path collapses from three `checked_add`s to one `saturating_add` plus one compare.
- **`perf(evm): gate zk gas deferred-flush scan…`** — adds `has_deferred_work: bool` to `ZkGasMeteringState`. `step()` only runs the `flush_deferred_steps` scan when the flag is set, instead of iterating `0..=max_active_depth` on every opcode looking for `None`s.
- **`perf(evm): collapse zk gas pending_steps array…`** — `pending_steps: [Option<PendingStep>; 1026]` becomes `pending: Option<(usize, PendingStep)>`. REVM executes one opcode at a time so only one slot was ever live; the array was ~24 KB of dead memory commitments and an unnecessary index-with-bounds-check on every `begin_step` / `finish_step`.

### Why

[taikoxyz/taiko-mono#21695](https://github.com/taikoxyz/taiko-mono/pull/21695) measured the inspector adding ~135 SP1 cycles (~87.5 µs prove time) per opcode and added a flat `+90` zk-gas constant to compensate. That fixed the *consensus side*. This PR attacks the *implementation side* — the hook can do less work for the same charges, so the compensation can shrink in a follow-up spec change.

Expected per-opcode hook overhead reduction: ~15–20% on flat workloads (ADD-spam), ~30–50% on typical call-heavy traffic, more on deep-call workloads where Change A's flush-loop savings scale with `max_active_depth`.

## Consensus safety

Each commit is independently consensus-identical. Equivalence proofs (case-by-case for each change):

- **`tx_budget`**: the boolean outcome of `checked_add(t, c) → checked_add(b, _) → > limit` is equivalent to `saturating_add(t, c) > tx_budget` given `tx_budget = limit - b` and `limit < u64::MAX`. The new behavior-pinning test (`meter_charge_amount_matches_reference_oracle_across_edge_cases`) transcribes the prior semantics as a reference oracle and probes 13 edge-case `(b, t, c)` triples covering all four equivalence branches plus `u64::MAX` overflow corners.
- **`has_deferred_work` flag**: the invariant `flag == true ⟺ ∃ i. deferred_steps[i].is_some()` is maintained at every write site (`defer_step` sets, `flush_deferred_steps` clears only on full-drain `Ok`, the `?` early-exit on `LimitExceeded` leaves the flag set so the next transaction's flush still runs).
- **Single-slot `pending`**: REVM's documented callback contract guarantees `step(d)` → `step_end(d)` pairs at the same depth with no nested `step`. So at most one `pending_steps[d]` is ever `Some`. The single-slot replacement tracks `(depth, PendingStep)` and depth-matches in `mark_spawn`, reproducing every observable behavior. Debug-only `debug_assert!` tripwires in `begin_step` and `finish_step` will fire if a future REVM upgrade ever changes that contract.

## Test plan

- [x] `just test` — full workspace, 178/178 pass (4 new tests added)
- [x] `just clippy` — clean with `-D warnings -D missing_docs -D clippy::missing_docs_in_private_items`
- [x] `just fmt` — clean
- [x] Integration tests `taiko_zk_gas_evm_*` and `unzen_adapter_*` (which drive REVM through actual CALL/CREATE flows) all pass — strongest end-to-end signal that the refactor doesn't break observable behavior
- [ ] **Devnet burn-in 48+ hours before promoting beyond Devnet** — even with the proofs and the integration test coverage, consensus equivalence at scale is only verifiable against real traffic
- [ ] (Recommended) Run the upstream marginal-benchmark harness from [ethresear.ch/t/23955](https://ethresear.ch/t/measuring-per-opcode-proving-time/23955) before recalibrating `ZK_GAS_METERING_OVERHEAD`

## Follow-up (out of scope)

After Devnet confirms no divergence, propose recalibrating the `+90` zk-gas constant in [taikoxyz/taiko-mono#21695](https://github.com/taikoxyz/taiko-mono/pull/21695)'s spec downward, based on remeasured marginal-benchmark data with this PR's hot-path cleanups in place.

Drafted because of the consensus surface — would appreciate a careful read of the equivalence reasoning in each commit message and the new pinning test in `crates/evm/src/zk_gas/tests.rs` before un-drafting.