### PR TITLE
perf(evm): meter zk gas in interpreter path

### DIFF
--- a/crates/evm/src/alloy.rs
+++ b/crates/evm/src/alloy.rs
@@ -69,7 +69,7 @@ impl<DB: Database, I, P> TaikoEvmWrapper<DB, I, P> {
     /// Returns `None` when the active spec/chain combination has no zk gas schedule
     /// (pre-Unzen specs).
     pub fn meter(&self) -> Option<&ZkGasMeter<'static>> {
-        self.inner.inner.inspector.meter()
+        self.inner.zk_gas_meter().or_else(|| self.inner.inner.inspector.meter())
     }
 
     /// Returns a mutable reference to the active zk gas meter, if metering is enabled.
@@ -77,7 +77,11 @@ impl<DB: Database, I, P> TaikoEvmWrapper<DB, I, P> {
     /// Returns `None` when the active spec/chain combination has no zk gas schedule
     /// (pre-Unzen specs).
     pub fn meter_mut(&mut self) -> Option<&mut ZkGasMeter<'static>> {
-        self.inner.inner.inspector.meter_mut()
+        if self.inner.zk_gas_meter().is_some() {
+            self.inner.zk_gas_meter_mut()
+        } else {
+            self.inner.inner.inspector.meter_mut()
+        }
     }
 }
 
@@ -358,6 +362,12 @@ where
     ///
     /// See also [`EvmFactory::create_evm_with_inspector`].
     fn set_inspector_enabled(&mut self, enabled: bool) {
+        // `create_evm` installs zk-gas on the production TaikoEvm wrapper and keeps the inner
+        // inspector unmetered. Enabling the NoOp inspector would route around that production
+        // meter, so only EVMs built through `create_evm_with_inspector` may switch to inspect mode.
+        if enabled && self.inner.zk_gas_meter().is_some() {
+            return;
+        }
         self.inspect = enabled;
     }
 

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -3,12 +3,18 @@ use alloy_primitives::Address;
 use reth_revm::{
     context::{ContextError, ContextTr, Evm as RevmEvm, FrameStack},
     handler::{
-        EthFrame, EvmTr, FrameInitOrResult, FrameTr, ItemOrResult, PrecompileProvider,
-        instructions::EthInstructions,
+        EthFrame, EvmTr, FrameInitOrResult, FrameResult, FrameTr, ItemOrResult, PrecompileProvider,
+        instructions::{EthInstructions, InstructionProvider},
     },
-    interpreter::{InterpreterResult, interpreter::EthInterpreter},
+    interpreter::{FrameInput, InterpreterResult, interpreter::EthInterpreter},
 };
 use revm_database_interface::Database;
+
+use crate::zk_gas::{
+    meter::{ZkGasMeter, ZkGasOutcome},
+    runtime::{run_metered_plain, set_custom_error},
+    schedule::ZkGasSchedule,
+};
 
 /// Custom EVM for Taiko, we extend the RevmEvm with
 /// [`TaikoEvmExtraContext`] to provide additional context
@@ -19,6 +25,8 @@ pub struct TaikoEvm<CTX, INSP, P> {
         RevmEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, P, EthFrame<EthInterpreter>>,
     /// Optional per-block context captured from pre-executed anchor system calls.
     pub extra_execution_ctx: Option<TaikoEvmExtraExecutionCtx>,
+    /// Production-path zk gas meter used when execution does not need an external inspector.
+    zk_gas_meter: Option<ZkGasMeter<'static>>,
 }
 
 impl<CTX: ContextTr, INSP, P> TaikoEvm<CTX, INSP, P> {
@@ -32,7 +40,23 @@ impl<CTX: ContextTr, INSP, P> TaikoEvm<CTX, INSP, P> {
             EthFrame<EthInterpreter>,
         >,
     ) -> Self {
-        Self { inner, extra_execution_ctx: None }
+        Self { inner, extra_execution_ctx: None, zk_gas_meter: None }
+    }
+
+    /// Installs a production-path zk gas meter for the provided schedule.
+    pub fn with_zk_gas_schedule(mut self, schedule: Option<&'static ZkGasSchedule>) -> Self {
+        self.zk_gas_meter = schedule.map(ZkGasMeter::new);
+        self
+    }
+
+    /// Returns the production-path zk gas meter, if one is installed.
+    pub(crate) const fn zk_gas_meter(&self) -> Option<&ZkGasMeter<'static>> {
+        self.zk_gas_meter.as_ref()
+    }
+
+    /// Returns the mutable production-path zk gas meter, if one is installed.
+    pub(crate) fn zk_gas_meter_mut(&mut self) -> Option<&mut ZkGasMeter<'static>> {
+        self.zk_gas_meter.as_mut()
     }
 
     #[inline]
