### PR TITLE
fix(rpc): correct tx-list witness env, decoding, and drop skip flag

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches: [main,feat/txlist-execution-witness]
+    branches: [main]
   release:
     types: [published]
 

--- a/crates/block/src/config.rs
+++ b/crates/block/src/config.rs
@@ -9,17 +9,17 @@ use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::Withdrawals;
 use reth_chainspec::EthChainSpec;
 use reth_ethereum_forks::Hardforks;
-use reth_ethereum_primitives::EthPrimitives;
+use reth_ethereum_primitives::{Block, EthPrimitives};
 #[cfg(feature = "net")]
 use reth_evm::ConfigureEngineEvm;
-use reth_evm::{ConfigureEvm, EvmEnv, EvmEnvFor};
+use reth_evm::{ConfigureEvm, EvmEnv, EvmEnvFor, block::BlockExecutionError};
 #[cfg(feature = "net")]
 use reth_evm::{ExecutableTxIterator, ExecutionCtxFor};
 use reth_evm_ethereum::RethReceiptBuilder;
 #[cfg(feature = "net")]
 use reth_payload_primitives::ExecutionPayload;
 use reth_primitives_traits::{
-    BlockTy, SealedBlock, SealedHeader, constants::MAX_TX_GAS_LIMIT_OSAKA,
+    BlockTy, RecoveredBlock, SealedBlock, SealedHeader, constants::MAX_TX_GAS_LIMIT_OSAKA,
 };
 #[cfg(feature = "net")]
 use reth_primitives_traits::{SignedTransaction, TxTy};
@@ -354,6 +354,28 @@ pub struct TaikoNextBlockEnvAttributes {
     pub extra_data: Bytes,
     /// The base fee per gas for the next block.
     pub base_fee_per_gas: u64,
+}
+
+/// Derives next-block environment attributes from a candidate block header.
+///
+/// Shared by prover derived-block execution and the proof-history tx-list witness RPC so the two
+/// paths build identical `parent + 1` environments.
+pub fn attributes_from_derived_block(
+    derived_block: &RecoveredBlock<Block>,
+) -> Result<TaikoNextBlockEnvAttributes, BlockExecutionError> {
+    let header = derived_block.header();
+    let base_fee_per_gas = header.base_fee_per_gas.ok_or_else(|| {
+        BlockExecutionError::other(MissingBaseFee { block_number: header.number })
+    })?;
+
+    Ok(TaikoNextBlockEnvAttributes {
+        timestamp: header.timestamp,
+        suggested_fee_recipient: header.beneficiary,
+        prev_randao: header.mix_hash,
+        gas_limit: header.gas_limit,
+        extra_data: header.extra_data.clone(),
+        base_fee_per_gas,
+    })
 }
 
 /// Map the latest active hardfork at the given header to a [`TaikoSpecId`].

--- a/crates/block/src/derived_block.rs
+++ b/crates/block/src/derived_block.rs
@@ -17,7 +17,7 @@ use reth_storage_api::noop::NoopProvider;
 use reth_trie_common::{HashedPostState, KeccakKeyHasher};
 
 use crate::{
-    config::{MissingBaseFee, TaikoEvmConfig, TaikoNextBlockEnvAttributes},
+    config::{TaikoEvmConfig, attributes_from_derived_block},
     executor::TaikoBlockExecutor,
     factory::TaikoBlockExecutorFactory,
 };
@@ -33,25 +33,6 @@ pub struct DerivedBlockExecutionOutcome {
     pub hashed_state: HashedPostState,
     /// Finalized zk gas accumulated by committed transactions.
     pub finalized_block_zk_gas: u64,
-}
-
-/// Derives next-block environment attributes from a candidate derived block header.
-fn attributes_from_derived_block(
-    derived_block: &RecoveredBlock<Block>,
-) -> Result<TaikoNextBlockEnvAttributes, BlockExecutionError> {
-    let header = derived_block.header();
-    let base_fee_per_gas = header.base_fee_per_gas.ok_or_else(|| {
-        BlockExecutionError::other(MissingBaseFee { block_number: header.number })
-    })?;
-
-    Ok(TaikoNextBlockEnvAttributes {
-        timestamp: header.timestamp,
-        suggested_fee_recipient: header.beneficiary,
-        prev_randao: header.mix_hash,
-        gas_limit: header.gas_limit,
-        extra_data: header.extra_data.clone(),
-        base_fee_per_gas,
-    })
 }
 
 /// Executes a candidate derived block in prover mode.

