### PR TITLE
feat(evm): recalibrate Unzen zk gas multipliers

### DIFF
--- a/crates/block/src/testutil.rs
+++ b/crates/block/src/testutil.rs
@@ -144,8 +144,8 @@ pub fn arithmetic_bytecode() -> Bytecode {
 ///
 /// Hashes a 64 KiB memory region in an infinite loop so the accumulated metered KECCAK256 cost
 /// busts the 100M Unzen block zk gas limit within the per-tx EVM gas budget, even after the
-/// #21720 recalibration lowered the keccak256 opcode multiplier (85 -> 31). The interpreter-path
-/// meter aborts with the zk gas limit error before the loop runs out of EVM gas.
+/// recalibration lowered the keccak256 opcode multiplier (85 -> 31). The interpreter-path meter
+/// aborts with the zk gas limit error before the loop runs out of EVM gas.
 pub fn limit_exceeding_keccak_bytecode() -> Bytecode {
     Bytecode::new_raw(Bytes::from(vec![
         opcode::JUMPDEST, // loop entry at offset 0

--- a/crates/block/src/testutil.rs
+++ b/crates/block/src/testutil.rs
@@ -152,7 +152,7 @@ pub fn limit_exceeding_keccak_bytecode() -> Bytecode {
         opcode::PUSH3,
         0x01,
         0x00,
-        0x00, // len 0x10000 (64 KiB)
+        0x00, // len 0x010000 (64 KiB)
         opcode::PUSH1,
         0x00, // memory offset 0
         opcode::KECCAK256,

--- a/crates/block/src/testutil.rs
+++ b/crates/block/src/testutil.rs
@@ -141,16 +141,25 @@ pub fn arithmetic_bytecode() -> Bytecode {
 }
 
 /// KECCAK256 bytecode that exceeds the zk gas block limit.
+///
+/// Hashes a 64 KiB memory region in an infinite loop so the accumulated metered KECCAK256 cost
+/// busts the 100M Unzen block zk gas limit within the per-tx EVM gas budget, even after the
+/// #21720 recalibration lowered the keccak256 opcode multiplier (85 -> 31). The interpreter-path
+/// meter aborts with the zk gas limit error before the loop runs out of EVM gas.
 pub fn limit_exceeding_keccak_bytecode() -> Bytecode {
     Bytecode::new_raw(Bytes::from(vec![
-        opcode::PUSH1,
-        0x20,
+        opcode::JUMPDEST, // loop entry at offset 0
         opcode::PUSH3,
-        0x10,
+        0x01,
         0x00,
-        0x00,
+        0x00, // len 0x10000 (64 KiB)
+        opcode::PUSH1,
+        0x00, // memory offset 0
         opcode::KECCAK256,
-        opcode::STOP,
+        opcode::POP, // discard the digest
+        opcode::PUSH1,
+        0x00,         // jump destination 0
+        opcode::JUMP, // loop
     ]))
 }
 

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -109,7 +109,8 @@ fn masaya_unzen_schedule_pins_tx_intrinsic_zk_gas_at_zero() {
 
 #[test]
 fn masaya_unzen_schedule_freezes_pre_recalibration_multipliers() {
-    // The recalibration changes the default tables but Masaya stays frozen, so they must now differ.
+    // The recalibration changes the default tables but Masaya stays frozen, so they must now
+    // differ.
     assert_ne!(
         UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers,
         MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -118,6 +118,17 @@ fn masaya_unzen_schedule_freezes_pre_recalibration_multipliers() {
         UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers,
         MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers
     );
+    // Spot-check a known recalibrated entry so this guard fails if the two tables ever realign:
+    // keccak256 went 85 -> 31 for the default schedule while Masaya stays at 85, and modexp went
+    // 1363 -> 923 while Masaya stays at 1363.
+    assert_ne!(
+        UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0x20],
+        MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0x20]
+    );
+    assert_ne!(
+        UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers[0x05],
+        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers[0x05]
+    );
     // Spawn estimates were not recalibrated, so they remain identical across networks.
     assert_eq!(UNZEN_ZK_GAS_SCHEDULE.spawn_estimates, MASAYA_UNZEN_ZK_GAS_SCHEDULE.spawn_estimates);
 }

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -66,15 +66,15 @@ fn unzen_schedule_uses_the_spec_block_limit() {
 fn unzen_schedule_uses_spec_opcode_and_precompile_multipliers() {
     let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
 
-    assert_eq!(schedule.opcode_multipliers[0x20], 85);
-    assert_eq!(schedule.opcode_multipliers[0xf1], 25);
-    assert_eq!(schedule.opcode_multipliers[0xfe], 0);
-    assert_eq!(schedule.opcode_multipliers[0xac], u16::MAX);
+    assert_eq!(schedule.opcode_multipliers[0x20], 31); // keccak256
+    assert_eq!(schedule.opcode_multipliers[0xf1], 20); // call
+    assert_eq!(schedule.opcode_multipliers[0xfe], 0); // invalid (terminal)
+    assert_eq!(schedule.opcode_multipliers[0xac], u16::MAX); // unlisted -> failsafe
 
-    assert_eq!(schedule.precompile_multipliers[0x05], 1363);
-    assert_eq!(schedule.precompile_multipliers[0x01], 81);
-    assert_eq!(schedule.precompile_multipliers[0x04], 2);
-    assert_eq!(schedule.precompile_multipliers[0x14], u16::MAX);
+    assert_eq!(schedule.precompile_multipliers[0x05], 923); // modexp
+    assert_eq!(schedule.precompile_multipliers[0x01], 47); // ecrecover
+    assert_eq!(schedule.precompile_multipliers[0x04], 6); // identity
+    assert_eq!(schedule.precompile_multipliers[0x14], u16::MAX); // unlisted -> failsafe
 }
 
 #[test]
@@ -108,15 +108,17 @@ fn masaya_unzen_schedule_pins_tx_intrinsic_zk_gas_at_zero() {
 }
 
 #[test]
-fn masaya_and_default_unzen_schedules_share_opcode_and_precompile_tables() {
-    assert_eq!(
+fn masaya_unzen_schedule_freezes_pre_recalibration_multipliers() {
+    // PR #21720 recalibrates the default tables but Masaya stays frozen, so they must now differ.
+    assert_ne!(
         UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers,
         MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers
     );
-    assert_eq!(
+    assert_ne!(
         UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers,
         MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers
     );
+    // Spawn estimates were not recalibrated, so they remain identical across networks.
     assert_eq!(UNZEN_ZK_GAS_SCHEDULE.spawn_estimates, MASAYA_UNZEN_ZK_GAS_SCHEDULE.spawn_estimates);
 }
 
@@ -376,7 +378,7 @@ fn unzen_adapter_raises_dedicated_error_when_limit_is_exceeded() {
         evm_env(TaikoSpecId::UNZEN),
     );
 
-    let err = evm.transact(tx_env(5_000_000)).expect_err("Unzen tx should abort");
+    let err = evm.transact(tx_env(16_000_000)).expect_err("Unzen tx should abort");
 
     assert!(matches!(
         err,
@@ -394,7 +396,7 @@ fn unzen_default_create_evm_path_is_metered() {
     );
 
     assert!(evm.meter().is_some());
-    assert!(evm.transact(tx_env(5_000_000)).is_err());
+    assert!(evm.transact(tx_env(16_000_000)).is_err());
 }
 
 #[test]
@@ -405,7 +407,7 @@ fn production_metered_path_stays_metered_when_noop_inspector_is_enabled() {
     );
 
     evm.enable_inspector();
-    let err = evm.transact(tx_env(5_000_000)).expect_err("Unzen tx should stay metered");
+    let err = evm.transact(tx_env(16_000_000)).expect_err("Unzen tx should stay metered");
 
     assert!(matches!(
         err,
@@ -460,10 +462,8 @@ fn taiko_zk_gas_evm_charge_tx_intrinsic_is_ok_when_metering_is_disabled() {
 
 #[test]
 fn non_unzen_default_create_evm_path_keeps_metering_disabled() {
-    let mut evm = TaikoEvmFactory.create_evm(
-        db_with_contract(limit_exceeding_keccak_bytecode()),
-        evm_env(TaikoSpecId::SHASTA),
-    );
+    let mut evm = TaikoEvmFactory
+        .create_evm(db_with_contract(simple_arithmetic_bytecode()), evm_env(TaikoSpecId::SHASTA));
 
     assert!(evm.meter().is_none());
     evm.transact(tx_env(5_000_000)).expect("non-Unzen tx should stay on the legacy path");
@@ -528,11 +528,14 @@ fn staticcall_identity_bytecode() -> Bytecode {
 }
 
 fn limit_exceeding_keccak_bytecode() -> Bytecode {
+    // Hash 0x18_0000 (1.5 MiB) of zero memory from offset 0x20. Sized so the metered KECCAK256
+    // cost busts the 100M Unzen block zk gas limit even after the #21720 recalibration lowered the
+    // keccak256 opcode multiplier (85 -> 31).
     Bytecode::new_raw(Bytes::from(vec![
         opcode::PUSH1,
         0x20,
         opcode::PUSH3,
-        0x10,
+        0x18,
         0x00,
         0x00,
         opcode::KECCAK256,

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -109,7 +109,7 @@ fn masaya_unzen_schedule_pins_tx_intrinsic_zk_gas_at_zero() {
 
 #[test]
 fn masaya_unzen_schedule_freezes_pre_recalibration_multipliers() {
-    // PR #21720 recalibrates the default tables but Masaya stays frozen, so they must now differ.
+    // The recalibration changes the default tables but Masaya stays frozen, so they must now differ.
     assert_ne!(
         UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers,
         MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers
@@ -540,7 +540,7 @@ fn staticcall_identity_bytecode() -> Bytecode {
 
 fn limit_exceeding_keccak_bytecode() -> Bytecode {
     // Hash 0x18_0000 (1.5 MiB) of zero memory from offset 0x20. Sized so the metered KECCAK256
-    // cost busts the 100M Unzen block zk gas limit even after the #21720 recalibration lowered the
+    // cost busts the 100M Unzen block zk gas limit even after the recalibration lowered the
     // keccak256 opcode multiplier (85 -> 31).
     Bytecode::new_raw(Bytes::from(vec![
         opcode::PUSH1,

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -1,7 +1,13 @@
 //! Fixed Unzen zk gas schedule constants copied from the approved protocol spec.
 //!
+//! The default schedule (Devnet / Hoodi / Mainnet) uses the recalibrated opcode and precompile
+//! multipliers from [taiko-mono#21720]. The Masaya schedule keeps the prior multipliers frozen to
+//! preserve consensus on its already-finalized Unzen blocks.
+//!
 //! Source:
 //! <https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/zk_gas_spec.md>
+//!
+//! [taiko-mono#21720]: https://github.com/taikoxyz/taiko-mono/pull/21720
 
 use super::schedule::{SpawnEstimates, ZkGasSchedule};
 
@@ -27,15 +33,20 @@ pub const MASAYA_TX_INTRINSIC_ZK_GAS: u64 = 0;
 /// Fail-safe multiplier used for any opcode or precompile missing from the Unzen table.
 const FAILSAFE_MULTIPLIER: u16 = u16::MAX;
 
-/// Builds an Unzen-shaped zk gas schedule with the requested block limit and per-transaction
-/// intrinsic charge. Opcode multipliers, precompile multipliers, and spawn estimates are
-/// identical across all networks; only the block budget and intrinsic charge differ.
-const fn unzen_schedule_with(block_limit: u64, tx_intrinsic_zk_gas: u64) -> ZkGasSchedule {
+/// Builds an Unzen-shaped zk gas schedule from the requested block limit, per-transaction
+/// intrinsic charge, and opcode/precompile multiplier tables. Spawn estimates are identical
+/// across all networks.
+const fn unzen_schedule_with(
+    block_limit: u64,
+    tx_intrinsic_zk_gas: u64,
+    opcode_multipliers: [u16; 256],
+    precompile_multipliers: [u16; 256],
+) -> ZkGasSchedule {
     ZkGasSchedule {
         block_limit,
         tx_intrinsic_zk_gas,
-        opcode_multipliers: unzen_opcode_multipliers(),
-        precompile_multipliers: unzen_precompile_multipliers(),
+        opcode_multipliers,
+        precompile_multipliers,
         spawn_estimates: SpawnEstimates {
             call: 12_500,
             callcode: 12_500,
@@ -47,17 +58,31 @@ const fn unzen_schedule_with(block_limit: u64, tx_intrinsic_zk_gas: u64) -> ZkGa
     }
 }
 
-/// Default Unzen zk gas schedule used by Devnet, Hoodi, and Mainnet.
-pub static UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule =
-    unzen_schedule_with(BLOCK_ZK_GAS_LIMIT, TX_INTRINSIC_ZK_GAS);
+/// Default Unzen zk gas schedule used by Devnet, Hoodi, and Mainnet, with the recalibrated
+/// taiko-mono#21720 multipliers.
+pub static UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = unzen_schedule_with(
+    BLOCK_ZK_GAS_LIMIT,
+    TX_INTRINSIC_ZK_GAS,
+    unzen_opcode_multipliers(),
+    unzen_precompile_multipliers(),
+);
 
-/// Unzen zk gas schedule used by the Taiko Masaya network with a 10× higher block budget and
-/// a zero intrinsic charge that preserves consensus on already-finalized blocks.
-pub static MASAYA_UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule =
-    unzen_schedule_with(MASAYA_BLOCK_ZK_GAS_LIMIT, MASAYA_TX_INTRINSIC_ZK_GAS);
+/// Unzen zk gas schedule used by the Taiko Masaya network: a 10× higher block budget, a zero
+/// intrinsic charge, and multipliers frozen at pre-#21720 values to preserve consensus on
+/// already-finalized blocks.
+pub static MASAYA_UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = unzen_schedule_with(
+    MASAYA_BLOCK_ZK_GAS_LIMIT,
+    MASAYA_TX_INTRINSIC_ZK_GAS,
+    masaya_unzen_opcode_multipliers(),
+    masaya_unzen_precompile_multipliers(),
+);
 
-/// Returns the fixed Unzen opcode multiplier table with fail-safe defaults for unlisted opcodes.
-const fn unzen_opcode_multipliers() -> [u16; 256] {
+/// Returns the frozen Masaya Unzen opcode multiplier table, pinned at the pre-#21720 values.
+///
+/// Recalibrating these retroactively would break consensus on Masaya's already-finalized Unzen
+/// blocks (their `difficulty` header equals the finalized block zk gas), so they stay frozen —
+/// same rationale as [`MASAYA_TX_INTRINSIC_ZK_GAS`].
+const fn masaya_unzen_opcode_multipliers() -> [u16; 256] {
     let mut array = [FAILSAFE_MULTIPLIER; 256];
     array[0x09] = 152; // mulmod
     array[0x04] = 110; // div
@@ -211,9 +236,10 @@ const fn unzen_opcode_multipliers() -> [u16; 256] {
     array
 }
 
-/// Returns the fixed Unzen precompile multiplier table with fail-safe defaults for unlisted
-/// entries.
-const fn unzen_precompile_multipliers() -> [u16; 256] {
+/// Returns the frozen Masaya Unzen precompile multiplier table, pinned at the pre-#21720 values.
+///
+/// Frozen for the same consensus reason as [`masaya_unzen_opcode_multipliers`].
+const fn masaya_unzen_precompile_multipliers() -> [u16; 256] {
     let mut array = [FAILSAFE_MULTIPLIER; 256];
     array[0x05] = 1363; // modexp
     array[0x0a] = 398; // point_evaluation
@@ -232,5 +258,189 @@ const fn unzen_precompile_multipliers() -> [u16; 256] {
     array[0x02] = 10; // sha256
     array[0x03] = 3; // ripemd160
     array[0x04] = 2; // identity
+    array
+}
+
+/// Returns the recalibrated Unzen opcode multiplier table from [taiko-mono#21720], with fail-safe
+/// defaults for unlisted opcodes.
+///
+/// [taiko-mono#21720]: https://github.com/taikoxyz/taiko-mono/pull/21720
+const fn unzen_opcode_multipliers() -> [u16; 256] {
+    let mut array = [FAILSAFE_MULTIPLIER; 256];
+    array[0x00] = 0; // stop
+    array[0x01] = 19; // add
+    array[0x02] = 19; // mul
+    array[0x03] = 22; // sub
+    array[0x04] = 76; // div
+    array[0x05] = 78; // sdiv
+    array[0x06] = 66; // mod
+    array[0x07] = 28; // smod
+    array[0x08] = 52; // addmod
+    array[0x09] = 113; // mulmod
+    array[0x0a] = 21; // exp
+    array[0x0b] = 17; // signextend
+    array[0x10] = 19; // lt
+    array[0x11] = 19; // gt
+    array[0x12] = 20; // slt
+    array[0x13] = 19; // sgt
+    array[0x14] = 36; // eq
+    array[0x15] = 16; // iszero
+    array[0x16] = 19; // and
+    array[0x17] = 20; // or
+    array[0x18] = 18; // xor
+    array[0x19] = 15; // not
+    array[0x1a] = 17; // byte
+    array[0x1b] = 24; // shl
+    array[0x1c] = 22; // shr
+    array[0x1d] = 21; // sar
+    array[0x20] = 31; // keccak256
+    array[0x30] = 19; // address
+    array[0x31] = 4; // balance
+    array[0x32] = 21; // origin
+    array[0x33] = 18; // caller
+    array[0x34] = 11; // callvalue
+    array[0x35] = 22; // calldataload
+    array[0x36] = 13; // calldatasize
+    array[0x37] = 13; // calldatacopy
+    array[0x38] = 11; // codesize
+    array[0x39] = 12; // codecopy
+    array[0x3a] = 15; // gasprice
+    array[0x3b] = 4; // extcodesize
+    array[0x3c] = 4; // extcodecopy
+    array[0x3d] = 12; // returndatasize
+    array[0x3e] = 10; // returndatacopy
+    array[0x3f] = 7; // extcodehash
+    array[0x40] = 6; // blockhash
+    array[0x41] = 18; // coinbase
+    array[0x42] = 10; // timestamp
+    array[0x43] = 12; // number
+    array[0x44] = 42; // prevrandao
+    array[0x45] = 13; // gaslimit
+    array[0x46] = 11; // chainid
+    array[0x47] = 52; // selfbalance
+    array[0x48] = 14; // basefee
+    array[0x49] = 13; // blobhash
+    array[0x4a] = 15; // blobbasefee
+    array[0x50] = 10; // pop
+    array[0x51] = 18; // mload
+    array[0x52] = 29; // mstore
+    array[0x53] = 10; // mstore8
+    array[0x54] = 3; // sload
+    array[0x55] = 5; // sstore
+    array[0x56] = 4; // jump
+    array[0x57] = 5; // jumpi
+    array[0x58] = 13; // pc
+    array[0x59] = 13; // msize
+    array[0x5a] = 11; // gas
+    array[0x5b] = 20; // jumpdest
+    array[0x5c] = 1; // tload
+    array[0x5d] = 5; // tstore
+    array[0x5e] = 4; // mcopy
+    array[0x5f] = 13; // push0
+    array[0x60] = 9; // push1
+    array[0x61] = 8; // push2
+    array[0x62] = 9; // push3
+    array[0x63] = 10; // push4
+    array[0x64] = 9; // push5
+    array[0x65] = 12; // push6
+    array[0x66] = 10; // push7
+    array[0x67] = 15; // push8
+    array[0x68] = 13; // push9
+    array[0x69] = 12; // push10
+    array[0x6a] = 12; // push11
+    array[0x6b] = 15; // push12
+    array[0x6c] = 15; // push13
+    array[0x6d] = 17; // push14
+    array[0x6e] = 21; // push15
+    array[0x6f] = 13; // push16
+    array[0x70] = 20; // push17
+    array[0x71] = 18; // push18
+    array[0x72] = 20; // push19
+    array[0x73] = 20; // push20
+    array[0x74] = 18; // push21
+    array[0x75] = 14; // push22
+    array[0x76] = 22; // push23
+    array[0x77] = 24; // push24
+    array[0x78] = 22; // push25
+    array[0x79] = 24; // push26
+    array[0x7a] = 16; // push27
+    array[0x7b] = 17; // push28
+    array[0x7c] = 28; // push29
+    array[0x7d] = 29; // push30
+    array[0x7e] = 16; // push31
+    array[0x7f] = 19; // push32
+    array[0x80] = 10; // dup1
+    array[0x81] = 8; // dup2
+    array[0x82] = 9; // dup3
+    array[0x83] = 10; // dup4
+    array[0x84] = 11; // dup5
+    array[0x85] = 8; // dup6
+    array[0x86] = 8; // dup7
+    array[0x87] = 10; // dup8
+    array[0x88] = 9; // dup9
+    array[0x89] = 10; // dup10
+    array[0x8a] = 10; // dup11
+    array[0x8b] = 9; // dup12
+    array[0x8c] = 9; // dup13
+    array[0x8d] = 8; // dup14
+    array[0x8e] = 8; // dup15
+    array[0x8f] = 10; // dup16
+    array[0x90] = 31; // swap1
+    array[0x91] = 30; // swap2
+    array[0x92] = 32; // swap3
+    array[0x93] = 31; // swap4
+    array[0x94] = 33; // swap5
+    array[0x95] = 34; // swap6
+    array[0x96] = 31; // swap7
+    array[0x97] = 30; // swap8
+    array[0x98] = 32; // swap9
+    array[0x99] = 31; // swap10
+    array[0x9a] = 33; // swap11
+    array[0x9b] = 32; // swap12
+    array[0x9c] = 31; // swap13
+    array[0x9d] = 31; // swap14
+    array[0x9e] = 36; // swap15
+    array[0x9f] = 31; // swap16
+    array[0xa0] = 3; // log0
+    array[0xa1] = 3; // log1
+    array[0xa2] = 2; // log2
+    array[0xa3] = 2; // log3
+    array[0xa4] = 2; // log4
+    array[0xf0] = 1; // create
+    array[0xf1] = 20; // call
+    array[0xf2] = 20; // callcode
+    array[0xf3] = 0; // return
+    array[0xf4] = 17; // delegatecall
+    array[0xf5] = 1; // create2
+    array[0xfa] = 23; // staticcall
+    array[0xfd] = 0; // revert
+    array[0xfe] = 0; // invalid
+    array[0xff] = 0; // selfdestruct
+    array
+}
+
+/// Returns the recalibrated Unzen precompile multiplier table from [taiko-mono#21720], with
+/// fail-safe defaults for unlisted entries.
+///
+/// [taiko-mono#21720]: https://github.com/taikoxyz/taiko-mono/pull/21720
+const fn unzen_precompile_multipliers() -> [u16; 256] {
+    let mut array = [FAILSAFE_MULTIPLIER; 256];
+    array[0x01] = 47; // ecrecover
+    array[0x02] = 10; // sha256
+    array[0x03] = 4; // ripemd160
+    array[0x04] = 6; // identity
+    array[0x05] = 923; // modexp
+    array[0x06] = 19; // bn128_add
+    array[0x07] = 58; // bn128_mul
+    array[0x08] = 54; // bn128_pairing
+    array[0x09] = 166; // blake2f
+    array[0x0a] = 859; // point_evaluation
+    array[0x0b] = 201; // bls12_g1add
+    array[0x0c] = 93; // bls12_g1msm
+    array[0x0e] = 230; // bls12_g2add
+    array[0x0f] = 71; // bls12_g2msm
+    array[0x11] = 365; // bls12_pairing
+    array[0x12] = 246; // bls12_map_fp_to_g1
+    array[0x13] = 208; // bls12_map_fp2_to_g2
     array
 }

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -1,13 +1,11 @@
 //! Fixed Unzen zk gas schedule constants copied from the approved protocol spec.
 //!
 //! The default schedule (Devnet / Hoodi / Mainnet) uses the recalibrated opcode and precompile
-//! multipliers from [taiko-mono#21720]. The Masaya schedule keeps the prior multipliers frozen to
-//! preserve consensus on its already-finalized Unzen blocks.
+//! multipliers. The Masaya schedule keeps the prior multipliers frozen to preserve consensus on
+//! its already-finalized Unzen blocks.
 //!
 //! Source:
 //! <https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/zk_gas_spec.md>
-//!
-//! [taiko-mono#21720]: https://github.com/taikoxyz/taiko-mono/pull/21720
 
 use super::schedule::{SpawnEstimates, ZkGasSchedule};
 
@@ -59,7 +57,7 @@ const fn unzen_schedule_with(
 }
 
 /// Default Unzen zk gas schedule used by Devnet, Hoodi, and Mainnet, with the recalibrated
-/// taiko-mono#21720 multipliers.
+/// multipliers.
 pub static UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = unzen_schedule_with(
     BLOCK_ZK_GAS_LIMIT,
     TX_INTRINSIC_ZK_GAS,
@@ -68,8 +66,8 @@ pub static UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = unzen_schedule_with(
 );
 
 /// Unzen zk gas schedule used by the Taiko Masaya network: a 10× higher block budget, a zero
-/// intrinsic charge, and multipliers frozen at pre-#21720 values to preserve consensus on
-/// already-finalized blocks.
+/// intrinsic charge, and multipliers frozen at their pre-recalibration values to preserve
+/// consensus on already-finalized blocks.
 pub static MASAYA_UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = unzen_schedule_with(
     MASAYA_BLOCK_ZK_GAS_LIMIT,
     MASAYA_TX_INTRINSIC_ZK_GAS,
@@ -77,7 +75,7 @@ pub static MASAYA_UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = unzen_schedule_with(
     masaya_unzen_precompile_multipliers(),
 );
 
-/// Returns the frozen Masaya Unzen opcode multiplier table, pinned at the pre-#21720 values.
+/// Returns the frozen Masaya Unzen opcode multiplier table, pinned at the pre-recalibration values.
 ///
 /// Recalibrating these retroactively would break consensus on Masaya's already-finalized Unzen
 /// blocks (their `difficulty` header equals the finalized block zk gas), so they stay frozen —
@@ -236,7 +234,8 @@ const fn masaya_unzen_opcode_multipliers() -> [u16; 256] {
     array
 }
 
-/// Returns the frozen Masaya Unzen precompile multiplier table, pinned at the pre-#21720 values.
+/// Returns the frozen Masaya Unzen precompile multiplier table, pinned at the pre-recalibration
+/// values.
 ///
 /// Frozen for the same consensus reason as [`masaya_unzen_opcode_multipliers`].
 const fn masaya_unzen_precompile_multipliers() -> [u16; 256] {
@@ -261,10 +260,8 @@ const fn masaya_unzen_precompile_multipliers() -> [u16; 256] {
     array
 }
 
-/// Returns the recalibrated Unzen opcode multiplier table from [taiko-mono#21720], with fail-safe
-/// defaults for unlisted opcodes.
-///
-/// [taiko-mono#21720]: https://github.com/taikoxyz/taiko-mono/pull/21720
+/// Returns the recalibrated Unzen opcode multiplier table, with fail-safe defaults for unlisted
+/// opcodes.
 const fn unzen_opcode_multipliers() -> [u16; 256] {
     let mut array = [FAILSAFE_MULTIPLIER; 256];
     array[0x00] = 0; // stop
@@ -419,10 +416,8 @@ const fn unzen_opcode_multipliers() -> [u16; 256] {
     array
 }
 
-/// Returns the recalibrated Unzen precompile multiplier table from [taiko-mono#21720], with
-/// fail-safe defaults for unlisted entries.
-///
-/// [taiko-mono#21720]: https://github.com/taikoxyz/taiko-mono/pull/21720
+/// Returns the recalibrated Unzen precompile multiplier table, with fail-safe defaults for unlisted
+/// entries.
 const fn unzen_precompile_multipliers() -> [u16; 256] {
     let mut array = [FAILSAFE_MULTIPLIER; 256];
     array[0x01] = 47; // ecrecover


### PR DESCRIPTION
## Summary

Adopts the recalibrated opcode and precompile zk-gas multipliers from [taikoxyz/taiko-mono#21720](https://github.com/taikoxyz/taiko-mono/pull/21720) for the **default** Unzen schedule (Devnet / Hoodi / Mainnet), while keeping **Masaya frozen** on the prior multipliers.

- `crates/evm/src/zk_gas/unzen.rs`: split the previously-shared multiplier tables. The existing tables are renamed to `masaya_unzen_*` and pinned at their pre-#21720 values; new `unzen_*` tables carry the recalibrated values. `unzen_schedule_with` is parameterized over the two `[u16; 256]` tables, and the two statics are wired accordingly.
- Block limit (100M / 1B), per-tx intrinsic zk gas (243k / 0), and spawn estimates are unchanged — #21720 only recalibrates opcode/precompile multipliers.

## Why freeze Masaya

Masaya is the only network with Unzen live (`Timestamp(1_778_158_800)`); its already-finalized blocks encode the old multipliers in the `difficulty` header. Recalibrating retroactively would break consensus on those blocks — same rationale as the existing `MASAYA_TX_INTRINSIC_ZK_GAS = 0` freeze. Mainnet/Hoodi are `Never` and Devnet is genesis/ephemeral, so the default schedule can change in place.

## Tests

- `crates/evm/src/zk_gas/tests.rs`: default-multiplier assertions updated to the new values; the old "tables shared" test inverted into `masaya_unzen_schedule_freezes_pre_recalibration_multipliers` (asserts the tables now differ, with explicit keccak256/modexp spot-checks, while spawn estimates stay equal); the Masaya pin guard is unchanged.
- `crates/block/src/testutil.rs`: `limit_exceeding_keccak_bytecode` rewritten to an infinite 64 KiB keccak loop, since the lower keccak256 multiplier (85 → 31) meant the old single-shot fixture no longer tripped the 100M block limit within the per-tx gas budget.

All 178 workspace tests pass; `clippy` clean.

> [!WARNING]
> taiko-mono#21720 is still **open / unmerged**. Values reflect the PR's current state and must be refreshed if it changes before merge. Draft until then.

## Test plan

- [ ] `just test`
- [ ] `just clippy`
- [ ] Confirm final multiplier values against taiko-mono#21720 once merged