### PR TITLE
fix(rpc): persist terminal zkgas transactions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches: [main]
+    branches: [main,fix/terminal-zkgas-witness-cache]
   release:
     types: [published]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "alethia-reth-consensus",
  "alethia-reth-db",
  "alethia-reth-evm",
+ "alethia-reth-payload",
  "alethia-reth-primitives",
  "alethia-reth-rpc-types",
  "alloy-consensus",

--- a/crates/block/src/tx_selection/mod.rs
+++ b/crates/block/src/tx_selection/mod.rs
@@ -208,6 +208,7 @@ where
             );
             continue;
         }
+
         if da_size > config.max_da_bytes_per_list {
             best_txs.mark_invalid(&pool_tx, &da_limit_error(da_size, config.max_da_bytes_per_list));
             continue;

--- a/crates/block/src/tx_selection/mod.rs
+++ b/crates/block/src/tx_selection/mod.rs
@@ -4,9 +4,9 @@
 //! from the mempool, used by both the payload builder and the RPC pre-building endpoint.
 
 use alethia_reth_primitives::transaction::is_allowed_tx_type;
-use alloy_consensus::transaction::Recovered;
+use alloy_consensus::transaction::{Recovered, TxHashRef};
 use alloy_eips::Encodable2718;
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256, Bytes};
 use op_alloy_flz::tx_estimated_size_fjord_bytes;
 use reth_ethereum_primitives::{EthPrimitives, TransactionSigned};
 use reth_evm::{
@@ -88,13 +88,38 @@ pub struct ExecutedTxList {
     pub total_da_bytes: u64,
 }
 
+/// Terminal transaction filtered after the block zk gas limit is exhausted.
+///
+/// At most one terminal zk-gas transaction may exist for a built block. When present, it is the
+/// first rejected transaction after the committed prefix; all later candidate transactions are
+/// discarded and are not part of the block or witness replay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalZkGasTxCandidate {
+    /// Hash of the filtered transaction.
+    pub tx_hash: B256,
+    /// EIP-2718 encoded signed transaction bytes.
+    pub tx_rlp: Bytes,
+}
+
+impl TerminalZkGasTxCandidate {
+    /// Captures the stable identity and encoded bytes for a filtered terminal transaction.
+    pub fn from_transaction(tx: &(impl TxHashRef + Encodable2718)) -> Self {
+        Self { tx_hash: *tx.tx_hash(), tx_rlp: tx.encoded_2718().into() }
+    }
+}
+
 /// Outcome of the transaction selection process.
 #[derive(Debug)]
 pub enum SelectionOutcome {
     /// Selection was cancelled before completion.
     Cancelled,
     /// Selection completed successfully with the produced lists.
-    Completed(Vec<ExecutedTxList>),
+    Completed {
+        /// Lists of transactions committed before selection stopped.
+        lists: Vec<ExecutedTxList>,
+        /// Terminal transaction filtered after the block zk gas limit was exhausted.
+        terminal_zkgas_tx: Option<TerminalZkGasTxCandidate>,
+    },
 }
 
 /// Default threshold for triggering the zlib guard check.
@@ -116,7 +141,7 @@ pub const DEFAULT_DA_ZLIB_GUARD_BYTES: u64 = 4 * 1024;
 /// # Returns
 ///
 /// * `Ok(SelectionOutcome::Cancelled)` - If cancelled during selection.
-/// * `Ok(SelectionOutcome::Completed(lists))` - If selection completed successfully.
+/// * `Ok(SelectionOutcome::Completed)` - If selection completed successfully.
 /// * `Err(err)` - If a fatal execution error occurred.
 pub fn select_and_execute_pool_transactions<B, Pool>(
     builder: &mut B,
@@ -133,6 +158,7 @@ where
 
     let mut lists = Vec::with_capacity(config.max_lists.max(1));
     lists.push(ExecutedTxList::default());
+    let mut terminal_zkgas_tx = None;
     // Per-list state for adaptive DA size calibration.
     let mut da_guard_states = Vec::with_capacity(config.max_lists.max(1));
     da_guard_states.push(DaRatioState::default());
@@ -235,6 +261,11 @@ where
             Ok(gas_used) => gas_used,
             Err(err) if is_zk_gas_limit_exceeded(&err) => {
                 trace!(target: "tx_selection", ?tx, "stopping selection after zk gas exhaustion");
+                debug_assert!(
+                    terminal_zkgas_tx.is_none(),
+                    "selection must stop after the first terminal zk-gas transaction"
+                );
+                terminal_zkgas_tx = Some(TerminalZkGasTxCandidate::from_transaction(&tx));
                 break;
             }
             Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
@@ -269,7 +300,7 @@ where
         trace!(target: "tx_selection", gas_used, da_size, "included transaction from pool");
     }
 
-    Ok(SelectionOutcome::Completed(lists))
+    Ok(SelectionOutcome::Completed { lists, terminal_zkgas_tx })
 }
 
 #[cfg(test)]
@@ -358,10 +389,15 @@ mod tests {
         )
         .expect("zk gas exhaustion should stop selection cleanly");
 
