### PR TITLE
fix(block): stop after finalized zk gas target

### DIFF
--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -284,8 +284,8 @@ where
             // We don't allow anchor transaction to be discarded even if it exceeds the zk gas
             // limit, this should never happen in practice.
             Err(err) if is_zk_gas_limit_exceeded(&err) && !is_anchor_transaction => Ok(false),
-            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. }))
-            | Err(BlockExecutionError::Validation(
+            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })) |
+            Err(BlockExecutionError::Validation(
                 BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. },
             )) if !is_anchor_transaction => Ok(false),
             Err(err) => Err(err),

--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -171,6 +171,7 @@ where
     }
 
     /// Returns the non-zero imported finalized zk gas target when zk gas metering is active.
+    #[cfg(feature = "prover")]
     fn expected_finalized_zk_gas(&self) -> Option<U256>
     where
         Evm: TaikoZkGasEvm,
@@ -184,6 +185,7 @@ where
 
     /// Checks whether committed transactions have reached the finalized zk gas advertised by the
     /// imported header, failing fast if execution overshoots it.
+    #[cfg(feature = "prover")]
     fn reached_expected_finalized_zk_gas(&self) -> Result<bool, BlockExecutionError>
     where
         Evm: TaikoZkGasEvm,
@@ -199,11 +201,8 @@ where
 
     /// Validates the imported header difficulty, when present, against the finalized block
     /// zk gas recomputed by execution.
-    fn validate_expected_zk_gas_difficulty(&self) -> Result<(), BlockExecutionError>
-    where
-        Evm: TaikoZkGasEvm,
-    {
-        let Some(expected) = self.expected_finalized_zk_gas() else { return Ok(()) };
+    fn validate_expected_zk_gas_difficulty(&self) -> Result<(), BlockExecutionError> {
+        let Some(expected) = self.ctx.expected_difficulty() else { return Ok(()) };
         let got = U256::from(self.ctx.finalized_block_zk_gas());
         if got == expected {
             return Ok(());
@@ -285,8 +284,8 @@ where
             // We don't allow anchor transaction to be discarded even if it exceeds the zk gas
             // limit, this should never happen in practice.
             Err(err) if is_zk_gas_limit_exceeded(&err) && !is_anchor_transaction => Ok(false),
-            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })) |
-            Err(BlockExecutionError::Validation(
+            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. }))
+            | Err(BlockExecutionError::Validation(
                 BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. },
             )) if !is_anchor_transaction => Ok(false),
             Err(err) => Err(err),
@@ -776,9 +775,8 @@ mod test {
         assert_eq!(ctx.finalized_block_zk_gas(), expected);
     }
 
-    #[cfg(feature = "prover")]
     #[test]