--- a/crates/node/src/proof_history/mod.rs
+++ b/crates/node/src/proof_history/mod.rs
@@ -12,6 +12,7 @@ use exex::{ProofHistorySidecar, ProofHistorySidecarConfig};
 use storage_init::proof_history_historical_init_metadata_path;
 
 use crate::TaikoNode;
+use alethia_reth_block::config::TaikoNextBlockEnvAttributes;
 use alethia_reth_rpc::{
     debug::{TaikoDebugWitnessApiServer, TaikoDebugWitnessExt},
     eth::proofs::{TaikoEthProofApiServer, TaikoEthProofExt},
@@ -26,7 +27,7 @@ use reth::{
 };
 use reth_db::{Database, database_metrics::DatabaseMetrics};
 use reth_ethereum::EthPrimitives;
-use reth_node_api::{FullNodeComponents, NodeAddOns};
+use reth_node_api::{ConfigureEvm, FullNodeComponents, NodeAddOns};
 use reth_node_builder::{
     NodeAdapter, NodeBuilderWithComponents, NodeComponentsBuilder, WithLaunchContext,
     rpc::{RethRpcAddOns, RpcContext},
@@ -135,6 +136,7 @@ pub fn install_proof_history_rpc<Node, EthApi>(
 where
     Node: FullNodeComponents,
     EthApi: FullEthApi<Primitives = EthPrimitives> + Send + Sync + 'static,
+    EthApi::Evm: ConfigureEvm<NextBlockEnvCtx = TaikoNextBlockEnvAttributes>,
     Node::Provider:
         HeaderProvider<Header = reth::primitives::Header> + Clone + Send + Sync + 'static,
 {

--- a/crates/primitives/src/payload/builder.rs
+++ b/crates/primitives/src/payload/builder.rs
@@ -243,7 +243,7 @@ pub fn payload_id_taiko(
 }
 
 /// Decode RLP-encoded bytes into signed transactions.
-fn decode_transactions(bytes: &[u8]) -> Result<Vec<TransactionSigned>, alloy_rlp::Error> {
+pub fn decode_transactions(bytes: &[u8]) -> Result<Vec<TransactionSigned>, alloy_rlp::Error> {
     Vec::<TransactionSigned>::decode(&mut &bytes[..])
 }
 

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -1,11 +1,14 @@
 //! Proof-history backed overrides for selected `debug_` RPC methods.
 
 use crate::proof_state::ProofHistoryStateProviderFactory;
-use alethia_reth_block::executor::{is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded};
+use alethia_reth_block::{
+    config::{TaikoNextBlockEnvAttributes, attributes_from_derived_block},
+    executor::is_zk_gas_limit_exceeded,
+};
+use alethia_reth_primitives::payload::builder::decode_transactions;
 use alloy_consensus::{BlockHeader, transaction::Recovered};
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, B256, Bytes};
-use alloy_rlp::Decodable;
 use alloy_rpc_types_debug::ExecutionWitness;
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
@@ -16,7 +19,7 @@ use reth_evm::{
     execute::{BlockExecutionError, BlockExecutor, BlockValidationError, Executor},
 };
 use reth_optimism_trie::{OpProofsStorage, OpProofsStore};
-use reth_primitives_traits::RecoveredBlock;
+use reth_primitives_traits::{RecoveredBlock, SealedHeader, SignedTransaction};
 use reth_provider::HeaderProvider;
 use reth_revm::{
     State, database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
@@ -25,7 +28,6 @@ use reth_revm::{
 use reth_rpc_eth_api::helpers::FullEthApi;
 use reth_rpc_eth_types::EthApiError;
 use reth_trie_common::ExecutionWitnessMode;
-use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
 
 /// Maximum number of concurrent proof-history witness requests.
@@ -53,26 +55,17 @@ pub trait TaikoDebugWitnessApi {
 
     /// Replays an explicit transaction list on top of the requested block's parent state and
     /// returns the generated execution witness.
+    ///
+    /// The list is executed as the `parent + 1` block (matching the prover's derived-block
+    /// environment), so the resulting witness reflects a stateless re-execution of the supplied
+    /// transactions rather than the canonical block's transactions.
     #[method(name = "executionWitnessForTxList")]
     async fn execution_witness_for_tx_list(
         &self,
         block: BlockId,
         tx_list: Bytes,
         mode: Option<ExecutionWitnessMode>,
-        options: Option<TxListWitnessOptions>,
     ) -> RpcResult<ExecutionWitness>;
-}
-
-/// Options for `debug_executionWitnessForTxList`.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TxListWitnessOptions {
-    /// Skip matching recomputed zk gas against `header.difficulty`.
-    ///
-    /// This is only useful for debug experiments that replay non-canonical transaction lists on
-    /// top of a canonical parent state.
-    #[serde(default)]
-    pub skip_zk_gas_difficulty_check: bool,
 }
 
 /// `debug_` namespace overrides that use proof-history state for witness generation.
@@ -91,6 +84,7 @@ pub struct TaikoDebugWitnessExt<Eth, Storage, Provider> {
 impl<Eth, Storage, Provider> TaikoDebugWitnessExt<Eth, Storage, Provider>
 where
     Eth: FullEthApi<Primitives = EthPrimitives> + Send + Sync + 'static,
+    Eth::Evm: ConfigureEvm<NextBlockEnvCtx = TaikoNextBlockEnvAttributes>,
     Storage: OpProofsStore + Clone + 'static,
     Provider: HeaderProvider + Clone + Send + Sync + 'static,
     Provider::Header: BlockHeader + alloy_rlp::Encodable,
@@ -125,7 +119,6 @@ where
         block_id: BlockId,
         tx_list: Bytes,
         mode: ExecutionWitnessMode,
-        options: TxListWitnessOptions,
     ) -> Result<ExecutionWitness, Eth::Error> {
         let block = self
             .eth_api
@@ -134,7 +127,7 @@ where
             .ok_or(EthApiError::HeaderNotFound(block_id))?;
         let txs = decode_recovered_tx_list(tx_list)?;
         let block = block_with_tx_list(block.as_ref().clone(), txs);
-        self.execution_witness_for_tx_list_block(&block, mode, options).await
+        self.execution_witness_for_tx_list_block(&block, mode).await
     }
 
     /// Re-executes the provided block against proof-history backed parent state and returns the
@@ -172,10 +165,24 @@ where
         &self,
         block: &RecoveredBlock<Block>,
         mode: ExecutionWitnessMode,
-        options: TxListWitnessOptions,
     ) -> Result<ExecutionWitness, Eth::Error> {
         let block_number = block.header().number();
         let parent_block = BlockId::Hash(block.parent_hash().into());
+
+        // Execute the replayed list as the `parent + 1` block, mirroring the prover's derived-block
+        // environment (`difficulty = 0`, no committed `expected_difficulty`) rather than the
+        // canonical block's environment. Reusing the canonical block env would expose the original
+        // block's zk-gas difficulty through the `DIFFICULTY` opcode and force a difficulty mismatch
+        // for any list other than the original one. Both async loads happen before the non-`Send`
+        // execution state is built so the RPC future stays `Send`.
+        let parent = self
+            .eth_api
+            .recovered_block(parent_block)
+            .await?
+            .ok_or(EthApiError::HeaderNotFound(parent_block))?;
+        let parent_header = SealedHeader::new(parent.header().clone(), block.parent_hash());
+        let attributes = attributes_from_derived_block(block).map_err(EthApiError::from)?;
+
         let state_provider = self
             .state_provider_factory
             .state_provider(parent_block)
@@ -186,16 +193,23 @@ where
         let mut witness_record = ExecutionWitnessRecord::default();
 
         {
-            let mut block_executor = self
-                .eth_api
-                .evm_config()
-                .executor_for_block(&mut state, block.sealed_block())
+            let evm_config = self.eth_api.evm_config();
+            let evm_env = evm_config
+                .next_evm_env(parent_header.header(), &attributes)
                 .map_err(|err| EthApiError::EvmCustom(err.to_string()))?;
+            let evm = evm_config.evm_with_env(&mut state, evm_env);
+            let execution_ctx = evm_config
+                .context_for_next_block(&parent_header, attributes)
+                .map_err(|err| EthApiError::EvmCustom(err.to_string()))?;
+            let mut block_executor = evm_config.create_executor(evm, execution_ctx);
 
             block_executor.apply_pre_execution_changes().map_err(EthApiError::from)?;
 
             for (idx, tx) in block.transactions_recovered().enumerate() {
                 let is_anchor_transaction = idx == 0;
+                // Non-anchor transactions whose signer could not be recovered are kept as
+                // zero-signer entries by the decoder to preserve list ordering; skip them exactly
+                // as the prover's tx-list filtering does.
                 if !is_anchor_transaction && tx.signer() == Address::ZERO {
                     continue;
                 }
@@ -211,13 +225,7 @@ where
                 }
             }
 
-            match block_executor.apply_post_execution_changes() {
-                Ok(_) => {}
-                Err(err)
-                    if options.skip_zk_gas_difficulty_check &&
-                        is_zk_gas_difficulty_mismatch(&err) => {}
-                Err(err) => return Err(EthApiError::from(err).into()),
-            }
+            block_executor.apply_post_execution_changes().map_err(EthApiError::from)?;
         }
 
         state.merge_transitions(BundleRetention::Reverts);
@@ -234,6 +242,7 @@ impl<Eth, Storage, Provider> TaikoDebugWitnessApiServer
     for TaikoDebugWitnessExt<Eth, Storage, Provider>
 where
     Eth: FullEthApi<Primitives = EthPrimitives> + Send + Sync + 'static,
+    Eth::Evm: ConfigureEvm<NextBlockEnvCtx = TaikoNextBlockEnvAttributes>,
     Storage: OpProofsStore + Clone + 'static,
     Provider: HeaderProvider + Clone + Send + Sync + 'static,
     Provider::Header: BlockHeader + alloy_rlp::Encodable,
@@ -268,27 +277,32 @@ where
         block: BlockId,
         tx_list: Bytes,
         mode: Option<ExecutionWitnessMode>,
-        options: Option<TxListWitnessOptions>,
     ) -> RpcResult<ExecutionWitness> {
         let _permit = self.semaphore.acquire().await;
-        self.execution_witness_for_tx_list_for_id(
-            block,
-            tx_list,
-            mode.unwrap_or_default(),
-            options.unwrap_or_default(),
-        )
-        .await
-        .map_err(Into::into)
+        self.execution_witness_for_tx_list_for_id(block, tx_list, mode.unwrap_or_default())
+            .await
+            .map_err(Into::into)
     }
 }
 
-/// Decode an RLP transaction list and recover each transaction signer for EVM execution.
+/// Decode an RLP transaction list, recovering each signer for EVM execution.
+///
+/// Mirrors the canonical Taiko tx-list handling ([`decode_transactions`]): the list is decoded as a
+/// whole, and transactions whose signer cannot be recovered are kept as zero-signer entries rather
+/// than failing the entire request. Keeping them preserves list ordering (the anchor stays at index
+/// 0) and lets the executor skip them, matching the prover's tx-list filtering.
 fn decode_recovered_tx_list(
     tx_list: Bytes,
 ) -> Result<Vec<Recovered<TransactionSigned>>, EthApiError> {
-    let mut tx_list = tx_list.as_ref();
-    Vec::<Recovered<TransactionSigned>>::decode(&mut tx_list)
-        .map_err(|err| EthApiError::EvmCustom(format!("failed to decode tx list: {err}")))
+    let txs = decode_transactions(tx_list.as_ref())
+        .map_err(|err| EthApiError::EvmCustom(format!("failed to decode tx list: {err}")))?;
+    Ok(txs
+        .into_iter()
+        .map(|tx| {
+            let signer = tx.try_recover().unwrap_or(Address::ZERO);
+            Recovered::new_unchecked(tx, signer)
+        })
+        .collect())
 }
 
 /// Replace a canonical block's transactions with the explicit replay transaction list.
@@ -330,14 +344,39 @@ fn is_recoverable_tx_list_error(err: &BlockExecutionError, is_anchor_transaction
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::Bytes;
-    use serde_json::json;
+    use alloy_consensus::{Signed, TxLegacy};
+    use alloy_primitives::{Bytes, Signature, TxKind, U256};
+    use alloy_rlp::Encodable;
 
     #[test]
     fn decode_recovered_tx_list_accepts_empty_rlp_list() {
         let txs = decode_recovered_tx_list(Bytes::from_static(&[0xc0])).unwrap();
 
         assert!(txs.is_empty());
+    }
+
+    #[test]
+    fn decode_recovered_tx_list_keeps_unrecoverable_tx_as_zero_signer() {
+        // A signature with `r = 0` cannot be recovered, but it must not fail the whole list.
+        let tx = TxLegacy {
+            chain_id: Some(1),
+            nonce: 0,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        };
+        let signature = Signature::new(U256::ZERO, U256::from(1u64), false);
+        let signed: TransactionSigned = Signed::new_unchecked(tx, signature, B256::ZERO).into();
+        let mut encoded = Vec::new();
+        vec![signed].encode(&mut encoded);
+
+        let decoded = decode_recovered_tx_list(Bytes::from(encoded))
+            .expect("list must decode despite bad sig");
+
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].signer(), Address::ZERO);
     }
 
     #[test]
@@ -351,20 +390,5 @@ mod tests {
 
         assert!(is_recoverable_tx_list_error(&err, false));
         assert!(!is_recoverable_tx_list_error(&err, true));
-    }
-
-    #[test]
-    fn tx_list_witness_options_validate_difficulty_by_default() {
-        let options = TxListWitnessOptions::default();
-
-        assert!(!options.skip_zk_gas_difficulty_check);
-    }
-
-    #[test]
-    fn tx_list_witness_options_accept_camel_case_skip_flag() {
-        let options: TxListWitnessOptions =
-            serde_json::from_value(json!({ "skipZkGasDifficultyCheck": true })).unwrap();
-
-        assert!(options.skip_zk_gas_difficulty_check);
     }
 }