-        let SelectionOutcome::Completed(lists) = outcome else {
+        let SelectionOutcome::Completed { lists, terminal_zkgas_tx } = outcome else {
             panic!("selection should not cancel")
         };
         assert_eq!(lists.len(), 1);
+        let terminal_zkgas_tx = terminal_zkgas_tx.expect("terminal zk-gas tx should be captured");
+        assert_eq!(
+            terminal_zkgas_tx.tx_hash,
+            *recovered_tx(BENCH_LIMIT_CALLER, BENCH_LIMIT_TARGET, 0, 20).tx_hash()
+        );
         assert_eq!(lists[0].transactions.len(), 1);
         assert_eq!(
             *lists[0].transactions[0].tx.tx_hash(),

--- a/crates/db/src/compress.rs
+++ b/crates/db/src/compress.rs
@@ -2,7 +2,55 @@ use alloy_primitives::{B256, U256};
 use alloy_rlp::{Buf, BufMut};
 use reth_codecs::{Compact, DecompressError};
 
-use crate::model::StoredL1Origin;
+use crate::model::{StoredL1Origin, TerminalZkGasTx};
+
+/// Number of bytes in a compact terminal zk-gas transaction before the tx RLP payload.
+const TERMINAL_ZKGAS_TX_FIXED_LEN: usize = 32 + 32 + 4;
+/// Maximum encoded transaction bytes retained for terminal zk-gas replay.
+const MAX_TERMINAL_ZKGAS_TX_RLP_BYTES: usize = 256 * 1024;
+
+/// Creates a database decompression error with a stable message.
+fn decompress_error(message: impl Into<String>) -> DecompressError {
+    DecompressError::new(std::io::Error::new(std::io::ErrorKind::InvalidData, message.into()))
+}
+
+/// Decodes a persisted terminal zk-gas transaction with defensive length validation.
+fn decode_terminal_zkgas_tx(value: &[u8]) -> Result<TerminalZkGasTx, DecompressError> {
+    if value.len() < TERMINAL_ZKGAS_TX_FIXED_LEN {
+        return Err(decompress_error(format!(
+            "terminal zk-gas tx record is too short: {} bytes",
+            value.len()
+        )));
+    }
+
+    let mut cursor = std::io::Cursor::new(value);
+    let mut block_hash_bytes = [0u8; 32];
+    cursor.copy_to_slice(&mut block_hash_bytes);
+    let block_hash = B256::from(block_hash_bytes);
+
+    let mut tx_hash_bytes = [0u8; 32];
+    cursor.copy_to_slice(&mut tx_hash_bytes);
+    let tx_hash = B256::from(tx_hash_bytes);
+
+    let tx_len = cursor.get_u32() as usize;
+    if tx_len > MAX_TERMINAL_ZKGAS_TX_RLP_BYTES {
+        return Err(decompress_error(format!(
+            "terminal zk-gas tx RLP is too large: {tx_len} bytes"
+        )));
+    }
+
+    let remaining = value.len() - TERMINAL_ZKGAS_TX_FIXED_LEN;
+    if tx_len != remaining {
+        return Err(decompress_error(format!(
+            "terminal zk-gas tx RLP length mismatch: declared {tx_len}, actual {remaining}"
+        )));
+    }
+
+    let mut tx_rlp = vec![0u8; tx_len];
+    cursor.copy_to_slice(&mut tx_rlp);
+
+    Ok(TerminalZkGasTx { block_hash, tx_hash, tx_rlp: tx_rlp.into() })
+}
 
 impl Compact for StoredL1Origin {
     /// Takes a buffer which can be written to. *Ideally*, it returns the length written to.
@@ -88,6 +136,65 @@ impl reth_db_api::table::Decompress for StoredL1Origin {
     }
 }
 
+impl Compact for TerminalZkGasTx {
+    /// Takes a buffer which can be written to. *Ideally*, it returns the length written to.
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: BufMut + AsMut<[u8]>,
+    {
+        let len = buf.remaining_mut();
+
+        buf.put_slice(self.block_hash.as_slice());
+        buf.put_slice(self.tx_hash.as_slice());
+        buf.put_u32(self.tx_rlp.len() as u32);
+        buf.put_slice(self.tx_rlp.as_ref());
+
+        len - buf.remaining_mut()
+    }
+
+    /// Takes a buffer which can be read from. Returns the object and `buf` with its internal cursor
+    /// advanced (eg.`.advance(len)`).
+    ///
+    /// `len` can either be the `buf` remaining length, or the length of the compacted type.
+    ///
+    /// It will panic, if `len` is smaller than `buf.len()`.
+    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+        let mut cursor = std::io::Cursor::new(&buf[..len]);
+
+        let mut block_hash_bytes = [0u8; 32];
+        cursor.copy_to_slice(&mut block_hash_bytes);
+        let block_hash = B256::from(block_hash_bytes);
+
+        let mut tx_hash_bytes = [0u8; 32];
+        cursor.copy_to_slice(&mut tx_hash_bytes);
+        let tx_hash = B256::from(tx_hash_bytes);
+
+        let tx_len = cursor.get_u32() as usize;
+        let mut tx_rlp = vec![0u8; tx_len];
+        cursor.copy_to_slice(&mut tx_rlp);
+
+        let stored = TerminalZkGasTx { block_hash, tx_hash, tx_rlp: tx_rlp.into() };
+        let remaining = &buf[cursor.position() as usize..];
+        (stored, remaining)
+    }
+}
+
+impl reth_db_api::table::Compress for TerminalZkGasTx {
+    type Compressed = Vec<u8>;
+
+    /// Compresses data to a given buffer.
+    fn compress_to_buf<B: alloy_primitives::bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
+        let _ = Compact::to_compact(self, buf);
+    }
+}
+
+impl reth_db_api::table::Decompress for TerminalZkGasTx {
+    /// Decompresses owned data coming from the database.
+    fn decompress(value: &[u8]) -> Result<Self, DecompressError> {
+        decode_terminal_zkgas_tx(value)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -132,5 +239,31 @@ mod test {
 
         let decompressed = StoredL1Origin::decompress(&buf).unwrap();
         assert_eq!(stored, decompressed);
+    }
+
+    #[test]
+    fn test_terminal_zk_gas_tx_compress_decompress() {
+        let stored = TerminalZkGasTx {
+            block_hash: B256::random(),
+            tx_hash: B256::random(),
+            tx_rlp: vec![0x02, 0xf8, 0x01, 0x42].into(),
+        };
+
+        let mut buf = Vec::new();
+        stored.compress_to_buf(&mut buf);
+
+        let decompressed = TerminalZkGasTx::decompress(&buf).unwrap();
+        assert_eq!(stored, decompressed);
+    }
+
+    #[test]
+    fn test_terminal_zk_gas_tx_rejects_oversized_rlp() {
+        let mut buf = Vec::new();
+        buf.put_slice(B256::random().as_slice());
+        buf.put_slice(B256::random().as_slice());
+        buf.put_u32((MAX_TERMINAL_ZKGAS_TX_RLP_BYTES + 1) as u32);
+
+        let err = TerminalZkGasTx::decompress(&buf).unwrap_err();
+        assert!(err.to_string().contains("too large"));
     }
 }

--- a/crates/db/src/model.rs
+++ b/crates/db/src/model.rs
@@ -2,12 +2,12 @@ use core::fmt;
 
 use alloy_primitives::BlockNumber;
 use reth::revm::primitives::{
-    B256, U256,
+    B256, Bytes, U256,
     alloy_primitives::{self},
 };
 use reth_db_api::{TableSet, TableType, TableViewer, table::TableInfo, tables};
 use serde::{Deserialize, Serialize};
-use serde_with::{Bytes, serde_as};
+use serde_with::{Bytes as SerdeBytes, serde_as};
 
 use alethia_reth_primitives::payload::attributes::RpcL1Origin;
 
@@ -31,8 +31,23 @@ pub struct StoredL1Origin {
     /// Indicates if the L2 block was included as a forced inclusion.
     pub is_forced_inclusion: bool,
     /// The signature of the L2 block payload.
-    #[serde_as(as = "Bytes")]
+    #[serde_as(as = "SerdeBytes")]
     pub signature: [u8; 65],
+}
+
+/// Durable recovery record for a terminal transaction filtered after block zk gas exhaustion.
+///
+/// The transaction bytes are kept outside proof-history storage because the upstream proofs store
+/// only retains trie and post-state data. Witness generation still requires the corresponding
+/// proof-history state window to be available.
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub struct TerminalZkGasTx {
+    /// Canonical block hash that this filtered terminal transaction supplements.
+    pub block_hash: B256,
+    /// Hash of the filtered transaction.
+    pub tx_hash: B256,
+    /// EIP-2718 encoded signed transaction bytes.
+    pub tx_rlp: Bytes,
 }
 
 impl From<RpcL1Origin> for StoredL1Origin {
@@ -94,6 +109,11 @@ tables! {
   table BatchToLastBlock {
     type Key = BlockNumber;
     type Value = BlockNumber;
+  }
+
+  table TerminalZkGasTxTable {
+    type Key = BlockNumber;
+    type Value = TerminalZkGasTx;
   }
 }
 

--- a/crates/node/src/proof_history/mod.rs
+++ b/crates/node/src/proof_history/mod.rs
@@ -25,6 +25,7 @@ use reth::{
     tasks::TaskExecutor,
 };
 use reth_db::{Database, database_metrics::DatabaseMetrics};
+use reth_ethereum::EthPrimitives;
 use reth_node_api::{FullNodeComponents, NodeAddOns};
 use reth_node_builder::{
     NodeAdapter, NodeBuilderWithComponents, NodeComponentsBuilder, WithLaunchContext,
@@ -133,7 +134,8 @@ pub fn install_proof_history_rpc<Node, EthApi>(
 ) -> eyre::Result<()>
 where
     Node: FullNodeComponents,
-    EthApi: FullEthApi + Send + Sync + 'static,
+    EthApi: FullEthApi<Primitives = EthPrimitives> + Send + Sync + 'static,
+    EthApi::Provider: DatabaseProviderFactory,
     Node::Provider:
         HeaderProvider<Header = reth::primitives::Header> + Clone + Send + Sync + 'static,
 {

--- a/crates/payload/src/builder/execution.rs
+++ b/crates/payload/src/builder/execution.rs
@@ -2,6 +2,7 @@
 
 use alloy_consensus::Transaction;
 use alloy_eips::eip4844::BYTES_PER_BLOB;
+use alloy_rpc_types_engine::PayloadId;
 use reth::{
     providers::{ChainSpecProvider, StateProviderFactory},
     revm::{cancelled::CancelOnDrop, primitives::U256},
@@ -19,7 +20,7 @@ use tracing::{debug, trace, warn};
 use alethia_reth_block::{
     executor::is_zk_gas_limit_exceeded,
     tx_selection::{
-        DEFAULT_DA_ZLIB_GUARD_BYTES, SelectionOutcome, TxSelectionConfig,
+        DEFAULT_DA_ZLIB_GUARD_BYTES, SelectionOutcome, TerminalZkGasTxCandidate, TxSelectionConfig,
         select_and_execute_pool_transactions,
     },
 };
@@ -39,7 +40,12 @@ pub(super) enum ExecutionOutcome {
     /// Execution was cancelled before completion.
     Cancelled,
     /// Execution completed successfully with accumulated fees.
-    Completed(U256),
+    Completed {
+        /// Accumulated priority fees from committed transactions.
+        total_fees: U256,
+        /// Terminal transaction filtered after the block zk gas limit was exhausted.
+        terminal_zkgas_tx: Option<TerminalZkGasTxCandidate>,
+    },
 }
 
 /// Context for executing transactions in new mode (anchor + pool transactions).
@@ -51,7 +57,7 @@ pub(super) struct PoolExecutionContext<'a> {
     /// Timestamp for the new block.
     pub(super) block_timestamp: u64,
     /// Payload identifier for logging.
-    pub(super) payload_id: String,
+    pub(super) payload_id: PayloadId,
     /// Base fee per gas for transaction selection.
     pub(super) base_fee: u64,
     /// Block gas limit.
@@ -69,6 +75,7 @@ pub(super) fn execute_provided_transactions(
     cancel: &CancelOnDrop,
 ) -> Result<ExecutionOutcome, PayloadBuilderError> {
     let mut total_fees = U256::ZERO;
+    let mut terminal_zkgas_tx = None;
 
     for tx in transactions {
         if cancel.is_cancelled() {
@@ -89,6 +96,11 @@ pub(super) fn execute_provided_transactions(
                     ?tx,
                     "stopping legacy-mode payload after zk gas exhaustion"
                 );
+                debug_assert!(
+                    terminal_zkgas_tx.is_none(),
+                    "provided transaction execution must stop after the first terminal zk-gas transaction"
+                );
+                terminal_zkgas_tx = Some(TerminalZkGasTxCandidate::from_transaction(tx));
                 break;
             }
             Err(BlockExecutionError::Validation(
@@ -111,7 +123,7 @@ pub(super) fn execute_provided_transactions(
         total_fees += U256::from(miner_fee) * U256::from(gas_used);
     }
 
-    Ok(ExecutionOutcome::Completed(total_fees))
+    Ok(ExecutionOutcome::Completed { total_fees, terminal_zkgas_tx })
 }
 
 /// Executes new-mode transactions: injects the anchor transaction, then pulls
@@ -181,7 +193,7 @@ where
 
     match select_and_execute_pool_transactions(builder, pool, &config, || cancel.is_cancelled()) {
         Ok(SelectionOutcome::Cancelled) => Ok(ExecutionOutcome::Cancelled),
-        Ok(SelectionOutcome::Completed(lists)) => {
+        Ok(SelectionOutcome::Completed { lists, terminal_zkgas_tx }) => {
             // Calculate total fees from the executed transactions.
             let total_fees = match lists.first() {
                 Some(list) => list.transactions.iter().try_fold(U256::ZERO, |acc, etx| {
@@ -193,7 +205,7 @@ where
                 })?,
                 None => U256::ZERO,
             };
-            Ok(ExecutionOutcome::Completed(total_fees))
+            Ok(ExecutionOutcome::Completed { total_fees, terminal_zkgas_tx })
         }
         Err(err) => Err(PayloadBuilderError::evm(err)),
     }
@@ -206,7 +218,7 @@ mod tests {
     use super::*;
     use alloy_consensus::{
         SignableTransaction, Signed, TxEip1559,
-        transaction::{SignerRecoverable, TxHashable},
+        transaction::{SignerRecoverable, TxHashRef, TxHashable},
     };
     use alloy_primitives::{Address, B256, Bytes};
     use alloy_signer::SignerSync;
@@ -356,9 +368,10 @@ mod tests {
         );
         let mut builder = ExecutorBackedBuilder { executor };
         let cancel = CancelOnDrop::default();
+        let limit_tx = recovered_tx(BENCH_LIMIT_CALLER, BENCH_LIMIT_TARGET, 0, 1);
         let transactions = vec![
             recovered_tx(BENCH_SUCCESS_CALLER, BENCH_SUCCESS_TARGET, 0, 1),
-            recovered_tx(BENCH_LIMIT_CALLER, BENCH_LIMIT_TARGET, 0, 1),
+            limit_tx.clone(),
             recovered_tx(BENCH_LATE_CALLER, BENCH_SUCCESS_TARGET, 0, 1),
         ];
 
@@ -366,8 +379,11 @@ mod tests {
             .expect("zk gas exhaustion should stop cleanly");
 
         match outcome {
-            ExecutionOutcome::Completed(total_fees) => {
+            ExecutionOutcome::Completed { total_fees, terminal_zkgas_tx } => {
                 assert!(total_fees > U256::ZERO, "fees from the committed prefix should remain");
+                let terminal_zkgas_tx =
+                    terminal_zkgas_tx.expect("terminal zk-gas tx should be captured");
+                assert_eq!(terminal_zkgas_tx.tx_hash, *limit_tx.tx_hash());
             }
             ExecutionOutcome::Cancelled => panic!("selection should not cancel"),
         }
@@ -406,7 +422,7 @@ mod tests {
                 anchor_tx: &anchor_tx,
                 parent_header: &parent_header,
                 block_timestamp: 1,
-                payload_id: "anchor-zk-gas".to_string(),
+                payload_id: PayloadId::new([1; 8]),
                 base_fee: 0,
                 gas_limit: 30_000_000,
             },
@@ -415,7 +431,7 @@ mod tests {
 
         let err = match result {
             Ok(ExecutionOutcome::Cancelled) => panic!("anchor execution should not cancel"),
-            Ok(ExecutionOutcome::Completed(_)) => {
+            Ok(ExecutionOutcome::Completed { .. }) => {
                 panic!("anchor zk gas exhaustion should fail payload building")
             }
             Err(err) => err,

--- a/crates/payload/src/builder/mod.rs
+++ b/crates/payload/src/builder/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use alloy_consensus::BlockHeader;
 use reth_basic_payload_builder::{
     BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder, PayloadConfig,
 };
@@ -32,6 +33,7 @@ use self::execution::{
     ExecutionOutcome, PoolExecutionContext, execute_anchor_and_pool_transactions,
     execute_provided_transactions,
 };
+use crate::terminal_zkgas::{PendingTerminalZkGasTx, record_terminal_zkgas_tx};
 
 /// Transaction-phase execution helpers for legacy/new-mode payload construction.
 mod execution;
@@ -218,12 +220,14 @@ where
 
     let base_fee = builder.evm_mut().block.basefee;
 
-    let total_fees = match &attributes.transactions {
+    let (total_fees, terminal_zkgas_tx) = match &attributes.transactions {
         Some(transactions) => {
             debug!(target: "payload_builder", id=%payload_id, tx_count=transactions.len(), "using provided transaction list");
             match execute_provided_transactions(&mut builder, transactions, base_fee, &cancel)? {
                 ExecutionOutcome::Cancelled => return Ok(BuildOutcome::Cancelled),
-                ExecutionOutcome::Completed(fees) => fees,
+                ExecutionOutcome::Completed { total_fees, terminal_zkgas_tx } => {
+                    (total_fees, terminal_zkgas_tx)
+                }
             }
         }
         None => {
@@ -238,7 +242,7 @@ where
                 anchor_tx,
                 parent_header: &parent_header,
                 block_timestamp: attributes.timestamp(),
-                payload_id: payload_id.to_string(),
+                payload_id,
                 base_fee,
                 gas_limit: attributes.gas_limit.saturating_sub(ANCHOR_V3_V4_GAS_LIMIT),
             };
@@ -246,7 +250,9 @@ where
             match execute_anchor_and_pool_transactions(&mut builder, &pool, &client, &ctx, &cancel)?
             {
                 ExecutionOutcome::Cancelled => return Ok(BuildOutcome::Cancelled),
-                ExecutionOutcome::Completed(fees) => fees,
+                ExecutionOutcome::Completed { total_fees, terminal_zkgas_tx } => {
+                    (total_fees, terminal_zkgas_tx)
+                }
             }
         }
     };
@@ -279,6 +285,17 @@ where
 
     let sealed_block = Arc::new(block.into_sealed_block());
     debug!(target: "payload_builder", id=%payload_id, sealed_block_header = ?sealed_block.sealed_header(), "sealed built block");
+    if let Some(tx) = terminal_zkgas_tx {
+        record_terminal_zkgas_tx(
+            payload_id,
+            PendingTerminalZkGasTx {
+                block_hash: sealed_block.hash(),
+                tx_hash: tx.tx_hash,
+                tx_rlp: tx.tx_rlp,
+            },
+        );
+        debug!(target: "payload_builder", id=%payload_id, block_number=sealed_block.header().number(), "recorded terminal zk-gas transaction for payload");
+    }
 
     Ok(BuildOutcome::Freeze(EthBuiltPayload::new(sealed_block, total_fees, None, None)))
 }

--- a/crates/payload/src/lib.rs
+++ b/crates/payload/src/lib.rs
@@ -14,6 +14,8 @@ use alethia_reth_primitives::engine::TaikoEngineTypes;
 
 /// Taiko payload-building implementation and transaction assembly flow.
 pub mod builder;
+/// Terminal zk-gas payload handoff for proof-history witness reconstruction.
+pub mod terminal_zkgas;
 pub use builder::TaikoPayloadBuilder;
 
 /// The builder to spawn [`TaikoPayloadBuilder`] payload building tasks.

--- a/crates/payload/src/terminal_zkgas.rs
+++ b/crates/payload/src/terminal_zkgas.rs
@@ -1,0 +1,144 @@
+//! In-process handoff for terminal zk-gas transactions observed during payload building.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{LazyLock, Mutex},
+};
+
+use alloy_primitives::{B256, Bytes};
+use alloy_rpc_types_engine::PayloadId;
+
+/// Maximum number of unclaimed terminal zk-gas transactions retained in memory.
+const MAX_PENDING_TERMINAL_ZKGAS_TXS: usize = 256;
+
+/// Terminal transaction metadata captured before payload filtering drops the transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingTerminalZkGasTx {
+    /// Canonical block hash of the sealed payload.
+    pub block_hash: B256,
+    /// Hash of the filtered transaction.
+    pub tx_hash: B256,
+    /// EIP-2718 encoded signed transaction bytes.
+    pub tx_rlp: Bytes,
+}
+
+/// Bounded pending terminal transactions keyed by Engine API payload id.
+#[derive(Debug, Default)]
+struct PendingTerminalZkGasRegistry {
+    /// Captured terminal transactions by payload id.
+    entries: HashMap<PayloadId, PendingTerminalZkGasTx>,
+    /// Insertion order used to evict stale entries that were never consumed.
+    order: VecDeque<PayloadId>,
+}
+
+impl PendingTerminalZkGasRegistry {
+    /// Inserts a pending terminal transaction and evicts the oldest stale entries.
+    fn insert(&mut self, payload_id: PayloadId, tx: PendingTerminalZkGasTx) {
+        if self.entries.insert(payload_id, tx).is_none() {
+            self.order.push_back(payload_id);
+        }
+        self.evict_stale_entries();
+    }
+
+    /// Returns a pending terminal transaction without consuming it.
+    fn peek(&self, payload_id: PayloadId) -> Option<PendingTerminalZkGasTx> {
+        self.entries.get(&payload_id).cloned()
+    }
+
+    /// Removes a pending terminal transaction after it is durably persisted or discarded.
+    fn remove(&mut self, payload_id: PayloadId) -> Option<PendingTerminalZkGasTx> {
+        let tx = self.entries.remove(&payload_id);
+        if tx.is_some() {
+            self.order.retain(|id| *id != payload_id);
+        }
+        tx
+    }
+
+    /// Keeps the registry bounded while tolerating duplicate stale order entries.
+    fn evict_stale_entries(&mut self) {
+        while self.order.front().is_some_and(|id| !self.entries.contains_key(id)) {
+            self.order.pop_front();
+        }
+        while self.entries.len() > MAX_PENDING_TERMINAL_ZKGAS_TXS {
+            let Some(oldest) = self.order.pop_front() else { break };
+            self.entries.remove(&oldest);
+        }
+    }
+}
+
+/// Pending terminal transaction registry shared by payload build and Engine API consumption.
+static PENDING_TERMINAL_ZKGAS_TXS: LazyLock<Mutex<PendingTerminalZkGasRegistry>> =
+    LazyLock::new(|| Mutex::new(PendingTerminalZkGasRegistry::default()));
+
+/// Records a terminal zk-gas transaction for a sealed payload.
+pub fn record_terminal_zkgas_tx(payload_id: PayloadId, tx: PendingTerminalZkGasTx) {
+    let mut pending = PENDING_TERMINAL_ZKGAS_TXS.lock().expect("terminal zkgas registry poisoned");
+    pending.insert(payload_id, tx);
+}
+
+/// Returns a previously recorded terminal zk-gas transaction for `payload_id`.
+pub fn peek_terminal_zkgas_tx(payload_id: PayloadId) -> Option<PendingTerminalZkGasTx> {
+    let pending = PENDING_TERMINAL_ZKGAS_TXS.lock().expect("terminal zkgas registry poisoned");
+    pending.peek(payload_id)
+}
+
+/// Removes a previously recorded terminal zk-gas transaction for `payload_id`.
+pub fn remove_terminal_zkgas_tx(payload_id: PayloadId) -> Option<PendingTerminalZkGasTx> {
+    let mut pending = PENDING_TERMINAL_ZKGAS_TXS.lock().expect("terminal zkgas registry poisoned");
+    pending.remove(payload_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pending_terminal_tx() -> PendingTerminalZkGasTx {
+        PendingTerminalZkGasTx {
+            block_hash: B256::repeat_byte(0x11),
+            tx_hash: B256::repeat_byte(0x33),
+            tx_rlp: vec![0x01, 0x02].into(),
+        }
+    }
+
+    fn payload_id(value: u64) -> PayloadId {
+        PayloadId::new(value.to_be_bytes())
+    }
+
+    #[test]
+    fn terminal_zkgas_registry_takes_once() {
+        let payload_id = payload_id(1);
+        let pending = pending_terminal_tx();
+
+        record_terminal_zkgas_tx(payload_id, pending.clone());
+
+        assert_eq!(peek_terminal_zkgas_tx(payload_id), Some(pending.clone()));
+        assert_eq!(remove_terminal_zkgas_tx(payload_id), Some(pending));
+        assert_eq!(peek_terminal_zkgas_tx(payload_id), None);
+    }
+
+    #[test]
+    fn terminal_zkgas_registry_take_removes_order_entry() {
+        let mut registry = PendingTerminalZkGasRegistry::default();
+        let pending = pending_terminal_tx();
+        let payload_id = payload_id(1);
+
+        registry.insert(payload_id, pending.clone());
+
+        assert_eq!(registry.remove(payload_id), Some(pending));
+        assert!(registry.order.is_empty());
+    }
+
+    #[test]
+    fn terminal_zkgas_registry_is_bounded() {
+        let mut registry = PendingTerminalZkGasRegistry::default();
+        let pending = pending_terminal_tx();
+
+        for i in 0..MAX_PENDING_TERMINAL_ZKGAS_TXS + 1 {
+            registry.insert(payload_id(i as u64), pending.clone());
+        }
+
+        assert_eq!(registry.entries.len(), MAX_PENDING_TERMINAL_ZKGAS_TXS);
+        assert_eq!(registry.remove(payload_id(0)), None);
+        assert_eq!(registry.remove(payload_id(1)), Some(pending));
+    }
+}

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -19,6 +19,7 @@ alethia-reth-chainspec = { path = "../chainspec" }
 alethia-reth-consensus = { path = "../consensus" }
 alethia-reth-db = { path = "../db" }
 alethia-reth-evm = { path = "../evm" }
+alethia-reth-payload = { path = "../payload" }
 alethia-reth-primitives = { path = "../primitives", features = ["serde"] }
 alethia-reth-rpc-types = { path = "../rpc-types" }
 alloy-consensus = { workspace = true }

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -1,15 +1,21 @@
 //! Proof-history backed overrides for selected `debug_` RPC methods.
 
 use crate::proof_state::ProofHistoryStateProviderFactory;
+use alethia_reth_block::executor::is_zk_gas_limit_exceeded;
+use alethia_reth_db::model::{TerminalZkGasTx, TerminalZkGasTxTable};
 use alloy_consensus::BlockHeader;
-use alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_eips::{BlockId, BlockNumberOrTag, Decodable2718};
 use alloy_primitives::B256;
 use alloy_rpc_types_debug::ExecutionWitness;
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use reth_db::transaction::DbTx;
+use reth_ethereum::{EthPrimitives, TransactionSigned};
+use reth_ethereum_primitives::Block;
 use reth_evm::{ConfigureEvm, execute::Executor};
 use reth_optimism_trie::{OpProofsStorage, OpProofsStore};
-use reth_provider::HeaderProvider;
+use reth_primitives_traits::{Block as RethBlock, RecoveredBlock, SignedTransaction as _};
+use reth_provider::{DBProvider, DatabaseProviderFactory, HeaderProvider};
 use reth_revm::{State, database::StateProviderDatabase, witness::ExecutionWitnessRecord};
 use reth_rpc_eth_api::helpers::FullEthApi;
 use reth_rpc_eth_types::EthApiError;
@@ -55,7 +61,8 @@ pub struct TaikoDebugWitnessExt<Eth, Storage, Provider> {
 
 impl<Eth, Storage, Provider> TaikoDebugWitnessExt<Eth, Storage, Provider>
 where
-    Eth: FullEthApi + Send + Sync + 'static,
+    Eth: FullEthApi<Primitives = EthPrimitives> + Send + Sync + 'static,
+    Eth::Provider: DatabaseProviderFactory,
     Storage: OpProofsStore + Clone + 'static,
     Provider: HeaderProvider + Clone + Send + Sync + 'static,
     Provider::Header: BlockHeader + alloy_rlp::Encodable,
@@ -82,25 +89,275 @@ where
             .await?
             .ok_or(EthApiError::HeaderNotFound(block_id))?;
         let block_number = block.header().number();
+        let block_hash = block.hash();
         let parent_block = BlockId::Hash(block.parent_hash().into());
+        // Proof-history state is still the witness source of truth. The terminal tx record is only
+        // a durable recovery index for bytes that are not part of the canonical block body.
         let state_provider = self
             .state_provider_factory
             .state_provider(parent_block)
             .await
             .map_err(EthApiError::from)?;
+        let terminal_zkgas_tx = self.terminal_zkgas_recovery_tx(block_number, block_hash)?;
+        let execution_block = match terminal_zkgas_tx.as_ref() {
+            Some(tx) => block_with_terminal_zkgas_tx(std::sync::Arc::unwrap_or_clone(block), tx)?,
+            None => std::sync::Arc::unwrap_or_clone(block),
+        };
         let db = StateProviderDatabase::new(&*state_provider);
         let block_executor = self.eth_api.evm_config().executor(db);
         let mut witness_record = ExecutionWitnessRecord::default();
 
-        block_executor
-            .execute_with_state_closure(&block, |statedb: &State<_>| {
-                witness_record.record_executed_state(statedb, mode);
-            })
-            .map_err(EthApiError::from)?;
+        if terminal_zkgas_tx.is_some() {
+            let result = block_executor.execute_with_state_closure_always(
+                &execution_block,
+                |statedb: &State<_>| {
+                    witness_record.record_executed_state(statedb, mode);
+                },
+            );
+            if let Err(err) = result &&
+                !is_zk_gas_limit_exceeded(&err)
+            {
+                return Err(EthApiError::from(err).into());
+            }
+        } else {
+            block_executor
+                .execute_with_state_closure(&execution_block, |statedb: &State<_>| {
+                    witness_record.record_executed_state(statedb, mode);
+                })
+                .map_err(EthApiError::from)?;
+        }
 
         Ok(witness_record
             .into_execution_witness(&*state_provider, &self.provider, block_number, mode)
             .map_err(EthApiError::from)?)
+    }
+
+    /// Reads the durable terminal zk-gas recovery record for a canonical block.
+    fn terminal_zkgas_recovery_tx(
+        &self,
+        block_number: u64,
+        block_hash: B256,
+    ) -> Result<Option<TerminalZkGasTx>, Eth::Error> {
+        read_terminal_zkgas_recovery_tx(self.eth_api.provider(), block_number, block_hash)
+            .map_err(Into::into)
+    }
+}
+
+/// Reads a persisted terminal zk-gas recovery record when it belongs to the canonical block hash.
+fn read_terminal_zkgas_recovery_tx<Provider>(
+    provider: &Provider,
+    block_number: u64,
+    block_hash: B256,
+) -> Result<Option<TerminalZkGasTx>, EthApiError>
+where
+    Provider: DatabaseProviderFactory,
+{
+    let db_provider = provider.database_provider_ro().map_err(|err| {
+        EthApiError::EvmCustom(format!("failed to open terminal zk-gas tx table: {err}"))
+    })?;
+    let terminal_tx =
+        db_provider.into_tx().get::<TerminalZkGasTxTable>(block_number).map_err(|err| {
+            EthApiError::EvmCustom(format!("failed to read terminal zk-gas tx: {err}"))
+        })?;
+
+    Ok(terminal_tx.filter(|tx| tx.block_hash == block_hash))
+}
+
+/// Appends a filtered terminal zk-gas transaction to the execution-only block.
+///
+/// The recovered block is not canonicalized; it is only used for witness replay. A terminal
+/// transaction must not already exist in the canonical body, and when present is appended as the
+/// final transaction because payload building discards every later candidate.
+fn block_with_terminal_zkgas_tx(
+    block: RecoveredBlock<Block>,
+    terminal_tx: &TerminalZkGasTx,
+) -> Result<RecoveredBlock<Block>, EthApiError> {
+    let block_hash = block.hash();
+    let mut senders = block.senders().to_vec();
+    let (header, mut body) = block.into_block().split();
+    let tx = TransactionSigned::decode_2718_exact(terminal_tx.tx_rlp.as_ref()).map_err(|err| {
+        EthApiError::EvmCustom(format!("failed to decode terminal zk-gas tx: {err}"))
+    })?;
+
+    if *tx.tx_hash() != terminal_tx.tx_hash {
+        return Err(EthApiError::EvmCustom(format!(
+            "terminal zk-gas tx hash mismatch: expected {:?}, got {:?}",
+            terminal_tx.tx_hash,
+            tx.tx_hash()
+        )));
+    }
+    if body.transactions.iter().any(|included| *included.tx_hash() == terminal_tx.tx_hash) {
+        return Err(EthApiError::EvmCustom(format!(
+            "terminal zk-gas tx {:?} already exists in canonical block body",
+            terminal_tx.tx_hash
+        )));
+    }
+
+    let signer = tx.try_recover().map_err(|err| {
+        EthApiError::EvmCustom(format!("failed to recover terminal zk-gas tx signer: {err}"))
+    })?;
+    body.transactions.push(tx);
+    senders.push(signer);
+
+    Ok(RecoveredBlock::new(Block::new(header, body), senders, block_hash))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{BlockBody, Header, TxLegacy};
+    use alloy_eips::Encodable2718;
+    use alloy_primitives::{Address, ChainId, Signature, TxKind, U256};
+    use reth_db::{
+        TableSet, Tables,
+        mdbx::{DatabaseArguments, init_db_for},
+        table::TableInfo,
+        test_utils::{
+            TempDatabase, create_test_rocksdb_dir, create_test_static_files_dir, tempdir_path,
+        },
+    };
+    use reth_db_api::transaction::DbTxMut;
+    use reth_ethereum::{TransactionSigned, chainspec::MAINNET};
+    use reth_provider::{
+        ProviderFactory,
+        providers::{RocksDBBuilder, StaticFileProvider},
+        test_utils::MockNodeTypesWithDB,
+    };
+    use std::{path::PathBuf, sync::Arc};
+
+    fn create_taiko_test_provider_factory() -> ProviderFactory<MockNodeTypesWithDB> {
+        struct TaikoTables;
+
+        impl TableSet for TaikoTables {
+            fn tables() -> Box<dyn Iterator<Item = Box<dyn TableInfo>>> {
+                Box::new(
+                    Tables::ALL.iter().map(|table| Box::new(*table) as Box<dyn TableInfo>).chain(
+                        alethia_reth_db::model::Tables::ALL
+                            .iter()
+                            .map(|table| Box::new(*table) as Box<dyn TableInfo>),
+                    ),
+                )
+            }
+        }
+
+        let (static_dir, _) = create_test_static_files_dir();
+        let (rocksdb_dir, _) = create_test_rocksdb_dir();
+        let path = tempdir_path();
+        let db = init_db_for::<PathBuf, TaikoTables>(path.clone(), DatabaseArguments::test())
+            .expect("init db");
+        let db = Arc::new(TempDatabase::new(db, path));
+        ProviderFactory::new(
+            db,
+            MAINNET.clone(),
+            StaticFileProvider::read_write(static_dir.keep()).expect("static file provider"),
+            RocksDBBuilder::new(&rocksdb_dir)
+                .with_default_tables()
+                .build()
+                .expect("failed to create test RocksDB provider"),
+            reth::tasks::Runtime::test(),
+        )
+        .expect("failed to create test provider factory")
+    }
+
+    fn signed_legacy_tx(nonce: u64) -> TransactionSigned {
+        let tx = TxLegacy {
+            chain_id: Some(ChainId::from(1u64)),
+            nonce,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::with_last_byte(0x42)),
+            value: U256::ZERO,
+            input: nonce.to_be_bytes().to_vec().into(),
+        };
+        TransactionSigned::new_unhashed(
+            tx.into(),
+            Signature::new(U256::from(nonce + 1), U256::from(nonce + 2), false),
+        )
+    }
+
+    #[test]
+    fn terminal_zkgas_recovery_round_trip_rebuilds_execution_block() {
+        let factory = create_taiko_test_provider_factory();
+        let canonical_tx = signed_legacy_tx(0);
+        let terminal_tx = signed_legacy_tx(1);
+        let canonical_signer = canonical_tx.try_recover().expect("canonical tx should recover");
+        let block_number = 42;
+        let block = Header { number: block_number, gas_limit: 30_000_000, ..Default::default() }
+            .into_block(BlockBody {
+                transactions: vec![canonical_tx.clone()],
+                ..Default::default()
+            });
+        let recovered_block = RecoveredBlock::new_unhashed(block, vec![canonical_signer]);
+        let block_hash = recovered_block.hash();
+
+        let tx = factory.database_provider_rw().expect("database provider").into_tx();
+        tx.put::<TerminalZkGasTxTable>(
+            block_number,
+            TerminalZkGasTx {
+                block_hash,
+                tx_hash: *terminal_tx.tx_hash(),
+                tx_rlp: terminal_tx.encoded_2718().into(),
+            },
+        )
+        .expect("persist terminal tx");
+        tx.commit().expect("commit terminal tx");
+
+        let recovered_tx = read_terminal_zkgas_recovery_tx(&factory, block_number, block_hash)
+            .expect("read recovery tx")
+            .expect("terminal tx should be present");
+        let execution_block =
+            block_with_terminal_zkgas_tx(recovered_block, &recovered_tx).expect("rebuild block");
+        let transactions = execution_block.body().transactions().collect::<Vec<_>>();
+
+        assert_eq!(execution_block.hash(), block_hash);
+        assert_eq!(transactions.len(), 2);
+        assert_eq!(*transactions[0].tx_hash(), *canonical_tx.tx_hash());
+        assert_eq!(*transactions[1].tx_hash(), *terminal_tx.tx_hash());
+    }
+
+    #[test]
+    fn terminal_zkgas_recovery_ignores_other_block_hashes() {
+        let factory = create_taiko_test_provider_factory();
+        let terminal_tx = signed_legacy_tx(1);
+        let block_number = 42;
+        let block_hash = B256::repeat_byte(0x11);
+
+        let tx = factory.database_provider_rw().expect("database provider").into_tx();
+        tx.put::<TerminalZkGasTxTable>(
+            block_number,
+            TerminalZkGasTx {
+                block_hash,
+                tx_hash: *terminal_tx.tx_hash(),
+                tx_rlp: terminal_tx.encoded_2718().into(),
+            },
+        )
+        .expect("persist terminal tx");
+        tx.commit().expect("commit terminal tx");
+
+        let recovered =
+            read_terminal_zkgas_recovery_tx(&factory, block_number, B256::repeat_byte(0x22))
+                .expect("read recovery tx");
+
+        assert!(recovered.is_none());
+    }
+
+    #[test]
+    fn terminal_zkgas_recovery_rejects_duplicate_canonical_tx() {
+        let terminal_tx = signed_legacy_tx(1);
+        let signer = terminal_tx.try_recover().expect("terminal tx should recover");
+        let block = Header { number: 42, gas_limit: 30_000_000, ..Default::default() }.into_block(
+            BlockBody { transactions: vec![terminal_tx.clone()], ..Default::default() },
+        );
+        let recovered_block = RecoveredBlock::new_unhashed(block, vec![signer]);
+        let terminal_tx = TerminalZkGasTx {
+            block_hash: recovered_block.hash(),
+            tx_hash: *terminal_tx.tx_hash(),
+            tx_rlp: terminal_tx.encoded_2718().into(),
+        };
+
+        let err = block_with_terminal_zkgas_tx(recovered_block, &terminal_tx).unwrap_err();
+
+        assert!(err.to_string().contains("already exists in canonical block body"));
     }
 }
 
@@ -108,7 +365,8 @@ where
 impl<Eth, Storage, Provider> TaikoDebugWitnessApiServer
     for TaikoDebugWitnessExt<Eth, Storage, Provider>
 where
-    Eth: FullEthApi + Send + Sync + 'static,
+    Eth: FullEthApi<Primitives = EthPrimitives> + Send + Sync + 'static,
+    Eth::Provider: DatabaseProviderFactory,
     Storage: OpProofsStore + Clone + 'static,
     Provider: HeaderProvider + Clone + Send + Sync + 'static,
     Provider::Header: BlockHeader + alloy_rlp::Encodable,

--- a/crates/rpc/src/engine/api.rs
+++ b/crates/rpc/src/engine/api.rs
@@ -1,10 +1,12 @@
 //! Taiko engine API RPC methods and persistence hooks.
 use std::{io, sync::Arc};
 
+use alethia_reth_payload::terminal_zkgas::{peek_terminal_zkgas_tx, remove_terminal_zkgas_tx};
 use alethia_reth_primitives::{
     decode_shasta_proposal_id, engine::types::TaikoExecutionData,
     payload::attributes::TaikoPayloadAttributes,
 };
+use alloy_consensus::BlockHeader;
 use alloy_hardforks::EthereumHardforks;
 use alloy_primitives::BlockNumber;
 use alloy_rpc_types_engine::{
@@ -32,8 +34,9 @@ use reth_rpc_engine_api::EngineApiError;
 use alethia_reth_chainspec::{hardfork::TaikoHardforks, spec::TaikoChainSpec};
 use alethia_reth_db::model::{
     BatchToLastBlock, STORED_L1_HEAD_ORIGIN_KEY, StoredL1HeadOriginTable, StoredL1Origin,
-    StoredL1OriginTable,
+    StoredL1OriginTable, TerminalZkGasTx, TerminalZkGasTxTable,
 };
+use tracing::{debug, warn};
 
 /// The list of all supported Engine capabilities available over the engine endpoint.
 pub const TAIKO_ENGINE_CAPABILITIES: &[&str] =
@@ -177,6 +180,80 @@ where
 
         Ok(())
     }
+
+    /// Persists any terminal zk-gas transaction captured while building `payload_id`.
+    fn persist_terminal_zkgas_tx(
+        &self,
+        payload_id: PayloadId,
+        built_payload: &EthBuiltPayload,
+    ) -> Result<(), EngineApiError> {
+        let Some(pending) = peek_terminal_zkgas_tx(payload_id) else {
+            return Ok(());
+        };
+
+        let block = built_payload.block();
+        let block_number = block.header().number();
+        let block_hash = block.hash_slow();
+
+        if pending.block_hash != block_hash {
+            warn!(
+                target: "taiko_engine",
+                %payload_id,
+                actual_block_number = block_number,
+                pending_block_hash = ?pending.block_hash,
+                actual_block_hash = ?block_hash,
+                "discarding terminal zk-gas transaction for mismatched payload"
+            );
+            remove_terminal_zkgas_tx(payload_id);
+            return Ok(());
+        }
+
+        let terminal_tx =
+            TerminalZkGasTx { block_hash, tx_hash: pending.tx_hash, tx_rlp: pending.tx_rlp };
+        let tx_hash = terminal_tx.tx_hash;
+
+        let persisted = {
+            let tx = self.provider.database_provider_rw().map_err(Self::internal_error)?.into_tx();
+            if let Some(existing) =
+                tx.get::<TerminalZkGasTxTable>(block_number).map_err(Self::internal_error)? &&
+                existing.block_hash == block_hash
+            {
+                if existing != terminal_tx {
+                    return Err(Self::internal_error(io::Error::other(format!(
+                        "terminal zk-gas transaction conflict for block {block_number}: existing {:?}, pending {:?}",
+                        existing.tx_hash, tx_hash
+                    ))));
+                }
+                false
+            } else {
+                tx.put::<TerminalZkGasTxTable>(block_number, terminal_tx)
+                    .map_err(Self::internal_error)?;
+                tx.commit().map_err(Self::internal_error)?;
+                true
+            }
+        };
+
+        remove_terminal_zkgas_tx(payload_id);
+
+        if persisted {
+            debug!(
+                target: "taiko_engine",
+                %payload_id,
+                block_number,
+                tx_hash = ?tx_hash,
+                "persisted terminal zk-gas transaction"
+            );
+        } else {
+            debug!(
+                target: "taiko_engine",
+                %payload_id,
+                block_number,
+                tx_hash = ?tx_hash,
+                "terminal zk-gas transaction was already persisted"
+            );
+        }
+        Ok(())
+    }
 }
 
 // This is the concrete ethereum engine API implementation.
@@ -238,6 +315,9 @@ where
 
             stored_l1_origin.l2_block_hash = built_payload.block().hash_slow();
 
+            self.persist_terminal_zkgas_tx(payload_id, &built_payload)
+                .map_err(|e: EngineApiError| ErrorObjectOwned::from(e))?;
+
             self.persist_l1_origin(stored_l1_origin, is_preconf_block, batch_id)
                 .map_err(|e: EngineApiError| ErrorObjectOwned::from(e))?;
         }
@@ -252,6 +332,8 @@ where
     ) -> RpcResult<EngineT::ExecutionPayloadEnvelopeV2> {
         let built_payload =
             self.wait_for_built_payload(payload_id).await.map_err(ErrorObjectOwned::from)?;
+        self.persist_terminal_zkgas_tx(payload_id, &built_payload)
+            .map_err(ErrorObjectOwned::from)?;
         Ok(self.convert_built_payload_to_execution_payload_envelope_v2(built_payload))
     }
 }

--- a/crates/rpc/src/eth/auth/mod.rs
+++ b/crates/rpc/src/eth/auth/mod.rs
@@ -352,7 +352,7 @@ where
         };
 
         match select_and_execute_pool_transactions(&mut builder, &self.pool, &config, || false) {
-            Ok(SelectionOutcome::Completed(lists)) => {
+            Ok(SelectionOutcome::Completed { lists, .. }) => {
                 // Convert ExecutedTxList to PreBuiltTxList with RPC transactions
                 lists
                     .into_iter()


### PR DESCRIPTION
## Why
- Terminal out-of-zkgas transactions are filtered from canonical block bodies, so proof-history witness replay cannot recover their bytes later.
- Engine API retries must not lose captured terminal transaction metadata before it is durably persisted.

## How
- Capture the first terminal zk-gas transaction from provided-list and pool selection paths, then stop executing later candidates.
- Persist one terminal transaction record per canonical block after the built payload is available, with idempotent duplicate handling.
- Replay witnesses by appending the persisted terminal transaction to an execution-only block while keeping proof-history state as the witness source of truth.

## Tests
- cargo check -p alethia-reth-block -p alethia-reth-payload -p alethia-reth-rpc -p alethia-reth-node
- cargo test -p alethia-reth-block tx_selection_breaks_on_zk_gas_error_but_keeps_skipping_invalid_txs --lib
- cargo test -p alethia-reth-payload execute_provided_transactions_stops_on_zk_gas_error --lib
- cargo test -p alethia-reth-payload terminal_zkgas_registry --lib
- just fmt
- just clippy
- just test
- git diff --check