@@ -114,7 +138,48 @@ where
         ItemOrResult<&mut Self::Frame, <Self::Frame as FrameTr>::FrameResult>,
         ContextError<<<Self::Context as ContextTr>::Db as Database>::Error>,
     > {
-        self.inner.frame_init(frame_input)
+        let precompile_metering = match &frame_input.frame_input {
+            FrameInput::Call(inputs) => {
+                Some((inputs.gas_limit, inputs.bytecode_address.as_slice()[19]))
+            }
+            FrameInput::Create(_) | FrameInput::Empty => None,
+        };
+
+        let is_first_init = self.inner.frame_stack.index().is_none();
+        let new_frame = if is_first_init {
+            self.inner.frame_stack.start_init()
+        } else {
+            self.inner.frame_stack.get_next()
+        };
+
+        let result = Self::Frame::init_with_context(
+            new_frame,
+            &mut self.inner.ctx,
+            &mut self.inner.precompiles,
+            frame_input,
+        )?;
+
+        if let ItemOrResult::Result(FrameResult::Call(outcome)) = &result &&
+            outcome.was_precompile_called &&
+            let Some((gas_limit, address_low_byte)) = precompile_metering &&
+            let Some(meter) = self.zk_gas_meter.as_mut()
+        {
+            let gas_used = gas_limit.saturating_sub(outcome.result.gas.remaining());
+            if let Err(ZkGasOutcome::LimitExceeded) =
+                meter.charge_precompile(address_low_byte, gas_used)
+            {
+                set_custom_error(&mut self.inner.ctx);
+            }
+        }
+
+        Ok(result.map_item(|token| {
+            if is_first_init {
+                unsafe { self.inner.frame_stack.end_init(token) };
+            } else {
+                unsafe { self.inner.frame_stack.push(token) };
+            }
+            self.inner.frame_stack.get()
+        }))
     }
 
     /// Run the frame from the top of the stack. Returns the frame init or result.
@@ -126,7 +191,26 @@ where
         FrameInitOrResult<Self::Frame>,
         ContextError<<<Self::Context as ContextTr>::Db as Database>::Error>,
     > {
-        self.inner.frame_run()
+        let Some(meter) = self.zk_gas_meter.as_mut() else {
+            return self.inner.frame_run();
+        };
+
+        let frame = self.inner.frame_stack.get();
+        let context = &mut self.inner.ctx;
+        let instructions = &mut self.inner.instruction;
+
+        let action = run_metered_plain(
+            context,
+            &mut frame.interpreter,
+            instructions.instruction_table(),
+            meter,
+        );
+
+        frame.process_next_action(context, action).inspect(|i| {
+            if i.is_result() {
+                frame.set_finished(true);
+            }
+        })
     }
 
     /// Returns the result of the frame to the caller. Frame is popped from the frame stack.

--- a/crates/evm/src/factory.rs
+++ b/crates/evm/src/factory.rs
@@ -49,17 +49,16 @@ impl EvmFactory for TaikoEvmFactory {
     ) -> Self::Evm<DB, NoOpInspector> {
         let spec_id = input.cfg_env.spec;
         let schedule = schedule_for(spec_id, input.cfg_env.chain_id);
-        let inspect = schedule.is_some();
         let evm = Context::mainnet()
             .with_cfg(input.cfg_env)
             .with_block(input.block_env)
             .with_db(db)
-            .build_mainnet_with_inspector(ZkGasInspector::new(NoOpInspector {}, schedule))
+            .build_mainnet_with_inspector(ZkGasInspector::new(NoOpInspector {}, None))
             .with_precompiles(PrecompilesMap::from_static(Precompiles::new(
                 PrecompileSpecId::from_spec_id(spec_id.into()),
             )));
 
-        TaikoEvmWrapper::new(TaikoEvm::new(evm), inspect)
+        TaikoEvmWrapper::new(TaikoEvm::new(evm).with_zk_gas_schedule(schedule), false)
     }
 
     /// Creates a new instance of an EVM with an inspector.