-    fn execute_block_treats_zero_expected_difficulty_as_unlimited() {
+    fn executor_rejects_imported_unzen_block_when_zero_difficulty_mismatches_finalized_zk_gas() {
         let chain_spec = Arc::new(unzen_chain_spec());
         let mut state = State::builder()
             .with_database(db_with_contracts(&[(BENCH_CALLER, 0)]))
@@ -787,17 +785,44 @@ mod test {
         let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
         let mut ctx = unzen_execution_ctx();
         ctx.expected_difficulty = Some(U256::ZERO);
-        let executor =
+        let mut executor =
             TaikoBlockExecutor::new(evm, ctx.clone(), chain_spec, RethReceiptBuilder::default());
 
-        let result = executor
-            .execute_block(vec![
-                recovered_tx(BENCH_CALLER, BENCH_SUCCESS_TARGET, 0, 1),
-                recovered_tx(BENCH_CALLER, BENCH_SUCCESS_TARGET, 1, 1),
-            ])
-            .expect("zero difficulty should not truncate or validate finalized zk gas");
+        executor
+            .execute_transaction(recovered_tx(BENCH_CALLER, BENCH_SUCCESS_TARGET, 0, 1))
+            .expect("transaction should execute successfully");
 
-        assert_eq!(result.receipts.len(), 2);
+        let err: BlockExecutionError = match executor.finish() {
+            Ok(_) => panic!("imported Unzen blocks must reject zero difficulty mismatches"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("difficulty"));
+        assert!(ctx.finalized_block_zk_gas() > 0);
+    }
+
+    #[cfg(feature = "prover")]
+    #[test]
+    fn reached_expected_finalized_zk_gas_treats_zero_as_no_stop_target() {
+        let chain_spec = Arc::new(unzen_chain_spec());
+        let mut state = State::builder()
+            .with_database(db_with_contracts(&[(BENCH_CALLER, 0)]))
+            .with_bundle_update()
+            .build();
+        let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
+        let mut ctx = unzen_execution_ctx();
+        ctx.expected_difficulty = Some(U256::ZERO);
+        let mut executor =
+            TaikoBlockExecutor::new(evm, ctx.clone(), chain_spec, RethReceiptBuilder::default());
+
+        executor
+            .execute_transaction(recovered_tx(BENCH_CALLER, BENCH_SUCCESS_TARGET, 0, 1))
+            .expect("transaction should execute successfully");
+
+        assert!(
+            !executor
+                .reached_expected_finalized_zk_gas()
+                .expect("zero target check should not fail")
+        );
         assert!(ctx.finalized_block_zk_gas() > 0);
     }
 

--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -170,10 +170,40 @@ where
         }
     }
 
+    /// Returns the non-zero imported finalized zk gas target when zk gas metering is active.
+    fn expected_finalized_zk_gas(&self) -> Option<U256>
+    where
+        Evm: TaikoZkGasEvm,
+    {
+        if !self.ctx.is_unzen_active || self.evm.block_zk_gas_used().is_none() {
+            return None;
+        }
+
+        self.ctx.expected_difficulty().filter(|expected| !expected.is_zero())
+    }
+
+    /// Checks whether committed transactions have reached the finalized zk gas advertised by the
+    /// imported header, failing fast if execution overshoots it.
+    fn reached_expected_finalized_zk_gas(&self) -> Result<bool, BlockExecutionError>
+    where
+        Evm: TaikoZkGasEvm,
+    {
+        let Some(expected) = self.expected_finalized_zk_gas() else { return Ok(false) };
+        let got = U256::from(self.ctx.finalized_block_zk_gas());
+        if got > expected {
+            return Err(BlockExecutionError::other(ZkGasDifficultyMismatch { expected, got }));
+        }
+
+        Ok(got == expected)
+    }
+
     /// Validates the imported header difficulty, when present, against the finalized block
     /// zk gas recomputed by execution.
-    fn validate_expected_zk_gas_difficulty(&self) -> Result<(), BlockExecutionError> {
-        let Some(expected) = self.ctx.expected_difficulty() else { return Ok(()) };
+    fn validate_expected_zk_gas_difficulty(&self) -> Result<(), BlockExecutionError>
+    where
+        Evm: TaikoZkGasEvm,
+    {
+        let Some(expected) = self.expected_finalized_zk_gas() else { return Ok(()) };
         let got = U256::from(self.ctx.finalized_block_zk_gas());
         if got == expected {
             return Ok(());
@@ -217,7 +247,7 @@ where
             if self.try_execute_filtered(tx, is_anchor_transaction)? {
                 committed_transactions.push(committed_tx);
             }
-            if self.zk_gas_exhausted {
+            if self.zk_gas_exhausted || self.reached_expected_finalized_zk_gas()? {
                 break;
             }
         }
@@ -488,7 +518,7 @@ where
                 continue;
             }
             self.try_execute_filtered((tx_env, tx), is_anchor_transaction)?;
-            if self.zk_gas_exhausted {
+            if self.zk_gas_exhausted || self.reached_expected_finalized_zk_gas()? {
                 break;
             }
         }
@@ -698,6 +728,79 @@ mod test {
         assert!(ctx.finalized_block_zk_gas() > 0);
     }
 
+    #[cfg(feature = "prover")]
+    #[test]
+    fn execute_block_stops_after_expected_finalized_zk_gas_is_reached() {
+        let chain_spec = Arc::new(unzen_chain_spec());
+        let expected = {
+            let mut state = State::builder()
+                .with_database(db_with_contracts(&[(BENCH_CALLER, 0)]))
+                .with_bundle_update()
+                .build();
+            let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
+            let ctx = unzen_execution_ctx();
+            let executor = TaikoBlockExecutor::new(
+                evm,
+                ctx.clone(),
+                chain_spec.clone(),
+                RethReceiptBuilder::default(),
+            );
+
+            let result = executor
+                .execute_block(vec![recovered_tx(BENCH_CALLER, BENCH_SUCCESS_TARGET, 0, 1)])
+                .expect("single transaction block should execute successfully");
+            assert_eq!(result.receipts.len(), 1);
+            ctx.finalized_block_zk_gas()
+        };
+        assert!(expected > 0);
+
+        let mut state = State::builder()
+            .with_database(db_with_contracts(&[(BENCH_CALLER, 0)]))
+            .with_bundle_update()
+            .build();
+        let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
+        let mut ctx = unzen_execution_ctx();
+        ctx.expected_difficulty = Some(U256::from(expected));
+        let executor =
+            TaikoBlockExecutor::new(evm, ctx.clone(), chain_spec, RethReceiptBuilder::default());
+
+        let result = executor
+            .execute_block(vec![
+                recovered_tx(BENCH_CALLER, BENCH_SUCCESS_TARGET, 0, 1),
+                recovered_tx(BENCH_CALLER, BENCH_SUCCESS_TARGET, 1, 1),
+                recovered_tx(BENCH_CALLER, BENCH_SUCCESS_TARGET, 2, 1),
+            ])
+            .expect("executor should stop at the finalized zk gas target");
+
+        assert_eq!(result.receipts.len(), 1);
+        assert_eq!(ctx.finalized_block_zk_gas(), expected);
+    }
+
+    #[cfg(feature = "prover")]
+    #[test]
+    fn execute_block_treats_zero_expected_difficulty_as_unlimited() {
+        let chain_spec = Arc::new(unzen_chain_spec());
+        let mut state = State::builder()
+            .with_database(db_with_contracts(&[(BENCH_CALLER, 0)]))
+            .with_bundle_update()
+            .build();
+        let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
+        let mut ctx = unzen_execution_ctx();
+        ctx.expected_difficulty = Some(U256::ZERO);
+        let executor =
+            TaikoBlockExecutor::new(evm, ctx.clone(), chain_spec, RethReceiptBuilder::default());
+
+        let result = executor
+            .execute_block(vec![
+                recovered_tx(BENCH_CALLER, BENCH_SUCCESS_TARGET, 0, 1),
+                recovered_tx(BENCH_CALLER, BENCH_SUCCESS_TARGET, 1, 1),
+            ])
+            .expect("zero difficulty should not truncate or validate finalized zk gas");
+
+        assert_eq!(result.receipts.len(), 2);
+        assert!(ctx.finalized_block_zk_gas() > 0);
+    }
+
     #[test]
     fn executor_rejects_imported_unzen_block_when_difficulty_mismatches_finalized_zk_gas() {
         let chain_spec = Arc::new(unzen_chain_spec());
@@ -707,7 +810,7 @@ mod test {
             .build();
         let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
         let mut ctx = unzen_execution_ctx();
-        ctx.expected_difficulty = Some(U256::ZERO);
+        ctx.expected_difficulty = Some(U256::from(1_u64));
         let mut executor =
             TaikoBlockExecutor::new(evm, ctx, chain_spec, RethReceiptBuilder::default());
 


### PR DESCRIPTION
Why
- Terminal out-of-zkgas tails should not force prover witness/getProof recovery once the committed prefix already reaches the finalized zk gas recorded in the header.
- Imported blocks with `difficulty = 0` should be treated as having no usable zk gas finalization signal.

How
- Gate finalized zk gas validation on active Unzen zk gas metering and a non-zero expected difficulty.
- Stop prover block execution when the committed finalized zk gas exactly reaches the expected header difficulty, and fail fast if it overshoots.
- Add regression coverage for prefix-stop behavior, zero difficulty, and mismatch validation.

Tests
- `just fmt`
- `cargo test -p alethia-reth-block execute_block_ --features prover`
- `cargo test -p alethia-reth-block executor_rejects_imported_unzen_block_when_difficulty_mismatches_finalized_zk_gas --features prover`
- `just clippy`
- `just test`
