### PR TITLE
feat(rpc): add tx-list execution witness debug RPC

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches: [main,feat/txlist-execution-witness]
+    branches: [main]
   release:
     types: [published]
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches: [main]
+    branches: [main,feat/txlist-execution-witness]
   release:
     types: [published]
 

--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -88,6 +88,25 @@ pub fn is_zk_gas_difficulty_mismatch(error: &BlockExecutionError) -> bool {
     }
 }
 
+/// Returns `true` when `error` is the kind of failure that prover-style execution tolerates for a
+/// non-anchor transaction by skipping it: zk gas truncation, an invalid transaction, or a gas limit
+/// exceeding the block's remaining gas.
+///
+/// This is the single definition of the recoverable error set, shared by the prover executor's
+/// `try_execute_filtered` and the tx-list witness debug RPC, so the two cannot drift when a new
+/// recoverable variant is added. Callers remain responsible for never applying it to the anchor
+/// transaction, which must always be fatal.
+pub fn is_recoverable_non_anchor_tx_error(error: &BlockExecutionError) -> bool {
+    is_zk_gas_limit_exceeded(error) ||
+        matches!(
+            error,
+            BlockExecutionError::Validation(
+                BlockValidationError::InvalidTx { .. } |
+                    BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. }
+            )
+        )
+}
+
 /// Block executor for Taiko network.
 pub struct TaikoBlockExecutor<'a, Evm, Spec, R: ReceiptBuilder> {
     /// Reference to the specification object.
@@ -260,13 +279,11 @@ where
     ) -> Result<bool, BlockExecutionError> {
         match self.execute_transaction(tx) {
             Ok(_) => Ok(true),
-            // We don't allow anchor transaction to be discarded even if it exceeds the zk gas
-            // limit, this should never happen in practice.
-            Err(err) if is_zk_gas_limit_exceeded(&err) && !is_anchor_transaction => Ok(false),
-            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })) |
-            Err(BlockExecutionError::Validation(
-                BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. },
-            )) if !is_anchor_transaction => Ok(false),
+            // We don't allow the anchor transaction to be discarded even if it would otherwise be a
+            // recoverable failure; this should never happen in practice.
+            Err(err) if !is_anchor_transaction && is_recoverable_non_anchor_tx_error(&err) => {
+                Ok(false)
+            }
             Err(err) => Err(err),
         }
     }
@@ -729,6 +746,24 @@ mod test {
         };
         assert!(is_zk_gas_difficulty_mismatch(&err));
         assert!(err.to_string().contains("difficulty"));
+    }
+
+    #[test]
+    fn is_recoverable_non_anchor_tx_error_classifies_recoverable_set() {
+        let gas_err = BlockExecutionError::Validation(
+            BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                transaction_gas_limit: 2,
+                block_available_gas: 1,
+            },
+        );
+        assert!(is_recoverable_non_anchor_tx_error(&gas_err));
+
+        // A zk gas difficulty mismatch is fatal, not a recoverable per-transaction failure.
+        let difficulty_err = BlockExecutionError::other(ZkGasDifficultyMismatch {
+            expected: U256::from(1u64),
+            got: U256::from(2u64),
+        });
+        assert!(!is_recoverable_non_anchor_tx_error(&difficulty_err));
     }
 
     #[test]

--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -2,29 +2,29 @@
 #[cfg(feature = "prover")]
 use alloy_consensus::transaction::Recovered;
 use alloy_consensus::{Transaction, TransactionEnvelope, TxReceipt};
-use alloy_eips::{Encodable2718, eip7685::Requests};
+use alloy_eips::{eip7685::Requests, Encodable2718};
 use alloy_evm::{
-    FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
     block::GasOutput,
-    eth::{EthTxResult, receipt_builder::ReceiptBuilder},
+    eth::{receipt_builder::ReceiptBuilder, EthTxResult},
+    FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
 };
-use alloy_primitives::{Address, Bytes, Log, U256, Uint};
+use alloy_primitives::{Address, Bytes, Log, Uint, U256};
 use reth_evm::{
-    Evm, OnStateHook,
     block::{
         BlockExecutionError, BlockExecutor, BlockValidationError, CommitChanges, ExecutableTx,
         InternalBlockExecutionError, StateChangeSource, StateDB, SystemCaller,
     },
     eth::receipt_builder::ReceiptBuilderCtx,
+    Evm, OnStateHook,
 };
 use reth_execution_types::BlockExecutionResult;
-use reth_revm::context::{Block as _, result::ResultAndState};
+use reth_revm::context::{result::ResultAndState, Block as _};
 use revm_database_interface::{Database, DatabaseCommit};
 
 use crate::factory::TaikoBlockExecutionCtx;
 use alethia_reth_chainspec::spec::TaikoExecutorSpec;
 use alethia_reth_evm::{
-    alloy::{TAIKO_GOLDEN_TOUCH_ADDRESS, TaikoZkGasEvm},
+    alloy::{TaikoZkGasEvm, TAIKO_GOLDEN_TOUCH_ADDRESS},
     handler::get_treasury_address,
     zk_gas::{adapter::ZK_GAS_LIMIT_ERR, meter::ZkGasOutcome},
 };
@@ -76,6 +76,14 @@ impl std::error::Error for ZkGasDifficultyMismatch {}
 pub fn is_zk_gas_limit_exceeded(error: &BlockExecutionError) -> bool {
     match error {
         BlockExecutionError::Internal(err) => err.is_other::<ZkGasLimitExceeded>(),
+        _ => false,
+    }
+}
+
+/// Returns `true` when `error` represents a zk gas difficulty commitment mismatch.
+pub fn is_zk_gas_difficulty_mismatch(error: &BlockExecutionError) -> bool {
+    match error {
+        BlockExecutionError::Internal(err) => err.is_other::<ZkGasDifficultyMismatch>(),
         _ => false,
     }
 }
@@ -192,9 +200,9 @@ where
         > + TaikoZkGasEvm,
     Spec: TaikoExecutorSpec + Clone,
     R: ReceiptBuilder<
-            Transaction: Transaction + Encodable2718 + Clone,
-            Receipt: TxReceipt<Log = Log>,
-        >,
+        Transaction: Transaction + Encodable2718 + Clone,
+        Receipt: TxReceipt<Log = Log>,
+    >,
 {
     /// Executes a prover candidate block and returns the transactions that were actually committed.
     pub fn execute_block_with_committed_transactions<'tx>(
@@ -255,8 +263,8 @@ where
             // We don't allow anchor transaction to be discarded even if it exceeds the zk gas
             // limit, this should never happen in practice.
             Err(err) if is_zk_gas_limit_exceeded(&err) && !is_anchor_transaction => Ok(false),
-            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })) |
-            Err(BlockExecutionError::Validation(
+            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. }))
+            | Err(BlockExecutionError::Validation(
                 BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. },
             )) if !is_anchor_transaction => Ok(false),
             Err(err) => Err(err),
@@ -522,15 +530,15 @@ mod test {
 
     use alloy_consensus::{Signed, TxLegacy};
     use alloy_evm::EvmFactory;
-    use alloy_primitives::{Address, B256, Bytes, ChainId, Signature, TxKind, U64, U256};
+    use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, B256, U256, U64};
     use reth_ethereum_primitives::TransactionSigned;
-    use reth_evm::{ConfigureEvm, block::BlockExecutor};
+    use reth_evm::{block::BlockExecutor, ConfigureEvm};
     use reth_evm_ethereum::RethReceiptBuilder;
     use reth_primitives_traits::SignedTransaction;
     use reth_revm::{
-        State,
         db::{CacheDB, EmptyDB},
         state::AccountInfo,
+        State,
     };
 
     use alethia_reth_chainspec::TAIKO_MASAYA_CHAIN_ID;