--- a/crates/evm/src/zk_gas/adapter.rs
+++ b/crates/evm/src/zk_gas/adapter.rs
@@ -8,7 +8,7 @@
 
 use reth_revm::{
     Inspector,
-    context::{ContextError, ContextTr, JournalTr},
+    context::{ContextTr, JournalTr},
     interpreter::{
         CallInputs, CallOutcome, CreateInputs, CreateOutcome, Interpreter,
         interpreter::EthInterpreter, interpreter_types::Jumps,
@@ -18,7 +18,8 @@ use reth_revm::{
 use crate::alloy::TaikoEvmContext;
 
 use super::{
-    meter::{ZkGasMeter, ZkGasOutcome},
+    meter::{ZkGasMeter, ZkGasOutcome, is_spawn_opcode},
+    runtime::set_custom_error,
     schedule::ZkGasSchedule,
 };
 
@@ -99,7 +100,9 @@ where
         if let Some(metering) = &mut self.metering {
             // Spawn opcodes are charged one callback later, once the runtime tells us whether
             // they actually opened a child frame or hit a precompile.
-            if let Err(ZkGasOutcome::LimitExceeded) = metering.flush_deferred_steps() {
+            if metering.has_deferred_steps &&
+                let Err(ZkGasOutcome::LimitExceeded) = metering.flush_deferred_steps()
+            {
                 set_custom_error(context);
                 interp.halt_fatal();
                 return;
@@ -128,9 +131,7 @@ where
         };
         let depth = context.journal().depth();
         // Pair the pre-step snapshot captured in `step` with the post-step gas remaining.
-        let Some(step) = metering.finish_step(depth, interp.gas.remaining()) else {
-            return;
-        };
+        let step = metering.finish_step(depth, interp.gas.remaining());
 
         if is_spawn_opcode(step.opcode) {
             // CALL/CREATE-family opcodes need one more callback to learn whether they really
@@ -141,7 +142,8 @@ where
         }
 
         // Ordinary opcodes can be charged immediately from their measured interpreter gas cost.
-        if let Err(ZkGasOutcome::LimitExceeded) = metering.charge_finished_step(step) {
+        if let Err(ZkGasOutcome::LimitExceeded) = metering.charge_opcode(step.opcode, step.step_gas)
+        {
             set_custom_error(context);
             interp.halt_fatal();
         }
@@ -239,9 +241,11 @@ struct ZkGasMeteringState {
     /// Owned checked meter that holds the schedule and accumulated usage.
     meter: ZkGasMeter<'static>,
     /// Per-frame in-flight opcode step state keyed by journal depth.
-    pending_steps: [Option<PendingStep>; MAX_CALL_DEPTH],
+    pending_steps: [PendingStep; MAX_CALL_DEPTH],
     /// Completed CALL/CREATE-family steps waiting for spawn information before charging.
     deferred_steps: [Option<FinishedStep>; MAX_CALL_DEPTH],
+    /// Whether any deferred CALL/CREATE-family step is currently waiting to be charged.
+    has_deferred_steps: bool,
     /// Highest journal depth ever observed in this state's lifetime.
     /// Bounds the work done by `flush_deferred_steps` so it stays proportional to
     /// the actual call depth a transaction reaches, not the array capacity.
@@ -253,16 +257,18 @@ impl ZkGasMeteringState {
     fn new(schedule: &'static ZkGasSchedule) -> Self {
         Self {
             meter: ZkGasMeter::new(schedule),
-            pending_steps: [const { None }; MAX_CALL_DEPTH],
+            pending_steps: [PendingStep::EMPTY; MAX_CALL_DEPTH],
             deferred_steps: [const { None }; MAX_CALL_DEPTH],
+            has_deferred_steps: false,
             max_active_depth: 0,
         }
     }
 
     /// Records the opcode and gas snapshot for the current frame depth.
+    #[inline(always)]
     fn begin_step(&mut self, depth: usize, opcode: u8, gas_remaining: u64) {
         // Any previous pending step at this depth must already have been consumed by `step_end`.
-        self.pending_steps[depth] = Some(PendingStep { opcode, gas_remaining, spawned: false });
+        self.pending_steps[depth] = PendingStep { opcode, gas_remaining, spawned: false };
         if depth > self.max_active_depth {
             self.max_active_depth = depth;
         }
@@ -284,16 +290,14 @@ impl ZkGasMeteringState {
     }
 
     /// Finalizes the current step state and returns the completed metering record.
-    fn finish_step(&mut self, depth: usize, gas_remaining: u64) -> Option<FinishedStep> {
-        let pending = self.pending_steps.get_mut(depth)?.take()?;
-        Some(FinishedStep {
-            // The schedule is stored on the finished record so later deferred charging does not
-            // have to rediscover it from surrounding callback context.
-            schedule: self.meter.schedule(),
+    #[inline(always)]
+    fn finish_step(&mut self, depth: usize, gas_remaining: u64) -> FinishedStep {
+        let pending = self.pending_steps[depth];
+        FinishedStep {
             opcode: pending.opcode,
             step_gas: pending.gas_remaining.saturating_sub(gas_remaining),
             spawned: pending.spawned,
-        })
+        }
     }
 
     /// Stores a finished spawn opcode until frame-resolution hooks can determine its raw gas
@@ -301,35 +305,55 @@ impl ZkGasMeteringState {
     fn defer_step(&mut self, depth: usize, step: FinishedStep) {
         // There should be at most one unresolved spawn step per frame depth at a time.
         self.deferred_steps[depth] = Some(step);
+        self.has_deferred_steps = true;
         if depth > self.max_active_depth {
             self.max_active_depth = depth;
         }
     }
 
     /// Charges and clears every deferred spawn opcode.
+    #[inline(always)]
     fn flush_deferred_steps(&mut self) -> Result<(), ZkGasOutcome> {
+        if !self.has_deferred_steps {
+            return Ok(());
+        }
+
         for index in 0..=self.max_active_depth {
             if let Some(step) = self.deferred_steps[index].take() {
                 // `take()` clears the slot first so partial progress is preserved if charging
                 // returns `LimitExceeded`.
-                self.charge_finished_step(step)?;
+                if let Err(err) = self.charge_finished_step(step) {
+                    self.has_deferred_steps =
+                        self.deferred_steps[..=self.max_active_depth].iter().any(Option::is_some);
+                    return Err(err);
+                }
             }
         }
+        self.has_deferred_steps = false;
         Ok(())
     }
 
     /// Charges a completed opcode step against the active meter.
+    #[inline(always)]
     fn charge_finished_step(&mut self, step: FinishedStep) -> Result<(), ZkGasOutcome> {
         // Spawn opcodes use the fixed consensus estimate only when they actually dispatched child
         // work. Otherwise we charge the measured interpreter gas delta from this opcode step.
-        let raw_gas =
-            if step.spawned { spawn_estimate(step.schedule, step.opcode) } else { step.step_gas };
-        self.meter.charge_opcode(step.opcode, raw_gas)
+        if step.spawned {
+            self.meter.charge_spawn_opcode(step.opcode)
+        } else {
+            self.charge_opcode(step.opcode, step.step_gas)
+        }
+    }
+
+    /// Charges a measured opcode against the active meter.
+    #[inline(always)]
+    fn charge_opcode(&mut self, opcode: u8, raw_gas: u64) -> Result<(), ZkGasOutcome> {
+        self.meter.charge_opcode(opcode, raw_gas)
     }
 
     /// Marks pending or deferred spawn steps when the opcode matches the expected family.
     fn mark_spawn(&mut self, depth: usize, predicate: fn(u8) -> bool) {
-        if let Some(Some(pending)) = self.pending_steps.get_mut(depth) &&
+        if let Some(pending) = self.pending_steps.get_mut(depth) &&
             predicate(pending.opcode)
         {
             pending.spawned = true;
@@ -353,11 +377,14 @@ struct PendingStep {
     spawned: bool,
 }
 
+impl PendingStep {
+    /// Empty placeholder overwritten by `begin_step` before `finish_step` reads a depth.
+    const EMPTY: Self = Self { opcode: 0, gas_remaining: 0, spawned: false };
+}
+
 /// Completed metering record for a single opcode step.
 #[derive(Clone, Copy)]
 struct FinishedStep {
-    /// Consensus-owned schedule backing the meter.
-    schedule: &'static ZkGasSchedule,
     /// Opcode byte that was just executed.
     opcode: u8,
     /// Raw EVM gas spent by the opcode step on the interpreter path.
@@ -378,33 +405,82 @@ fn is_create_opcode(opcode: u8) -> bool {
     matches!(opcode, 0xf0 | 0xf5)
 }
 
-/// Returns `true` when `opcode` belongs to the spawn-opcode set.
-fn is_spawn_opcode(opcode: u8) -> bool {
-    is_call_opcode(opcode) || is_create_opcode(opcode)
-}
-
 /// Returns the caller-frame depth that owns the current spawn-opcode step.
 fn parent_step_depth(depth: usize) -> usize {
     depth.saturating_sub(1)
 }
 
-/// Returns the fixed spawn estimate for the provided Unzen opcode.
-fn spawn_estimate(schedule: &'static ZkGasSchedule, opcode: u8) -> u64 {
-    match opcode {
-        0xf1 => schedule.spawn_estimates.call,
-        0xf2 => schedule.spawn_estimates.callcode,
-        0xf4 => schedule.spawn_estimates.delegatecall,
-        0xfa => schedule.spawn_estimates.staticcall,
-        0xf0 => schedule.spawn_estimates.create,
-        0xf5 => schedule.spawn_estimates.create2,
-        _ => unreachable!("spawn estimate requested for non-spawn opcode: {opcode:#x}"),
-    }
-}
+#[cfg(test)]
+mod tests {
+    use crate::{
+        spec::TaikoSpecId,
+        zk_gas::{
+            schedule::schedule_for,
+            unzen::{MASAYA_UNZEN_ZK_GAS_SCHEDULE, UNZEN_ZK_GAS_SCHEDULE},
+        },
+    };
 
-/// Sets the dedicated custom zk gas limit error on the EVM context when none is present yet.
-fn set_custom_error<CTX: ContextTr>(context: &mut CTX) {
-    let err_slot = context.error();
-    if err_slot.is_ok() {
-        *err_slot = Err(ContextError::Custom(ZK_GAS_LIMIT_ERR.to_string()));
+    use super::{FinishedStep, ZkGasMeteringState};
+
+    #[test]
+    fn flush_deferred_steps_returns_immediately_when_empty() {
+        let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+        let mut metering = ZkGasMeteringState::new(schedule);
+
+        metering.flush_deferred_steps().expect("empty flush should succeed");
+
+        assert!(!metering.has_deferred_steps);
+        assert_eq!(metering.meter.tx_zk_gas_used(), 0);
+    }
+
+    #[test]
+    fn flush_deferred_steps_clears_flag_after_charging_deferred_step() {
+        let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+        let mut metering = ZkGasMeteringState::new(schedule);
+
+        metering.defer_step(0, FinishedStep { opcode: 0x01, step_gas: 3, spawned: false });
+        metering.flush_deferred_steps().expect("deferred flush should succeed");
+
+        assert!(!metering.has_deferred_steps);
+        assert_eq!(
+            metering.meter.tx_zk_gas_used(),
+            3 * u64::from(schedule.opcode_multipliers[0x01])
+        );
+    }
+
+    #[test]
+    fn flush_deferred_steps_preserves_flag_when_later_deferred_step_remains_after_error() {
+        let mut metering = ZkGasMeteringState::new(&MASAYA_UNZEN_ZK_GAS_SCHEDULE);
+
+        metering.defer_step(
+            0,
+            FinishedStep {
+                opcode: 0xf0,
+                step_gas: MASAYA_UNZEN_ZK_GAS_SCHEDULE.block_limit + 1,
+                spawned: false,
+            },
+        );
+        metering.defer_step(1, FinishedStep { opcode: 0x01, step_gas: 1, spawned: false });
+
+        assert!(metering.flush_deferred_steps().is_err());
+
+        assert!(metering.has_deferred_steps);
+        assert!(metering.deferred_steps[0].is_none());
+        assert!(metering.deferred_steps[1].is_some());
+    }
+
+    #[test]
+    fn charge_finished_step_uses_active_meter_schedule_for_spawn_estimate() {
+        let mut metering = ZkGasMeteringState::new(&UNZEN_ZK_GAS_SCHEDULE);
+
+        metering
+            .charge_finished_step(FinishedStep { opcode: 0xf0, step_gas: 1, spawned: true })
+            .expect("spawn estimate should fit");
+
+        assert_eq!(
+            metering.meter.tx_zk_gas_used(),
+            UNZEN_ZK_GAS_SCHEDULE.spawn_estimates.create *
+                u64::from(UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0xf0])
+        );
     }
 }

--- a/crates/evm/src/zk_gas/meter.rs
+++ b/crates/evm/src/zk_gas/meter.rs
@@ -17,25 +17,37 @@ pub struct ZkGasMeter<'a> {
     block_zk_gas_used: u64,
     /// In-flight zk gas accumulated for the currently executing transaction.
     tx_zk_gas_used: u64,
+    /// Remaining block zk gas budget after finalized and in-flight transaction charges.
+    remaining_zk_gas: u64,
 }
 
 impl<'a> ZkGasMeter<'a> {
     /// Creates a new meter for the provided consensus schedule.
     pub const fn new(schedule: &'a ZkGasSchedule) -> Self {
-        Self { schedule, block_zk_gas_used: 0, tx_zk_gas_used: 0 }
+        Self {
+            schedule,
+            block_zk_gas_used: 0,
+            tx_zk_gas_used: 0,
+            remaining_zk_gas: schedule.block_limit,
+        }
     }
 
     /// Resets the in-flight zk gas for the current transaction.
     pub fn reset_transaction(&mut self) {
         self.tx_zk_gas_used = 0;
+        self.remaining_zk_gas = self.schedule.block_limit.saturating_sub(self.block_zk_gas_used);
     }
 
     /// Promotes the current transaction's zk gas into the finalized block total.
     pub fn commit_transaction(&mut self) -> Result<(), ZkGasOutcome> {
-        self.block_zk_gas_used = self
+        let next_block = self
             .block_zk_gas_used
             .checked_add(self.tx_zk_gas_used)
             .ok_or(ZkGasOutcome::LimitExceeded)?;
+        if next_block > self.schedule.block_limit {
+            return Err(ZkGasOutcome::LimitExceeded);
+        }
+        self.block_zk_gas_used = next_block;
         self.tx_zk_gas_used = 0;
         Ok(())
     }
@@ -56,13 +68,21 @@ impl<'a> ZkGasMeter<'a> {
     }
 
     /// Charges zk gas for a single opcode execution.
+    #[inline(always)]
     pub fn charge_opcode(&mut self, opcode: u8, raw_gas: u64) -> Result<(), ZkGasOutcome> {
         let multiplier = u64::from(self.schedule.opcode_multipliers[usize::from(opcode)]);
         let charge = raw_gas.checked_mul(multiplier).ok_or(ZkGasOutcome::LimitExceeded)?;
         self.charge_amount(charge)
     }
 
+    /// Charges a CALL/CREATE-family opcode that dispatched child work.
+    #[inline(always)]
+    pub fn charge_spawn_opcode(&mut self, opcode: u8) -> Result<(), ZkGasOutcome> {
+        self.charge_opcode(opcode, spawn_estimate(self.schedule, opcode))
+    }
+
     /// Charges zk gas for a single precompile execution.
+    #[inline(always)]
     pub fn charge_precompile(
         &mut self,
         address_low_byte: u8,
@@ -84,14 +104,34 @@ impl<'a> ZkGasMeter<'a> {
     }
 
     /// Applies a checked zk gas charge against the current transaction and block budget.
+    #[inline(always)]
     fn charge_amount(&mut self, charge: u64) -> Result<(), ZkGasOutcome> {
-        let next_tx = self.tx_zk_gas_used.checked_add(charge).ok_or(ZkGasOutcome::LimitExceeded)?;
-        let projected_block_zk_gas_used =
-            self.block_zk_gas_used.checked_add(next_tx).ok_or(ZkGasOutcome::LimitExceeded)?;
-        if projected_block_zk_gas_used > self.schedule.block_limit {
+        if charge > self.remaining_zk_gas {
             return Err(ZkGasOutcome::LimitExceeded);
         }
-        self.tx_zk_gas_used = next_tx;
+        self.tx_zk_gas_used =
+            self.tx_zk_gas_used.checked_add(charge).ok_or(ZkGasOutcome::LimitExceeded)?;
+        self.remaining_zk_gas -= charge;
         Ok(())
+    }
+}
+
+/// Returns `true` when `opcode` belongs to the CALL/CREATE spawn-opcode set.
+#[inline(always)]
+pub(crate) fn is_spawn_opcode(opcode: u8) -> bool {
+    matches!(opcode, 0xf0 | 0xf1 | 0xf2 | 0xf4 | 0xf5 | 0xfa)
+}
+
+/// Returns the fixed raw-gas estimate used when a spawn opcode opens child work.
+#[inline(always)]
+fn spawn_estimate(schedule: &ZkGasSchedule, opcode: u8) -> u64 {
+    match opcode {
+        0xf1 => schedule.spawn_estimates.call,
+        0xf2 => schedule.spawn_estimates.callcode,
+        0xf4 => schedule.spawn_estimates.delegatecall,
+        0xfa => schedule.spawn_estimates.staticcall,
+        0xf0 => schedule.spawn_estimates.create,
+        0xf5 => schedule.spawn_estimates.create2,
+        _ => unreachable!("spawn estimate requested for non-spawn opcode: {opcode:#x}"),
     }
 }

--- a/crates/evm/src/zk_gas/mod.rs
+++ b/crates/evm/src/zk_gas/mod.rs
@@ -4,6 +4,8 @@
 pub mod adapter;
 /// Checked zk gas accounting for a single Unzen block execution.
 pub mod meter;
+/// Production interpreter-side zk gas metering.
+pub mod runtime;
 /// Shared schedule types and fork selection helpers.
 pub mod schedule;
 /// Unzen-specific fixed zk gas schedule data.

--- a/crates/evm/src/zk_gas/runtime.rs
+++ b/crates/evm/src/zk_gas/runtime.rs
@@ -1,0 +1,56 @@
+//! Interpreter-side zk gas metering used by the production no-inspector path.
+
+use reth_revm::{
+    context::{ContextError, ContextTr},
+    interpreter::{
+        Interpreter, InterpreterAction,
+        instructions::InstructionTable,
+        interpreter::EthInterpreter,
+        interpreter_types::{Jumps, LoopControl},
+    },
+};
+
+use super::{
+    adapter::ZK_GAS_LIMIT_ERR,
+    meter::{ZkGasMeter, ZkGasOutcome, is_spawn_opcode},
+};
+
+/// Runs the interpreter loop while charging zk gas directly in the production path.
+#[inline]
+pub(crate) fn run_metered_plain<CTX: ContextTr>(
+    context: &mut CTX,
+    interpreter: &mut Interpreter<EthInterpreter>,
+    instruction_table: &InstructionTable<EthInterpreter, CTX>,
+    meter: &mut ZkGasMeter<'static>,
+) -> InterpreterAction {
+    while interpreter.bytecode.is_not_end() {
+        let opcode = interpreter.bytecode.opcode();
+        let gas_before = interpreter.gas.remaining();
+
+        interpreter.step(instruction_table, context);
+
+        let charge = if is_spawn_opcode(opcode) &&
+            matches!(&interpreter.bytecode.action, Some(InterpreterAction::NewFrame(_)))
+        {
+            meter.charge_spawn_opcode(opcode)
+        } else {
+            meter.charge_opcode(opcode, gas_before.saturating_sub(interpreter.gas.remaining()))
+        };
+
+        if let Err(ZkGasOutcome::LimitExceeded) = charge {
+            set_custom_error(context);
+            interpreter.halt_fatal();
+            break;
+        }
+    }
+
+    interpreter.take_next_action()
+}
+
+/// Sets the dedicated custom zk gas limit error on the EVM context when none is present yet.
+pub(crate) fn set_custom_error<CTX: ContextTr>(context: &mut CTX) {
+    let err_slot = context.error();
+    if err_slot.is_ok() {
+        *err_slot = Err(ContextError::Custom(ZK_GAS_LIMIT_ERR.to_string()));
+    }
+}

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -5,6 +5,7 @@ use reth_revm::{
     Inspector,
     context::TxEnv,
     db::InMemoryDB,
+    inspector::NoOpInspector,
     interpreter::{
         CallInputs, CallOutcome, Interpreter, interpreter::EthInterpreter, interpreter_types::Jumps,
     },
@@ -210,6 +211,7 @@ fn meter_resets_transaction_usage_without_affecting_block_usage() {
 
     assert_eq!(meter.tx_zk_gas_used(), 0);
     assert_eq!(meter.block_zk_gas_used(), 0);
+    meter.charge_opcode(0xf0, schedule.block_limit).expect("reset should restore full budget");
 }
 
 #[test]
@@ -328,6 +330,46 @@ fn unzen_adapter_uses_spawn_estimate_for_precompile_dispatch() {
 }
 
 #[test]
+fn production_metered_path_matches_inspector_path_for_precompile_dispatch() {
+    let mut production_evm = TaikoEvmFactory
+        .create_evm(db_with_contract(staticcall_identity_bytecode()), evm_env(TaikoSpecId::UNZEN));
+    production_evm.transact(tx_env(100_000)).expect("production path should execute");
+    let production_zk_gas =
+        production_evm.meter().expect("production path should install a meter").tx_zk_gas_used();
+
+    let mut inspector_evm = TaikoEvmFactory.create_evm_with_inspector(
+        db_with_contract(staticcall_identity_bytecode()),
+        evm_env(TaikoSpecId::UNZEN),
+        NoOpInspector {},
+    );
+    inspector_evm.transact(tx_env(100_000)).expect("inspector path should execute");
+    let inspector_zk_gas =
+        inspector_evm.meter().expect("inspector path should install a meter").tx_zk_gas_used();
+
+    assert_eq!(production_zk_gas, inspector_zk_gas);
+}
+
+#[test]
+fn production_metered_path_matches_inspector_path_for_ordinary_opcodes() {
+    let mut production_evm = TaikoEvmFactory
+        .create_evm(db_with_contract(simple_arithmetic_bytecode()), evm_env(TaikoSpecId::UNZEN));
+    production_evm.transact(tx_env(100_000)).expect("production path should execute");
+    let production_zk_gas =
+        production_evm.meter().expect("production path should install a meter").tx_zk_gas_used();
+
+    let mut inspector_evm = TaikoEvmFactory.create_evm_with_inspector(
+        db_with_contract(simple_arithmetic_bytecode()),
+        evm_env(TaikoSpecId::UNZEN),
+        NoOpInspector {},
+    );
+    inspector_evm.transact(tx_env(100_000)).expect("inspector path should execute");
+    let inspector_zk_gas =
+        inspector_evm.meter().expect("inspector path should install a meter").tx_zk_gas_used();
+
+    assert_eq!(production_zk_gas, inspector_zk_gas);
+}
+
+#[test]
 fn unzen_adapter_raises_dedicated_error_when_limit_is_exceeded() {
     let mut evm = TaikoEvmFactory.create_evm(
         db_with_contract(limit_exceeding_keccak_bytecode()),
@@ -353,6 +395,23 @@ fn unzen_default_create_evm_path_is_metered() {
 
     assert!(evm.meter().is_some());
     assert!(evm.transact(tx_env(5_000_000)).is_err());
+}
+
+#[test]
+fn production_metered_path_stays_metered_when_noop_inspector_is_enabled() {
+    let mut evm = TaikoEvmFactory.create_evm(
+        db_with_contract(limit_exceeding_keccak_bytecode()),
+        evm_env(TaikoSpecId::UNZEN),
+    );
+
+    evm.enable_inspector();
+    let err = evm.transact(tx_env(5_000_000)).expect_err("Unzen tx should stay metered");
+
+    assert!(matches!(
+        err,
+        reth_revm::context::result::EVMError::Custom(message)
+            if message == ZK_GAS_LIMIT_ERR
+    ));
 }
 
 #[test]
@@ -477,6 +536,17 @@ fn limit_exceeding_keccak_bytecode() -> Bytecode {
         0x00,
         0x00,
         opcode::KECCAK256,
+        opcode::STOP,
+    ]))
+}
+
+fn simple_arithmetic_bytecode() -> Bytecode {
+    Bytecode::new_raw(Bytes::from(vec![
+        opcode::PUSH1,
+        0x01,
+        opcode::PUSH1,
+        0x02,
+        opcode::ADD,
         opcode::STOP,
     ]))
 }


### PR DESCRIPTION
## Why
- Production zk-gas metering was paying per-opcode Inspector step/step_end overhead.
- SP1 mock profiling for proposal 26590 showed the hook path dominating execution cycles.

## How
- Add a production metered interpreter loop that charges zk gas around interpreter.step.
- Keep create_evm_with_inspector on the existing inspector path for external inspectors.
- Preserve CALL/CREATE spawn estimates and precompile metering semantics, with parity tests against the inspector path.

## Results

```console
new vs old baseline:
    total_instruction_count: -60.68%, 2.54x faster
    stateless_evm_execute:   -66.34%, 2.97x faster
```

## Tests
- just fmt-check
- cargo test -p alethia-reth-evm zk_gas --locked
- cargo clippy -p alethia-reth-evm --all-targets --locked -- -D warnings
- git diff --check
- just build-guest sp1 --bench in /tmp/raiko2-ab-new
- SP1 mock execute for proposal 26590: total_instruction_count 438,692,917; stateless_evm_execute 343,591,340; public values unchanged