### PR TITLE
fix(rpc): decode tx-list witness transactions leniently

### DIFF
--- a/crates/primitives/src/payload/builder.rs
+++ b/crates/primitives/src/payload/builder.rs
@@ -105,29 +105,16 @@ impl TaikoPayloadBuilderAttributes {
                 None
             }
             Some(tx_list_bytes) => {
-                // Legacy mode: decode and use provided transactions
-                let txs = decode_transactions(tx_list_bytes)
-                    .unwrap_or_else(|e| {
-                        // If we can't decode the given transactions bytes, we will mine an empty
-                        // block instead.
-                        debug!(
-                            target: "payload_builder",
-                            "Failed to decode transactions: {e}, bytes: {:?}, mining empty block",
-                            tx_list_bytes
-                        );
-                        Vec::new()
-                    })
-                    .into_iter()
-                    .filter_map(|tx| match tx.try_into_recovered() {
-                        Ok(recovered) => Some(recovered),
-                        Err(e) => {
-                            debug!(
-                                "Failed to recover transaction: {e}, skipping invalid transaction"
-                            );
-                            None
-                        }
-                    })
-                    .collect();
+                // Legacy mode: decode and recover the provided transactions, skipping any that
+                // fail signer recovery. If the list itself cannot be decoded, mine an empty block.
+                let txs = decode_recovered_transactions(tx_list_bytes).unwrap_or_else(|e| {
+                    debug!(
+                        target: "payload_builder",
+                        "Failed to decode transactions: {e}, bytes: {:?}, mining empty block",
+                        tx_list_bytes
+                    );
+                    Vec::new()
+                });
                 Some(txs)
             }
         };