@@ -544,8 +552,8 @@ mod test {
     use crate::{
         config::{TaikoEvmConfig, TaikoNextBlockEnvAttributes},
         testutil::{
-            BENCH_LIMIT_TARGET, BENCH_SUCCESS_TARGET, db_with_contracts, recovered_tx,
-            recovered_tx_with_chain_id, unzen_chain_spec, unzen_evm_env, unzen_execution_ctx,
+            db_with_contracts, recovered_tx, recovered_tx_with_chain_id, unzen_chain_spec,
+            unzen_evm_env, unzen_execution_ctx, BENCH_LIMIT_TARGET, BENCH_SUCCESS_TARGET,
         },
     };
     use alethia_reth_chainspec::spec::TaikoChainSpec;
@@ -719,6 +727,7 @@ mod test {
             Ok(_) => panic!("imported Unzen blocks must reject difficulty mismatches"),
             Err(err) => err,
         };
+        assert!(is_zk_gas_difficulty_mismatch(&err));
         assert!(err.to_string().contains("difficulty"));
     }
 

--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -2,29 +2,29 @@
 #[cfg(feature = "prover")]
 use alloy_consensus::transaction::Recovered;
 use alloy_consensus::{Transaction, TransactionEnvelope, TxReceipt};
-use alloy_eips::{eip7685::Requests, Encodable2718};
+use alloy_eips::{Encodable2718, eip7685::Requests};
 use alloy_evm::{
-    block::GasOutput,
-    eth::{receipt_builder::ReceiptBuilder, EthTxResult},
     FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
+    block::GasOutput,
+    eth::{EthTxResult, receipt_builder::ReceiptBuilder},
 };
-use alloy_primitives::{Address, Bytes, Log, Uint, U256};
+use alloy_primitives::{Address, Bytes, Log, U256, Uint};
 use reth_evm::{
+    Evm, OnStateHook,
     block::{
         BlockExecutionError, BlockExecutor, BlockValidationError, CommitChanges, ExecutableTx,
         InternalBlockExecutionError, StateChangeSource, StateDB, SystemCaller,
     },
     eth::receipt_builder::ReceiptBuilderCtx,
-    Evm, OnStateHook,
 };
 use reth_execution_types::BlockExecutionResult;
-use reth_revm::context::{result::ResultAndState, Block as _};
+use reth_revm::context::{Block as _, result::ResultAndState};
 use revm_database_interface::{Database, DatabaseCommit};
 
 use crate::factory::TaikoBlockExecutionCtx;
 use alethia_reth_chainspec::spec::TaikoExecutorSpec;
 use alethia_reth_evm::{
-    alloy::{TaikoZkGasEvm, TAIKO_GOLDEN_TOUCH_ADDRESS},
+    alloy::{TAIKO_GOLDEN_TOUCH_ADDRESS, TaikoZkGasEvm},
     handler::get_treasury_address,
     zk_gas::{adapter::ZK_GAS_LIMIT_ERR, meter::ZkGasOutcome},
 };
@@ -200,9 +200,9 @@ where
         > + TaikoZkGasEvm,
     Spec: TaikoExecutorSpec + Clone,
     R: ReceiptBuilder<
-        Transaction: Transaction + Encodable2718 + Clone,
-        Receipt: TxReceipt<Log = Log>,
-    >,
+            Transaction: Transaction + Encodable2718 + Clone,
+            Receipt: TxReceipt<Log = Log>,
+        >,
 {
     /// Executes a prover candidate block and returns the transactions that were actually committed.
     pub fn execute_block_with_committed_transactions<'tx>(
@@ -263,8 +263,8 @@ where
             // We don't allow anchor transaction to be discarded even if it exceeds the zk gas
             // limit, this should never happen in practice.
             Err(err) if is_zk_gas_limit_exceeded(&err) && !is_anchor_transaction => Ok(false),
-            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. }))
-            | Err(BlockExecutionError::Validation(
+            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })) |
+            Err(BlockExecutionError::Validation(
                 BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. },
             )) if !is_anchor_transaction => Ok(false),
             Err(err) => Err(err),