### PR DESCRIPTION
Stacked on #189 (base: `feat/txlist-execution-witness`). Addresses the code-review findings on the tx-list execution witness debug RPC. Confirmed intent with the author: the RPC replays the list as the **`parent + 1` block**.

## Changes

### C1 — Decoder no longer fails on a single bad-signature tx
`decode_recovered_tx_list` previously used `Vec::<Recovered<TransactionSigned>>::decode`, whose checked recovery fails the **whole** request if any one transaction's signer can't be recovered — exactly the input the prover's filtering exists to tolerate. It now decodes the list with the canonical `decode_transactions` and keeps unrecoverable transactions as **zero-signer entries**. This:
- preserves list ordering (anchor stays at index 0),
- makes the in-loop `signer == ZERO` skip **live** (it was dead code before), and
- matches the prover's tx-list filtering.

### C2 — Witness now uses the `parent + 1` environment
Execution was built from the canonical block's env (`executor_for_block`), which for Unzen sets `difficulty = header.difficulty()` (committed zk gas) and `expected_difficulty = Some(...)`. Replaying a *different* list under that env exposed the original block's zk-gas difficulty via the `DIFFICULTY` opcode and forced a difficulty mismatch for any non-original list. It now builds the env via `next_evm_env` + `context_for_next_block` (`difficulty = 0`, `expected_difficulty = None`), mirroring the prover's derived-block path.

### Drop the difficulty-skip flag
With `expected_difficulty = None` there is no mismatch to skip, so `skipZkGasDifficultyCheck`, the `TxListWitnessOptions` type, and the `options` RPC parameter are removed.

### Shared env builder (anti-drift)
`attributes_from_derived_block` moved from the `prover`-gated `derived_block` module into the non-gated `config` module, so the prover and the witness RPC share **one** `parent + 1` env builder and can't diverge. `decode_transactions` is now `pub` and reused by the RPC.

### Misc
- Revert the throwaway `docker-build.yml` feature-branch trigger back to `[main]`.
- Add a decode test for the unrecoverable-signature case; remove the now-dead options tests.

## Test plan
- `just fmt` — clean
- `just clippy` (`--all-features`, `-D warnings`) — clean
- `cargo nextest run -p alethia-reth-block -p alethia-reth-primitives -p alethia-reth-rpc --all-features` — 63 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)