@@ -245,6 +232,27 @@ pub fn payload_id_taiko(
 /// Decode RLP-encoded bytes into signed transactions.
 fn decode_transactions(bytes: &[u8]) -> Result<Vec<TransactionSigned>, alloy_rlp::Error> {
     Vec::<TransactionSigned>::decode(&mut &bytes[..])
+}
+
+/// Decode an RLP transaction list and recover each signer, dropping any transaction whose signer
+/// cannot be recovered.
+///
+/// This mirrors Taiko's lenient tx-list ingestion: a malformed top-level RLP list is reported as an
+/// error (so callers can decide whether to fall back, e.g. mine an empty block), while individual
+/// transactions that fail signer recovery are skipped rather than failing the whole list.
+pub fn decode_recovered_transactions(
+    bytes: &[u8],
+) -> Result<Vec<Recovered<TransactionSigned>>, alloy_rlp::Error> {
+    Ok(decode_transactions(bytes)?
+        .into_iter()
+        .filter_map(|tx| match tx.try_into_recovered() {
+            Ok(recovered) => Some(recovered),
+            Err(e) => {
+                debug!("Failed to recover transaction: {e}, skipping invalid transaction");
+                None
+            }
+        })
+        .collect())
 }
 
 #[cfg(all(test, feature = "net"))]

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -2,10 +2,10 @@
 
 use crate::proof_state::ProofHistoryStateProviderFactory;
 use alethia_reth_block::executor::{is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded};
+use alethia_reth_primitives::payload::builder::decode_recovered_transactions;
 use alloy_consensus::{BlockHeader, transaction::Recovered};
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::{Address, B256, Bytes};
-use alloy_rlp::Decodable;
+use alloy_primitives::{B256, Bytes};
 use alloy_rpc_types_debug::ExecutionWitness;
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
@@ -196,9 +196,6 @@ where
 
             for (idx, tx) in block.transactions_recovered().enumerate() {
                 let is_anchor_transaction = idx == 0;
-                if !is_anchor_transaction && tx.signer() == Address::ZERO {
-                    continue;
-                }
 
                 match block_executor.execute_transaction(tx) {
                     Ok(_) => {}
@@ -283,11 +280,15 @@ where
 }
 
 /// Decode an RLP transaction list and recover each transaction signer for EVM execution.
+///
+/// Uses the same lenient ingestion as the payload builder ([`decode_recovered_transactions`]):
+/// transactions whose signer cannot be recovered are skipped rather than failing the request, so
+/// the replayed witness matches what the node would have executed for the same tx list. A malformed
+/// top-level RLP list is still reported as an error.
 fn decode_recovered_tx_list(
     tx_list: Bytes,
 ) -> Result<Vec<Recovered<TransactionSigned>>, EthApiError> {
-    let mut tx_list = tx_list.as_ref();
-    Vec::<Recovered<TransactionSigned>>::decode(&mut tx_list)
+    decode_recovered_transactions(tx_list.as_ref())
         .map_err(|err| EthApiError::EvmCustom(format!("failed to decode tx list: {err}")))
 }
 
@@ -330,12 +331,39 @@ fn is_recoverable_tx_list_error(err: &BlockExecutionError, is_anchor_transaction
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::Bytes;
+    use alloy_consensus::{Signed, TxLegacy};
+    use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
+    use alloy_rlp::Encodable;
     use serde_json::json;
 
     #[test]
     fn decode_recovered_tx_list_accepts_empty_rlp_list() {
         let txs = decode_recovered_tx_list(Bytes::from_static(&[0xc0])).unwrap();
+
+        assert!(txs.is_empty());
+    }
+
+    #[test]
+    fn decode_recovered_tx_list_skips_unrecoverable_transactions() {
+        // A legacy transaction with `r = 0` has an unrecoverable signature. Previously this aborted
+        // the whole request; it must now be skipped, matching the payload builder's lenient tx-list
+        // ingestion so the replay reflects what the node would have executed.
+        let tx = TxLegacy {
+            chain_id: Some(1),
+            nonce: 0,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        };
+        let signature = Signature::new(U256::ZERO, U256::from(1u64), false);
+        let signed: TransactionSigned = Signed::new_unchecked(tx, signature, B256::ZERO).into();
+        let mut encoded = Vec::new();
+        vec![signed].encode(&mut encoded);
+
+        let txs = decode_recovered_tx_list(Bytes::from(encoded))
+            .expect("unrecoverable transactions are skipped, not fatal");
 
         assert!(txs.is_empty());
     }


### PR DESCRIPTION
Stacked on top of #189. Fixes the **Critical** review finding on that PR.

## Problem
`debug_executionWitnessForTxList` decodes the input with `Vec::<Recovered<TransactionSigned>>::decode`. That `Decodable` impl recovers the signer of **every** transaction and returns an error on the **first** unrecoverable signature — so a single bad-signature tx aborts the whole request.

Taiko tx lists legitimately contain transactions the proposer/prover filters out. The node's own build path ([`PayloadBuilder::try_new`](https://github.com/taikoxyz/alethia-reth/blob/feat/txlist-execution-witness/crates/primitives/src/payload/builder.rs), legacy mode) decodes `Vec<TransactionSigned>` and **skips** individually unrecoverable transactions via `filter_map(|tx| tx.try_into_recovered().ok())`. So the witness RPC errored on exactly the inputs it exists to debug, and the witness it returned could not match what the node actually executed — defeating the prover-parity goal.

## Fix
- Extract a shared, lenient decoder `decode_recovered_transactions` in the **primitives** crate (next to `decode_transactions`).
- Route **both** `PayloadBuilder::try_new` and the debug RPC through it — single source of truth for "decode a Taiko tx list into recovered transactions".
- Per-transaction recovery failures are **dropped**; a malformed **top-level** RLP list is still surfaced as an error, so each caller keeps its own fallback policy:
  - payload builder → mine an empty block (unchanged behavior),
  - debug RPC → return an error (useful for a debug tool).

## ⚠️ Point for review
Because unrecoverable txs are now dropped at decode time, the replay loop's `if !is_anchor_transaction && tx.signer() == Address::ZERO { continue; }` guard became **unreachable** (decode can no longer yield a zero signer), so I **removed it**. The witness is identical either way. If you'd rather keep it as a defensive no-op for structural parity with the prover's `execute_block`, say so and I'll restore it with a comment.

## Test plan
- `cargo test -p alethia-reth-rpc debug::tests` — 5 pass, including new `decode_recovered_tx_list_skips_unrecoverable_transactions` (an `r = 0` / unrecoverable-signature tx is skipped, not fatal).
- `cargo test -p alethia-reth-primitives --all-features` — 10 pass, incl. `test_taiko_payload_builder_attributes_legacy_mode` (refactor is behavior-preserving).
- `cargo clippy -p alethia-reth-primitives -p alethia-reth-rpc -p alethia-reth-node --all-targets --all-features -- -D warnings` — clean.
- `just fmt` — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)