@@ -530,15 +530,15 @@ mod test {
 
     use alloy_consensus::{Signed, TxLegacy};
     use alloy_evm::EvmFactory;
-    use alloy_primitives::{Address, Bytes, ChainId, Signature, TxKind, B256, U256, U64};
+    use alloy_primitives::{Address, B256, Bytes, ChainId, Signature, TxKind, U64, U256};
     use reth_ethereum_primitives::TransactionSigned;
-    use reth_evm::{block::BlockExecutor, ConfigureEvm};
+    use reth_evm::{ConfigureEvm, block::BlockExecutor};
     use reth_evm_ethereum::RethReceiptBuilder;
     use reth_primitives_traits::SignedTransaction;
     use reth_revm::{
+        State,
         db::{CacheDB, EmptyDB},
         state::AccountInfo,
-        State,
     };
 
     use alethia_reth_chainspec::TAIKO_MASAYA_CHAIN_ID;
@@ -552,8 +552,8 @@ mod test {
     use crate::{
         config::{TaikoEvmConfig, TaikoNextBlockEnvAttributes},
         testutil::{
-            db_with_contracts, recovered_tx, recovered_tx_with_chain_id, unzen_chain_spec,
-            unzen_evm_env, unzen_execution_ctx, BENCH_LIMIT_TARGET, BENCH_SUCCESS_TARGET,
+            BENCH_LIMIT_TARGET, BENCH_SUCCESS_TARGET, db_with_contracts, recovered_tx,
+            recovered_tx_with_chain_id, unzen_chain_spec, unzen_evm_env, unzen_execution_ctx,
         },
     };
     use alethia_reth_chainspec::spec::TaikoChainSpec;

--- a/crates/block/src/tx_selection/limits.rs
+++ b/crates/block/src/tx_selection/limits.rs
@@ -125,6 +125,22 @@ fn adjusted_estimate(estimated_after: u64, state: &DaRatioState) -> u64 {
         as u64
 }
 
+/// Returns the zlib-compressed byte length of `rlp_bytes` using the protocol's compression
+/// settings, or `u64::MAX` if compression fails.
+///
+/// This is the single definition of "compressed tx-list size" shared by transaction selection
+/// (DA limiting) and the debug witness RPC, so the two cannot drift apart.
+pub fn zlib_compressed_len(rlp_bytes: &[u8]) -> u64 {
+    let mut encoder = ZlibEncoder::new(Vec::new(), zlib_compression());
+    if encoder.write_all(rlp_bytes).is_err() {
+        return u64::MAX;
+    }
+    match encoder.finish() {
+        Ok(data) => u64::try_from(data.len()).unwrap_or(u64::MAX),
+        Err(_) => u64::MAX,
+    }
+}
+
 /// Returns the zlib-compressed byte size for the list plus the candidate.
 fn zlib_tx_list_size_bytes(list: &ExecutedTxList, candidate: &Recovered<TransactionSigned>) -> u64 {
     let mut txs: Vec<&TransactionSigned> = Vec::with_capacity(list.transactions.len() + 1);
@@ -135,15 +151,7 @@ fn zlib_tx_list_size_bytes(list: &ExecutedTxList, candidate: &Recovered<Transact
         Vec::with_capacity(list_length::<&TransactionSigned, TransactionSigned>(&txs));
     encode_list::<&TransactionSigned, TransactionSigned>(&txs, &mut rlp_bytes);
 
-    let mut encoder = ZlibEncoder::new(Vec::new(), zlib_compression());
-    if encoder.write_all(&rlp_bytes).is_err() {
-        return u64::MAX;
-    }
-    let compressed_len = match encoder.finish() {
-        Ok(data) => data.len(),
-        Err(_) => return u64::MAX,
-    };
-    u64::try_from(compressed_len).unwrap_or(u64::MAX)
+    zlib_compressed_len(&rlp_bytes)
 }
 
 /// Returns the DA size that exceeded the limit, if any (estimated or actual).

--- a/crates/block/src/tx_selection/mod.rs
+++ b/crates/block/src/tx_selection/mod.rs
@@ -26,6 +26,8 @@ use crate::executor::is_zk_gas_limit_exceeded;
 /// DA-limit checking and adaptive zlib sizing helpers.
 mod limits;
 
+pub use limits::zlib_compressed_len;
+
 /// Returns the appropriate pool error for the exceeded limit.
 fn limit_exceeded_error(
     gas_limit: u64,

--- a/crates/node/src/proof_history/mod.rs
+++ b/crates/node/src/proof_history/mod.rs
@@ -25,6 +25,7 @@ use reth::{
     tasks::TaskExecutor,
 };
 use reth_db::{Database, database_metrics::DatabaseMetrics};
+use reth_ethereum::EthPrimitives;
 use reth_node_api::{FullNodeComponents, NodeAddOns};
 use reth_node_builder::{
     NodeAdapter, NodeBuilderWithComponents, NodeComponentsBuilder, WithLaunchContext,
@@ -59,7 +60,7 @@ where
     T: reth_node_api::FullNodeTypes<Types = TaikoNode>,
     CB: NodeComponentsBuilder<T>,
     AO: NodeAddOns<NodeAdapter<T, CB::Components>> + RethRpcAddOns<NodeAdapter<T, CB::Components>>,
-    AO::EthApi: FullEthApi + Send + Sync + 'static,
+    AO::EthApi: FullEthApi<Primitives = EthPrimitives> + Send + Sync + 'static,
     T::Provider: BlockHashReader
         + BlockNumReader
         + BlockReader
@@ -133,7 +134,7 @@ pub fn install_proof_history_rpc<Node, EthApi>(
 ) -> eyre::Result<()>
 where
     Node: FullNodeComponents,
-    EthApi: FullEthApi + Send + Sync + 'static,
+    EthApi: FullEthApi<Primitives = EthPrimitives> + Send + Sync + 'static,
     Node::Provider:
         HeaderProvider<Header = reth::primitives::Header> + Clone + Send + Sync + 'static,
 {

--- a/crates/primitives/src/payload/builder.rs
+++ b/crates/primitives/src/payload/builder.rs
@@ -105,29 +105,16 @@ impl TaikoPayloadBuilderAttributes {
                 None
             }
             Some(tx_list_bytes) => {
-                // Legacy mode: decode and use provided transactions
-                let txs = decode_transactions(tx_list_bytes)
-                    .unwrap_or_else(|e| {
-                        // If we can't decode the given transactions bytes, we will mine an empty
-                        // block instead.
-                        debug!(
-                            target: "payload_builder",
-                            "Failed to decode transactions: {e}, bytes: {:?}, mining empty block",
-                            tx_list_bytes
-                        );
-                        Vec::new()
-                    })
-                    .into_iter()
-                    .filter_map(|tx| match tx.try_into_recovered() {
-                        Ok(recovered) => Some(recovered),
-                        Err(e) => {
-                            debug!(
-                                "Failed to recover transaction: {e}, skipping invalid transaction"
-                            );
-                            None
-                        }
-                    })
-                    .collect();
+                // Legacy mode: decode and recover the provided transactions, skipping any that
+                // fail signer recovery. If the list itself cannot be decoded, mine an empty block.
+                let txs = decode_recovered_transactions(tx_list_bytes).unwrap_or_else(|e| {
+                    debug!(
+                        target: "payload_builder",
+                        "Failed to decode transactions: {e}, bytes: {:?}, mining empty block",
+                        tx_list_bytes
+                    );
+                    Vec::new()
+                });
                 Some(txs)
             }
         };
@@ -245,6 +232,27 @@ pub fn payload_id_taiko(
 /// Decode RLP-encoded bytes into signed transactions.
 fn decode_transactions(bytes: &[u8]) -> Result<Vec<TransactionSigned>, alloy_rlp::Error> {
     Vec::<TransactionSigned>::decode(&mut &bytes[..])
+}
+
+/// Decode an RLP transaction list and recover each signer, dropping any transaction whose signer
+/// cannot be recovered.
+///
+/// This mirrors Taiko's lenient tx-list ingestion: a malformed top-level RLP list is reported as an
+/// error (so callers can decide whether to fall back, e.g. mine an empty block), while individual
+/// transactions that fail signer recovery are skipped rather than failing the whole list.
+pub fn decode_recovered_transactions(
+    bytes: &[u8],
+) -> Result<Vec<Recovered<TransactionSigned>>, alloy_rlp::Error> {
+    Ok(decode_transactions(bytes)?
+        .into_iter()
+        .filter_map(|tx| match tx.try_into_recovered() {
+            Ok(recovered) => Some(recovered),
+            Err(e) => {
+                debug!("Failed to recover transaction: {e}, skipping invalid transaction");
+                None
+            }
+        })
+        .collect())
 }
 
 #[cfg(all(test, feature = "net"))]

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -7,7 +7,9 @@ use alethia_reth_block::{
     },
     tx_selection::zlib_compressed_len,
 };
-use alethia_reth_primitives::payload::builder::decode_recovered_transactions;
+use alethia_reth_primitives::{
+    payload::builder::decode_recovered_transactions, transaction::is_allowed_tx_type,
+};
 use alloy_consensus::{BlockHeader, transaction::Recovered};
 use alloy_eips::{BlockId, BlockNumberOrTag, eip4844::BYTES_PER_BLOB};
 use alloy_primitives::{B256, Bytes};
@@ -216,6 +218,14 @@ where
             for (idx, tx) in block.transactions_recovered().enumerate() {
                 let is_anchor_transaction = idx == 0;
 
+                // Taiko blocks never contain blob transactions: the build paths skip them
+                // (crates/payload/src/builder/execution.rs) and consensus validation rejects any
+                // block that includes one. Skip them here too so the replayed witness matches what
+                // the node would have executed for the same tx list.
+                if !is_allowed_tx_type(*tx.inner()) {
+                    continue;
+                }
+
                 match block_executor.execute_transaction(tx) {
                     Ok(_) => {}
                     Err(err) if is_recoverable_tx_list_error(&err, is_anchor_transaction) => {
@@ -373,7 +383,7 @@ fn is_recoverable_tx_list_error(err: &BlockExecutionError, is_anchor_transaction
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::{Signed, TxLegacy};
+    use alloy_consensus::{Signed, TxEip4844, TxLegacy};
     use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
     use alloy_rlp::Encodable;
     use reth_evm::execute::BlockValidationError;
@@ -384,6 +394,49 @@ mod tests {
         let txs = decode_recovered_tx_list(Bytes::from_static(&[0xc0])).unwrap();
 
         assert!(txs.is_empty());
+    }
+
+    #[test]
+    fn blob_transactions_are_not_an_allowed_tx_type() {
+        // The replay loop skips any tx for which `is_allowed_tx_type` is false, matching the build
+        // paths. Blob (EIP-4844) transactions are never allowed in a Taiko block; legacy ones are.
+        let signature = Signature::new(U256::from(1u64), U256::from(1u64), false);
+
+        let legacy: TransactionSigned = Signed::new_unchecked(
+            TxLegacy {
+                chain_id: Some(1),
+                nonce: 0,
+                gas_price: 1,
+                gas_limit: 21_000,
+                to: TxKind::Call(Address::ZERO),
+                value: U256::ZERO,
+                input: Bytes::new(),
+            },
+            signature,
+            B256::ZERO,
+        )
+        .into();
+        assert!(is_allowed_tx_type(&legacy));
+
+        let blob: TransactionSigned = Signed::new_unchecked(
+            TxEip4844 {
+                chain_id: 1,
+                nonce: 0,
+                gas_limit: 21_000,
+                max_fee_per_gas: 1,
+                max_priority_fee_per_gas: 0,
+                to: Address::ZERO,
+                value: U256::ZERO,
+                access_list: Default::default(),
+                blob_versioned_hashes: vec![B256::ZERO],
+                max_fee_per_blob_gas: 1,
+                input: Bytes::new(),
+            },
+            signature,
+            B256::ZERO,
+        )
+        .into();
+        assert!(!is_allowed_tx_type(&blob));
     }
 
     #[test]

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -2,9 +2,9 @@
 
 use crate::proof_state::ProofHistoryStateProviderFactory;
 use alethia_reth_block::executor::{is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded};
-use alloy_consensus::{transaction::Recovered, BlockHeader};
+use alloy_consensus::{BlockHeader, transaction::Recovered};
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::{Address, Bytes, B256};
+use alloy_primitives::{Address, B256, Bytes};
 use alloy_rlp::Decodable;
 use alloy_rpc_types_debug::ExecutionWitness;
 use async_trait::async_trait;
@@ -12,15 +12,15 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_ethereum::{EthPrimitives, TransactionSigned};
 use reth_ethereum_primitives::Block;
 use reth_evm::{
-    execute::{BlockExecutionError, BlockExecutor, BlockValidationError, Executor},
     ConfigureEvm,
+    execute::{BlockExecutionError, BlockExecutor, BlockValidationError, Executor},
 };
 use reth_optimism_trie::{OpProofsStorage, OpProofsStore};
 use reth_primitives_traits::RecoveredBlock;
 use reth_provider::HeaderProvider;
 use reth_revm::{
-    database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
-    witness::ExecutionWitnessRecord, State,
+    State, database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
+    witness::ExecutionWitnessRecord,
 };
 use reth_rpc_eth_api::helpers::FullEthApi;
 use reth_rpc_eth_types::EthApiError;
@@ -214,8 +214,8 @@ where
             match block_executor.apply_post_execution_changes() {
                 Ok(_) => {}
                 Err(err)
-                    if options.skip_zk_gas_difficulty_check
-                        && is_zk_gas_difficulty_mismatch(&err) => {}
+                    if options.skip_zk_gas_difficulty_check &&
+                        is_zk_gas_difficulty_mismatch(&err) => {}
                 Err(err) => return Err(EthApiError::from(err).into()),
             }
         }
@@ -317,12 +317,12 @@ fn is_recoverable_tx_list_error(err: &BlockExecutionError, is_anchor_transaction
         return false;
     }
 
-    is_zk_gas_limit_exceeded(err)
-        || matches!(
+    is_zk_gas_limit_exceeded(err) ||
+        matches!(
             err,
             BlockExecutionError::Validation(
-                BlockValidationError::InvalidTx { .. }
-                    | BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. }
+                BlockValidationError::InvalidTx { .. } |
+                    BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. }
             )
         )
 }

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -1,10 +1,15 @@
 //! Proof-history backed overrides for selected `debug_` RPC methods.
 
 use crate::proof_state::ProofHistoryStateProviderFactory;
-use alethia_reth_block::executor::{is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded};
+use alethia_reth_block::{
+    executor::{
+        is_recoverable_non_anchor_tx_error, is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded,
+    },
+    tx_selection::zlib_compressed_len,
+};
 use alethia_reth_primitives::payload::builder::decode_recovered_transactions;
 use alloy_consensus::{BlockHeader, transaction::Recovered};
-use alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_eips::{BlockId, BlockNumberOrTag, eip4844::BYTES_PER_BLOB};
 use alloy_primitives::{B256, Bytes};
 use alloy_rpc_types_debug::ExecutionWitness;
 use async_trait::async_trait;
@@ -13,7 +18,7 @@ use reth_ethereum::{EthPrimitives, TransactionSigned};
 use reth_ethereum_primitives::Block;
 use reth_evm::{
     ConfigureEvm,
-    execute::{BlockExecutionError, BlockExecutor, BlockValidationError, Executor},
+    execute::{BlockExecutionError, BlockExecutor, Executor},
 };
 use reth_optimism_trie::{OpProofsStorage, OpProofsStore};
 use reth_primitives_traits::RecoveredBlock;
@@ -30,6 +35,20 @@ use tokio::sync::Semaphore;
 
 /// Maximum number of concurrent proof-history witness requests.
 const MAX_CONCURRENT_WITNESS_REQUESTS: usize = 3;
+
+/// Block-level tx-list DA limit: the zlib-compressed transaction list must fit in one blob.
+///
+/// This mirrors the limit the proposer and [`alethia_reth_block::tx_selection`] enforce per block
+/// (`max_da_bytes_per_list`), so a tx list that would never have been a valid block is rejected.
+const MAX_TX_LIST_COMPRESSED_BYTES: usize = BYTES_PER_BLOB;
+
+/// Generous upper bound on the raw (decompressed) tx-list bytes accepted before compression.
+///
+/// This is not a protocol limit; it only bounds the work done by the compressed-size check so an
+/// oversized request (the auth RPC server accepts bodies up to 128 MiB) cannot be handed to zlib.
+/// A valid single block's decompressed tx list is far smaller — a 45M-gas block holds at most
+/// ~11 MiB of zero-byte calldata — so this never rejects a legitimately proposed block.
+const MAX_TX_LIST_RAW_BYTES: usize = 16 * 1024 * 1024;
 
 /// RPC server trait for Taiko proof-history backed `debug_` witness methods.
 #[cfg_attr(not(test), rpc(server, namespace = "debug"))]
@@ -281,15 +300,45 @@ where
 
 /// Decode an RLP transaction list and recover each transaction signer for EVM execution.
 ///
-/// Uses the same lenient ingestion as the payload builder ([`decode_recovered_transactions`]):
-/// transactions whose signer cannot be recovered are skipped rather than failing the request, so
-/// the replayed witness matches what the node would have executed for the same tx list. A malformed
-/// top-level RLP list is still reported as an error.
+/// Rejects oversized inputs (see [`check_tx_list_size`]) before decoding. Uses the same lenient
+/// ingestion as the payload builder ([`decode_recovered_transactions`]): transactions whose signer
+/// cannot be recovered are skipped rather than failing the request, so the replayed witness matches
+/// what the node would have executed for the same tx list. A malformed top-level RLP list is still
+/// reported as an error.
 fn decode_recovered_tx_list(
     tx_list: Bytes,
 ) -> Result<Vec<Recovered<TransactionSigned>>, EthApiError> {
-    decode_recovered_transactions(tx_list.as_ref())
+    let raw = tx_list.as_ref();
+    check_tx_list_size(raw, MAX_TX_LIST_RAW_BYTES, MAX_TX_LIST_COMPRESSED_BYTES)?;
+    decode_recovered_transactions(raw)
         .map_err(|err| EthApiError::EvmCustom(format!("failed to decode tx list: {err}")))
+}
+
+/// Reject a tx list that is too large to be a valid block-level transaction list.
+///
+/// `raw` is the decompressed RLP tx list. The cheap `max_raw` byte check runs first to bound the
+/// work of the compression check; the authoritative limit is `max_compressed`, the zlib-compressed
+/// size that must fit the block DA budget (one blob).
+fn check_tx_list_size(
+    raw: &[u8],
+    max_raw: usize,
+    max_compressed: usize,
+) -> Result<(), EthApiError> {
+    if raw.len() > max_raw {
+        return Err(EthApiError::EvmCustom(format!(
+            "tx list size {} exceeds raw limit {max_raw}",
+            raw.len(),
+        )));
+    }
+
+    let compressed = zlib_compressed_len(raw);
+    if compressed > max_compressed as u64 {
+        return Err(EthApiError::EvmCustom(format!(
+            "tx list compressed size {compressed} exceeds block DA limit {max_compressed}",
+        )));
+    }
+
+    Ok(())
 }
 
 /// Replace a canonical block's transactions with the explicit replay transaction list.
@@ -313,19 +362,12 @@ fn block_with_tx_list(
 }
 
 /// Return whether a transaction-list replay error should be tolerated for prover witness parity.
+///
+/// Anchor (index 0) failures are always fatal; non-anchor failures defer to the shared
+/// [`is_recoverable_non_anchor_tx_error`] classifier so the recoverable error set stays in sync
+/// with the prover executor and cannot drift.
 fn is_recoverable_tx_list_error(err: &BlockExecutionError, is_anchor_transaction: bool) -> bool {
-    if is_anchor_transaction {
-        return false;
-    }
-
-    is_zk_gas_limit_exceeded(err) ||
-        matches!(
-            err,
-            BlockExecutionError::Validation(
-                BlockValidationError::InvalidTx { .. } |
-                    BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. }
-            )
-        )
+    !is_anchor_transaction && is_recoverable_non_anchor_tx_error(err)
 }
 
 #[cfg(test)]
@@ -334,6 +376,7 @@ mod tests {
     use alloy_consensus::{Signed, TxLegacy};
     use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
     use alloy_rlp::Encodable;
+    use reth_evm::execute::BlockValidationError;
     use serde_json::json;
 
     #[test]
@@ -394,5 +437,33 @@ mod tests {
             serde_json::from_value(json!({ "skipZkGasDifficultyCheck": true })).unwrap();
 
         assert!(options.skip_zk_gas_difficulty_check);
+    }
+
+    #[test]
+    fn check_tx_list_size_accepts_list_within_limits() {
+        assert!(check_tx_list_size(&[1, 2, 3], 1024, 1024).is_ok());
+    }
+
+    #[test]
+    fn check_tx_list_size_rejects_raw_over_limit() {
+        // The raw guard fires on length alone, before any compression.
+        let err = check_tx_list_size(&[0u8; 10], 4, usize::MAX)
+            .expect_err("raw byte limit must be enforced");
+
+        assert!(err.to_string().contains("raw limit"), "{err}");
+    }
+
+    #[test]
+    fn check_tx_list_size_rejects_compressed_over_limit() {
+        let raw = [7u8; 64];
+        let actual = zlib_compressed_len(&raw);
+        assert!(actual > 0);
+
+        // One byte below the actual compressed size is rejected; exactly at the size is accepted.
+        let err = check_tx_list_size(&raw, raw.len(), (actual - 1) as usize)
+            .expect_err("compressed size limit must be enforced");
+        assert!(err.to_string().contains("compressed size"), "{err}");
+
+        assert!(check_tx_list_size(&raw, raw.len(), actual as usize).is_ok());
     }
 }

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -2,10 +2,10 @@
 
 use crate::proof_state::ProofHistoryStateProviderFactory;
 use alethia_reth_block::executor::{is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded};
+use alethia_reth_primitives::payload::builder::decode_recovered_transactions;
 use alloy_consensus::{BlockHeader, transaction::Recovered};
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::{Address, B256, Bytes};
-use alloy_rlp::Decodable;
+use alloy_primitives::{B256, Bytes};
 use alloy_rpc_types_debug::ExecutionWitness;
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
@@ -196,9 +196,6 @@ where
 
             for (idx, tx) in block.transactions_recovered().enumerate() {
                 let is_anchor_transaction = idx == 0;
-                if !is_anchor_transaction && tx.signer() == Address::ZERO {
-                    continue;
-                }
 
                 match block_executor.execute_transaction(tx) {
                     Ok(_) => {}
@@ -283,11 +280,15 @@ where
 }
 
 /// Decode an RLP transaction list and recover each transaction signer for EVM execution.
+///
+/// Uses the same lenient ingestion as the payload builder ([`decode_recovered_transactions`]):
+/// transactions whose signer cannot be recovered are skipped rather than failing the request, so
+/// the replayed witness matches what the node would have executed for the same tx list. A malformed
+/// top-level RLP list is still reported as an error.
 fn decode_recovered_tx_list(
     tx_list: Bytes,
 ) -> Result<Vec<Recovered<TransactionSigned>>, EthApiError> {
-    let mut tx_list = tx_list.as_ref();
-    Vec::<Recovered<TransactionSigned>>::decode(&mut tx_list)
+    decode_recovered_transactions(tx_list.as_ref())
         .map_err(|err| EthApiError::EvmCustom(format!("failed to decode tx list: {err}")))
 }
 
@@ -330,12 +331,39 @@ fn is_recoverable_tx_list_error(err: &BlockExecutionError, is_anchor_transaction
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::Bytes;
+    use alloy_consensus::{Signed, TxLegacy};
+    use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
+    use alloy_rlp::Encodable;
     use serde_json::json;
 
     #[test]
     fn decode_recovered_tx_list_accepts_empty_rlp_list() {
         let txs = decode_recovered_tx_list(Bytes::from_static(&[0xc0])).unwrap();
+
+        assert!(txs.is_empty());
+    }
+
+    #[test]
+    fn decode_recovered_tx_list_skips_unrecoverable_transactions() {
+        // A legacy transaction with `r = 0` has an unrecoverable signature. Previously this aborted
+        // the whole request; it must now be skipped, matching the payload builder's lenient tx-list
+        // ingestion so the replay reflects what the node would have executed.
+        let tx = TxLegacy {
+            chain_id: Some(1),
+            nonce: 0,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        };
+        let signature = Signature::new(U256::ZERO, U256::from(1u64), false);
+        let signed: TransactionSigned = Signed::new_unchecked(tx, signature, B256::ZERO).into();
+        let mut encoded = Vec::new();
+        vec![signed].encode(&mut encoded);
+
+        let txs = decode_recovered_tx_list(Bytes::from(encoded))
+            .expect("unrecoverable transactions are skipped, not fatal");
 
         assert!(txs.is_empty());
     }

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -244,8 +244,8 @@ where
             match block_executor.apply_post_execution_changes() {
                 Ok(_) => {}
                 Err(err)
-                    if options.skip_zk_gas_difficulty_check
-                        && is_zk_gas_difficulty_mismatch(&err) => {}
+                    if options.skip_zk_gas_difficulty_check &&
+                        is_zk_gas_difficulty_mismatch(&err) => {}
                 Err(err) => return Err(EthApiError::from(err).into()),
             }
         }
@@ -387,8 +387,8 @@ fn is_recoverable_tx_list_error(err: &BlockExecutionError, is_anchor_transaction
 /// Return whether a disallowed transaction type should be skipped in tx-list replay.
 ///
 /// Non-anchor transactions match the payload-builder filtering behavior. The anchor transaction is
-/// mandatory block setup, so silently skipping it would produce a witness for a block the node would
-/// never execute.
+/// mandatory block setup, so silently skipping it would produce a witness for a block the node
+/// would never execute.
 fn should_skip_disallowed_tx_type(
     tx: &TransactionSigned,
     is_anchor_transaction: bool,

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -1,10 +1,10 @@
 //! Proof-history backed overrides for selected `debug_` RPC methods.
 
 use crate::proof_state::ProofHistoryStateProviderFactory;
-use alethia_reth_block::executor::is_zk_gas_limit_exceeded;
-use alloy_consensus::{BlockHeader, transaction::Recovered};
+use alethia_reth_block::executor::{is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded};
+use alloy_consensus::{transaction::Recovered, BlockHeader};
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::{Address, Bytes, B256};
 use alloy_rlp::Decodable;
 use alloy_rpc_types_debug::ExecutionWitness;
 use async_trait::async_trait;
@@ -12,19 +12,20 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_ethereum::{EthPrimitives, TransactionSigned};
 use reth_ethereum_primitives::Block;
 use reth_evm::{
-    ConfigureEvm,
     execute::{BlockExecutionError, BlockExecutor, BlockValidationError, Executor},
+    ConfigureEvm,
 };
 use reth_optimism_trie::{OpProofsStorage, OpProofsStore};
 use reth_primitives_traits::RecoveredBlock;
 use reth_provider::HeaderProvider;
 use reth_revm::{
-    State, database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
-    witness::ExecutionWitnessRecord,
+    database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
+    witness::ExecutionWitnessRecord, State,
 };
 use reth_rpc_eth_api::helpers::FullEthApi;
 use reth_rpc_eth_types::EthApiError;
 use reth_trie_common::ExecutionWitnessMode;
+use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
 
 /// Maximum number of concurrent proof-history witness requests.
@@ -58,7 +59,20 @@ pub trait TaikoDebugWitnessApi {
         block: BlockId,
         tx_list: Bytes,
         mode: Option<ExecutionWitnessMode>,
+        options: Option<TxListWitnessOptions>,
     ) -> RpcResult<ExecutionWitness>;
+}
+
+/// Options for `debug_executionWitnessForTxList`.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TxListWitnessOptions {
+    /// Skip matching recomputed zk gas against `header.difficulty`.
+    ///
+    /// This is only useful for debug experiments that replay non-canonical transaction lists on
+    /// top of a canonical parent state.
+    #[serde(default)]
+    pub skip_zk_gas_difficulty_check: bool,
 }
 
 /// `debug_` namespace overrides that use proof-history state for witness generation.
@@ -111,6 +125,7 @@ where
         block_id: BlockId,
         tx_list: Bytes,
         mode: ExecutionWitnessMode,
+        options: TxListWitnessOptions,
     ) -> Result<ExecutionWitness, Eth::Error> {
         let block = self
             .eth_api
@@ -119,7 +134,7 @@ where
             .ok_or(EthApiError::HeaderNotFound(block_id))?;
         let txs = decode_recovered_tx_list(tx_list)?;
         let block = block_with_tx_list(block.as_ref().clone(), txs);
-        self.execution_witness_for_tx_list_block(&block, mode).await
+        self.execution_witness_for_tx_list_block(&block, mode, options).await
     }
 
     /// Re-executes the provided block against proof-history backed parent state and returns the
@@ -157,6 +172,7 @@ where
         &self,
         block: &RecoveredBlock<Block>,
         mode: ExecutionWitnessMode,
+        options: TxListWitnessOptions,
     ) -> Result<ExecutionWitness, Eth::Error> {
         let block_number = block.header().number();
         let parent_block = BlockId::Hash(block.parent_hash().into());
@@ -195,7 +211,13 @@ where
                 }
             }
 
-            block_executor.apply_post_execution_changes().map_err(EthApiError::from)?;
+            match block_executor.apply_post_execution_changes() {
+                Ok(_) => {}
+                Err(err)
+                    if options.skip_zk_gas_difficulty_check
+                        && is_zk_gas_difficulty_mismatch(&err) => {}
+                Err(err) => return Err(EthApiError::from(err).into()),
+            }
         }
 
         state.merge_transitions(BundleRetention::Reverts);
@@ -246,11 +268,17 @@ where
         block: BlockId,
         tx_list: Bytes,
         mode: Option<ExecutionWitnessMode>,
+        options: Option<TxListWitnessOptions>,
     ) -> RpcResult<ExecutionWitness> {
         let _permit = self.semaphore.acquire().await;
-        self.execution_witness_for_tx_list_for_id(block, tx_list, mode.unwrap_or_default())
-            .await
-            .map_err(Into::into)
+        self.execution_witness_for_tx_list_for_id(
+            block,
+            tx_list,
+            mode.unwrap_or_default(),
+            options.unwrap_or_default(),
+        )
+        .await
+        .map_err(Into::into)
     }
 }
 
@@ -289,12 +317,12 @@ fn is_recoverable_tx_list_error(err: &BlockExecutionError, is_anchor_transaction
         return false;
     }
 
-    is_zk_gas_limit_exceeded(err) ||
-        matches!(
+    is_zk_gas_limit_exceeded(err)
+        || matches!(
             err,
             BlockExecutionError::Validation(
-                BlockValidationError::InvalidTx { .. } |
-                    BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. }
+                BlockValidationError::InvalidTx { .. }
+                    | BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. }
             )
         )
 }
@@ -303,6 +331,7 @@ fn is_recoverable_tx_list_error(err: &BlockExecutionError, is_anchor_transaction
 mod tests {
     use super::*;
     use alloy_primitives::Bytes;
+    use serde_json::json;
 
     #[test]
     fn decode_recovered_tx_list_accepts_empty_rlp_list() {
@@ -322,5 +351,20 @@ mod tests {
 
         assert!(is_recoverable_tx_list_error(&err, false));
         assert!(!is_recoverable_tx_list_error(&err, true));
+    }
+
+    #[test]
+    fn tx_list_witness_options_validate_difficulty_by_default() {
+        let options = TxListWitnessOptions::default();
+
+        assert!(!options.skip_zk_gas_difficulty_check);
+    }
+
+    #[test]
+    fn tx_list_witness_options_accept_camel_case_skip_flag() {
+        let options: TxListWitnessOptions =
+            serde_json::from_value(json!({ "skipZkGasDifficultyCheck": true })).unwrap();
+
+        assert!(options.skip_zk_gas_difficulty_check);
     }
 }

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -218,12 +218,16 @@ where
             for (idx, tx) in block.transactions_recovered().enumerate() {
                 let is_anchor_transaction = idx == 0;
 
-                // Taiko blocks never contain blob transactions: the build paths skip them
-                // (crates/payload/src/builder/execution.rs) and consensus validation rejects any
-                // block that includes one. Skip them here too so the replayed witness matches what
-                // the node would have executed for the same tx list.
-                if !is_allowed_tx_type(*tx.inner()) {
-                    continue;
+                // Taiko blocks never contain blob transactions: the build paths skip non-anchor
+                // ones (crates/payload/src/builder/execution.rs) and consensus validation rejects
+                // any block that includes one. Keep the same filtering, but never silently discard
+                // the mandatory anchor transaction.
+                match should_skip_disallowed_tx_type(tx.inner(), is_anchor_transaction) {
+                    Ok(true) => {
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(err) => return Err(err.into()),
                 }
 
                 match block_executor.execute_transaction(tx) {
@@ -240,8 +244,8 @@ where
             match block_executor.apply_post_execution_changes() {
                 Ok(_) => {}
                 Err(err)
-                    if options.skip_zk_gas_difficulty_check &&
-                        is_zk_gas_difficulty_mismatch(&err) => {}
+                    if options.skip_zk_gas_difficulty_check
+                        && is_zk_gas_difficulty_mismatch(&err) => {}
                 Err(err) => return Err(EthApiError::from(err).into()),
             }
         }
@@ -380,6 +384,26 @@ fn is_recoverable_tx_list_error(err: &BlockExecutionError, is_anchor_transaction
     !is_anchor_transaction && is_recoverable_non_anchor_tx_error(err)
 }
 
+/// Return whether a disallowed transaction type should be skipped in tx-list replay.
+///
+/// Non-anchor transactions match the payload-builder filtering behavior. The anchor transaction is
+/// mandatory block setup, so silently skipping it would produce a witness for a block the node would
+/// never execute.
+fn should_skip_disallowed_tx_type(
+    tx: &TransactionSigned,
+    is_anchor_transaction: bool,
+) -> Result<bool, EthApiError> {
+    if is_allowed_tx_type(tx) {
+        return Ok(false);
+    }
+
+    if is_anchor_transaction {
+        return Err(EthApiError::EvmCustom("anchor transaction type is not allowed".to_string()));
+    }
+
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -418,24 +442,7 @@ mod tests {
         .into();
         assert!(is_allowed_tx_type(&legacy));
 
-        let blob: TransactionSigned = Signed::new_unchecked(
-            TxEip4844 {
-                chain_id: 1,
-                nonce: 0,
-                gas_limit: 21_000,
-                max_fee_per_gas: 1,
-                max_priority_fee_per_gas: 0,
-                to: Address::ZERO,
-                value: U256::ZERO,
-                access_list: Default::default(),
-                blob_versioned_hashes: vec![B256::ZERO],
-                max_fee_per_blob_gas: 1,
-                input: Bytes::new(),
-            },
-            signature,
-            B256::ZERO,
-        )
-        .into();
+        let blob = blob_transaction();
         assert!(!is_allowed_tx_type(&blob));
     }
 
@@ -475,6 +482,26 @@ mod tests {
 
         assert!(is_recoverable_tx_list_error(&err, false));
         assert!(!is_recoverable_tx_list_error(&err, true));
+    }
+
+    #[test]
+    fn tx_list_replay_rejects_disallowed_anchor_tx_type() {
+        let blob = blob_transaction();
+
+        let err = should_skip_disallowed_tx_type(&blob, true)
+            .expect_err("anchor transaction type failures must be fatal");
+
+        assert!(err.to_string().contains("anchor transaction type is not allowed"), "{err}");
+    }
+
+    #[test]
+    fn tx_list_replay_skips_disallowed_non_anchor_tx_type() {
+        let blob = blob_transaction();
+
+        let should_skip = should_skip_disallowed_tx_type(&blob, false)
+            .expect("non-anchor disallowed tx types should be skipped");
+
+        assert!(should_skip);
     }
 
     #[test]
@@ -518,5 +545,28 @@ mod tests {
         assert!(err.to_string().contains("compressed size"), "{err}");
 
         assert!(check_tx_list_size(&raw, raw.len(), actual as usize).is_ok());
+    }
+
+    fn blob_transaction() -> TransactionSigned {
+        let signature = Signature::new(U256::from(1u64), U256::from(1u64), false);
+
+        Signed::new_unchecked(
+            TxEip4844 {
+                chain_id: 1,
+                nonce: 0,
+                gas_limit: 21_000,
+                max_fee_per_gas: 1,
+                max_priority_fee_per_gas: 0,
+                to: Address::ZERO,
+                value: U256::ZERO,
+                access_list: Default::default(),
+                blob_versioned_hashes: vec![B256::ZERO],
+                max_fee_per_blob_gas: 1,
+                input: Bytes::new(),
+            },
+            signature,
+            B256::ZERO,
+        )
+        .into()
     }
 }

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -1,16 +1,27 @@
 //! Proof-history backed overrides for selected `debug_` RPC methods.
 
 use crate::proof_state::ProofHistoryStateProviderFactory;
-use alloy_consensus::BlockHeader;
+use alethia_reth_block::executor::is_zk_gas_limit_exceeded;
+use alloy_consensus::{BlockHeader, transaction::Recovered};
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256, Bytes};
+use alloy_rlp::Decodable;
 use alloy_rpc_types_debug::ExecutionWitness;
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_evm::{ConfigureEvm, execute::Executor};
+use reth_ethereum::{EthPrimitives, TransactionSigned};
+use reth_ethereum_primitives::Block;
+use reth_evm::{
+    ConfigureEvm,
+    execute::{BlockExecutionError, BlockExecutor, BlockValidationError, Executor},
+};
 use reth_optimism_trie::{OpProofsStorage, OpProofsStore};
+use reth_primitives_traits::RecoveredBlock;
 use reth_provider::HeaderProvider;
-use reth_revm::{State, database::StateProviderDatabase, witness::ExecutionWitnessRecord};
+use reth_revm::{
+    State, database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
+    witness::ExecutionWitnessRecord,
+};
 use reth_rpc_eth_api::helpers::FullEthApi;
 use reth_rpc_eth_types::EthApiError;
 use reth_trie_common::ExecutionWitnessMode;
@@ -38,6 +49,16 @@ pub trait TaikoDebugWitnessApi {
         hash: B256,
         mode: Option<ExecutionWitnessMode>,
     ) -> RpcResult<ExecutionWitness>;
+
+    /// Replays an explicit transaction list on top of the requested block's parent state and
+    /// returns the generated execution witness.
+    #[method(name = "executionWitnessForTxList")]
+    async fn execution_witness_for_tx_list(
+        &self,
+        block: BlockId,
+        tx_list: Bytes,
+        mode: Option<ExecutionWitnessMode>,
+    ) -> RpcResult<ExecutionWitness>;
 }
 
 /// `debug_` namespace overrides that use proof-history state for witness generation.
@@ -55,7 +76,7 @@ pub struct TaikoDebugWitnessExt<Eth, Storage, Provider> {
 
 impl<Eth, Storage, Provider> TaikoDebugWitnessExt<Eth, Storage, Provider>
 where
-    Eth: FullEthApi + Send + Sync + 'static,
+    Eth: FullEthApi<Primitives = EthPrimitives> + Send + Sync + 'static,
     Storage: OpProofsStore + Clone + 'static,
     Provider: HeaderProvider + Clone + Send + Sync + 'static,
     Provider::Header: BlockHeader + alloy_rlp::Encodable,
@@ -70,7 +91,7 @@ where
         }
     }
 
-    /// Re-executes the requested block and returns the generated witness.
+    /// Re-executes the requested canonical block and returns the generated witness.
     async fn execution_witness_for_id(
         &self,
         block_id: BlockId,
@@ -81,6 +102,33 @@ where
             .recovered_block(block_id)
             .await?
             .ok_or(EthApiError::HeaderNotFound(block_id))?;
+        self.execution_witness_for_block(block.as_ref(), mode).await
+    }
+
+    /// Replays the explicit transaction list on top of the requested block's parent state.
+    async fn execution_witness_for_tx_list_for_id(
+        &self,
+        block_id: BlockId,
+        tx_list: Bytes,
+        mode: ExecutionWitnessMode,
+    ) -> Result<ExecutionWitness, Eth::Error> {
+        let block = self
+            .eth_api
+            .recovered_block(block_id)
+            .await?
+            .ok_or(EthApiError::HeaderNotFound(block_id))?;
+        let txs = decode_recovered_tx_list(tx_list)?;
+        let block = block_with_tx_list(block.as_ref().clone(), txs);
+        self.execution_witness_for_tx_list_block(&block, mode).await
+    }
+
+    /// Re-executes the provided block against proof-history backed parent state and returns the
+    /// generated witness.
+    async fn execution_witness_for_block(
+        &self,
+        block: &RecoveredBlock<Block>,
+        mode: ExecutionWitnessMode,
+    ) -> Result<ExecutionWitness, Eth::Error> {
         let block_number = block.header().number();
         let parent_block = BlockId::Hash(block.parent_hash().into());
         let state_provider = self
@@ -93,10 +141,65 @@ where
         let mut witness_record = ExecutionWitnessRecord::default();
 
         block_executor
-            .execute_with_state_closure(&block, |statedb: &State<_>| {
+            .execute_with_state_closure(block, |statedb: &State<_>| {
                 witness_record.record_executed_state(statedb, mode);
             })
             .map_err(EthApiError::from)?;
+
+        Ok(witness_record
+            .into_execution_witness(&*state_provider, &self.provider, block_number, mode)
+            .map_err(EthApiError::from)?)
+    }
+
+    /// Replays the explicit transaction-list block with prover-style filtering, without enabling
+    /// the block crate's global `prover` feature for normal node execution.
+    async fn execution_witness_for_tx_list_block(
+        &self,
+        block: &RecoveredBlock<Block>,
+        mode: ExecutionWitnessMode,
+    ) -> Result<ExecutionWitness, Eth::Error> {
+        let block_number = block.header().number();
+        let parent_block = BlockId::Hash(block.parent_hash().into());
+        let state_provider = self
+            .state_provider_factory
+            .state_provider(parent_block)
+            .await
+            .map_err(EthApiError::from)?;
+        let db = StateProviderDatabase::new(&*state_provider);
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let mut witness_record = ExecutionWitnessRecord::default();
+
+        {
+            let mut block_executor = self
+                .eth_api
+                .evm_config()
+                .executor_for_block(&mut state, block.sealed_block())
+                .map_err(|err| EthApiError::EvmCustom(err.to_string()))?;
+
+            block_executor.apply_pre_execution_changes().map_err(EthApiError::from)?;
+
+            for (idx, tx) in block.transactions_recovered().enumerate() {
+                let is_anchor_transaction = idx == 0;
+                if !is_anchor_transaction && tx.signer() == Address::ZERO {
+                    continue;
+                }
+
+                match block_executor.execute_transaction(tx) {
+                    Ok(_) => {}
+                    Err(err) if is_recoverable_tx_list_error(&err, is_anchor_transaction) => {
+                        if is_zk_gas_limit_exceeded(&err) {
+                            break;
+                        }
+                    }
+                    Err(err) => return Err(EthApiError::from(err).into()),
+                }
+            }
+
+            block_executor.apply_post_execution_changes().map_err(EthApiError::from)?;
+        }
+
+        state.merge_transitions(BundleRetention::Reverts);
+        witness_record.record_executed_state(&state, mode);
 
         Ok(witness_record
             .into_execution_witness(&*state_provider, &self.provider, block_number, mode)
@@ -108,7 +211,7 @@ where
 impl<Eth, Storage, Provider> TaikoDebugWitnessApiServer
     for TaikoDebugWitnessExt<Eth, Storage, Provider>
 where
-    Eth: FullEthApi + Send + Sync + 'static,
+    Eth: FullEthApi<Primitives = EthPrimitives> + Send + Sync + 'static,
     Storage: OpProofsStore + Clone + 'static,
     Provider: HeaderProvider + Clone + Send + Sync + 'static,
     Provider::Header: BlockHeader + alloy_rlp::Encodable,
@@ -135,5 +238,89 @@ where
         self.execution_witness_for_id(hash.into(), mode.unwrap_or_default())
             .await
             .map_err(Into::into)
+    }
+
+    /// Handles `debug_executionWitnessForTxList` with proof-history backed parent state.
+    async fn execution_witness_for_tx_list(
+        &self,
+        block: BlockId,
+        tx_list: Bytes,
+        mode: Option<ExecutionWitnessMode>,
+    ) -> RpcResult<ExecutionWitness> {
+        let _permit = self.semaphore.acquire().await;
+        self.execution_witness_for_tx_list_for_id(block, tx_list, mode.unwrap_or_default())
+            .await
+            .map_err(Into::into)
+    }
+}
+
+/// Decode an RLP transaction list and recover each transaction signer for EVM execution.
+fn decode_recovered_tx_list(
+    tx_list: Bytes,
+) -> Result<Vec<Recovered<TransactionSigned>>, EthApiError> {
+    let mut tx_list = tx_list.as_ref();
+    Vec::<Recovered<TransactionSigned>>::decode(&mut tx_list)
+        .map_err(|err| EthApiError::EvmCustom(format!("failed to decode tx list: {err}")))
+}
+
+/// Replace a canonical block's transactions with the explicit replay transaction list.
+fn block_with_tx_list(
+    block: RecoveredBlock<Block>,
+    txs: Vec<Recovered<TransactionSigned>>,
+) -> RecoveredBlock<Block> {
+    let block_hash = block.hash();
+    let mut block = block.into_block();
+    let mut senders = Vec::with_capacity(txs.len());
+    let mut transactions = Vec::with_capacity(txs.len());
+
+    for tx in txs {
+        let (tx, sender) = tx.into_parts();
+        transactions.push(tx);
+        senders.push(sender);
+    }
+
+    block.body.transactions = transactions;
+    RecoveredBlock::new(block, senders, block_hash)
+}
+
+/// Return whether a transaction-list replay error should be tolerated for prover witness parity.
+fn is_recoverable_tx_list_error(err: &BlockExecutionError, is_anchor_transaction: bool) -> bool {
+    if is_anchor_transaction {
+        return false;
+    }
+
+    is_zk_gas_limit_exceeded(err) ||
+        matches!(
+            err,
+            BlockExecutionError::Validation(
+                BlockValidationError::InvalidTx { .. } |
+                    BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. }
+            )
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::Bytes;
+
+    #[test]
+    fn decode_recovered_tx_list_accepts_empty_rlp_list() {
+        let txs = decode_recovered_tx_list(Bytes::from_static(&[0xc0])).unwrap();
+
+        assert!(txs.is_empty());
+    }
+
+    #[test]
+    fn tx_list_replay_recovers_non_anchor_block_gas_errors() {
+        let err = BlockExecutionError::Validation(
+            BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                transaction_gas_limit: 2,
+                block_available_gas: 1,
+            },
+        );
+
+        assert!(is_recoverable_tx_list_error(&err, false));
+        assert!(!is_recoverable_tx_list_error(&err, true));
     }
 }

--- a/crates/rpc/src/eth/auth/mod.rs
+++ b/crates/rpc/src/eth/auth/mod.rs
@@ -227,7 +227,6 @@ where
         )) else {
             return Ok(None);
         };
-
         self.read_l1_origin_by_block_id(block_id)
     }
 


### PR DESCRIPTION
## Summary
- Add `debug_executionWitnessForTxList` to replay an explicit RLP transaction list on the requested block's parent state.
- Reuse proof-history state for historical witness generation and preserve prover-style filtering for non-anchor tx replay errors.
- Constrain proof-history debug RPC registration to Ethereum primitives, matching the replay implementation.

## Test Plan
- `cargo test -p alethia-reth-rpc debug::tests`
- `cargo check -p alethia-reth-node -p alethia-reth-rpc`
- `just fmt`
- `just clippy`
