### PR TITLE
feat(rpc): bound tx-list witness input by block DA limit

### DIFF
--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -88,6 +88,25 @@ pub fn is_zk_gas_difficulty_mismatch(error: &BlockExecutionError) -> bool {
     }
 }
 
+/// Returns `true` when `error` is the kind of failure that prover-style execution tolerates for a
+/// non-anchor transaction by skipping it: zk gas truncation, an invalid transaction, or a gas limit
+/// exceeding the block's remaining gas.
+///
+/// This is the single definition of the recoverable error set, shared by the prover executor's
+/// `try_execute_filtered` and the tx-list witness debug RPC, so the two cannot drift when a new
+/// recoverable variant is added. Callers remain responsible for never applying it to the anchor
+/// transaction, which must always be fatal.
+pub fn is_recoverable_non_anchor_tx_error(error: &BlockExecutionError) -> bool {
+    is_zk_gas_limit_exceeded(error) ||
+        matches!(
+            error,
+            BlockExecutionError::Validation(
+                BlockValidationError::InvalidTx { .. } |
+                    BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. }
+            )
+        )
+}
+
 /// Block executor for Taiko network.
 pub struct TaikoBlockExecutor<'a, Evm, Spec, R: ReceiptBuilder> {
     /// Reference to the specification object.
@@ -260,13 +279,11 @@ where
     ) -> Result<bool, BlockExecutionError> {
         match self.execute_transaction(tx) {
             Ok(_) => Ok(true),
-            // We don't allow anchor transaction to be discarded even if it exceeds the zk gas
-            // limit, this should never happen in practice.
-            Err(err) if is_zk_gas_limit_exceeded(&err) && !is_anchor_transaction => Ok(false),
-            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx { .. })) |
-            Err(BlockExecutionError::Validation(
-                BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. },
-            )) if !is_anchor_transaction => Ok(false),
+            // We don't allow the anchor transaction to be discarded even if it would otherwise be a
+            // recoverable failure; this should never happen in practice.
+            Err(err) if !is_anchor_transaction && is_recoverable_non_anchor_tx_error(&err) => {
+                Ok(false)
+            }
             Err(err) => Err(err),
         }
     }
@@ -729,6 +746,24 @@ mod test {
         };
         assert!(is_zk_gas_difficulty_mismatch(&err));
         assert!(err.to_string().contains("difficulty"));
+    }
+
+    #[test]
+    fn is_recoverable_non_anchor_tx_error_classifies_recoverable_set() {
+        let gas_err = BlockExecutionError::Validation(
+            BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                transaction_gas_limit: 2,
+                block_available_gas: 1,
+            },
+        );
+        assert!(is_recoverable_non_anchor_tx_error(&gas_err));
+
+        // A zk gas difficulty mismatch is fatal, not a recoverable per-transaction failure.
+        let difficulty_err = BlockExecutionError::other(ZkGasDifficultyMismatch {
+            expected: U256::from(1u64),
+            got: U256::from(2u64),
+        });
+        assert!(!is_recoverable_non_anchor_tx_error(&difficulty_err));
     }
 
     #[test]

--- a/crates/block/src/tx_selection/limits.rs
+++ b/crates/block/src/tx_selection/limits.rs
@@ -125,6 +125,22 @@ fn adjusted_estimate(estimated_after: u64, state: &DaRatioState) -> u64 {
         as u64
 }
 
+/// Returns the zlib-compressed byte length of `rlp_bytes` using the protocol's compression
+/// settings, or `u64::MAX` if compression fails.
+///
+/// This is the single definition of "compressed tx-list size" shared by transaction selection
+/// (DA limiting) and the debug witness RPC, so the two cannot drift apart.
+pub fn zlib_compressed_len(rlp_bytes: &[u8]) -> u64 {
+    let mut encoder = ZlibEncoder::new(Vec::new(), zlib_compression());
+    if encoder.write_all(rlp_bytes).is_err() {
+        return u64::MAX;
+    }
+    match encoder.finish() {
+        Ok(data) => u64::try_from(data.len()).unwrap_or(u64::MAX),
+        Err(_) => u64::MAX,
+    }
+}
+
 /// Returns the zlib-compressed byte size for the list plus the candidate.
 fn zlib_tx_list_size_bytes(list: &ExecutedTxList, candidate: &Recovered<TransactionSigned>) -> u64 {
     let mut txs: Vec<&TransactionSigned> = Vec::with_capacity(list.transactions.len() + 1);
@@ -135,15 +151,7 @@ fn zlib_tx_list_size_bytes(list: &ExecutedTxList, candidate: &Recovered<Transact
         Vec::with_capacity(list_length::<&TransactionSigned, TransactionSigned>(&txs));
     encode_list::<&TransactionSigned, TransactionSigned>(&txs, &mut rlp_bytes);
 
-    let mut encoder = ZlibEncoder::new(Vec::new(), zlib_compression());
-    if encoder.write_all(&rlp_bytes).is_err() {
-        return u64::MAX;
-    }
-    let compressed_len = match encoder.finish() {
-        Ok(data) => data.len(),
-        Err(_) => return u64::MAX,
-    };
-    u64::try_from(compressed_len).unwrap_or(u64::MAX)
+    zlib_compressed_len(&rlp_bytes)
 }
 
 /// Returns the DA size that exceeded the limit, if any (estimated or actual).

--- a/crates/block/src/tx_selection/mod.rs
+++ b/crates/block/src/tx_selection/mod.rs
@@ -26,6 +26,8 @@ use crate::executor::is_zk_gas_limit_exceeded;
 /// DA-limit checking and adaptive zlib sizing helpers.
 mod limits;
 
+pub use limits::zlib_compressed_len;
+
 /// Returns the appropriate pool error for the exceeded limit.
 fn limit_exceeded_error(
     gas_limit: u64,

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -2,7 +2,9 @@
 
 use crate::proof_state::ProofHistoryStateProviderFactory;
 use alethia_reth_block::{
-    executor::{is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded},
+    executor::{
+        is_recoverable_non_anchor_tx_error, is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded,
+    },
     tx_selection::zlib_compressed_len,
 };
 use alethia_reth_primitives::payload::builder::decode_recovered_transactions;
@@ -16,7 +18,7 @@ use reth_ethereum::{EthPrimitives, TransactionSigned};
 use reth_ethereum_primitives::Block;
 use reth_evm::{
     ConfigureEvm,
-    execute::{BlockExecutionError, BlockExecutor, BlockValidationError, Executor},
+    execute::{BlockExecutionError, BlockExecutor, Executor},
 };
 use reth_optimism_trie::{OpProofsStorage, OpProofsStore};
 use reth_primitives_traits::RecoveredBlock;
@@ -360,19 +362,12 @@ fn block_with_tx_list(
 }
 
 /// Return whether a transaction-list replay error should be tolerated for prover witness parity.
+///
+/// Anchor (index 0) failures are always fatal; non-anchor failures defer to the shared
+/// [`is_recoverable_non_anchor_tx_error`] classifier so the recoverable error set stays in sync
+/// with the prover executor and cannot drift.
 fn is_recoverable_tx_list_error(err: &BlockExecutionError, is_anchor_transaction: bool) -> bool {
-    if is_anchor_transaction {
-        return false;
-    }
-
-    is_zk_gas_limit_exceeded(err) ||
-        matches!(
-            err,
-            BlockExecutionError::Validation(
-                BlockValidationError::InvalidTx { .. } |
-                    BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. }
-            )
-        )
+    !is_anchor_transaction && is_recoverable_non_anchor_tx_error(err)
 }
 
 #[cfg(test)]
@@ -381,6 +376,7 @@ mod tests {
     use alloy_consensus::{Signed, TxLegacy};
     use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
     use alloy_rlp::Encodable;
+    use reth_evm::execute::BlockValidationError;
     use serde_json::json;
 
     #[test]

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -1,10 +1,13 @@
 //! Proof-history backed overrides for selected `debug_` RPC methods.
 
 use crate::proof_state::ProofHistoryStateProviderFactory;
-use alethia_reth_block::executor::{is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded};
+use alethia_reth_block::{
+    executor::{is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded},
+    tx_selection::zlib_compressed_len,
+};
 use alethia_reth_primitives::payload::builder::decode_recovered_transactions;
 use alloy_consensus::{BlockHeader, transaction::Recovered};
-use alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_eips::{BlockId, BlockNumberOrTag, eip4844::BYTES_PER_BLOB};
 use alloy_primitives::{B256, Bytes};
 use alloy_rpc_types_debug::ExecutionWitness;
 use async_trait::async_trait;
@@ -30,6 +33,20 @@ use tokio::sync::Semaphore;
 
 /// Maximum number of concurrent proof-history witness requests.
 const MAX_CONCURRENT_WITNESS_REQUESTS: usize = 3;
+
+/// Block-level tx-list DA limit: the zlib-compressed transaction list must fit in one blob.
+///
+/// This mirrors the limit the proposer and [`alethia_reth_block::tx_selection`] enforce per block
+/// (`max_da_bytes_per_list`), so a tx list that would never have been a valid block is rejected.
+const MAX_TX_LIST_COMPRESSED_BYTES: usize = BYTES_PER_BLOB;
+
+/// Generous upper bound on the raw (decompressed) tx-list bytes accepted before compression.
+///
+/// This is not a protocol limit; it only bounds the work done by the compressed-size check so an
+/// oversized request (the auth RPC server accepts bodies up to 128 MiB) cannot be handed to zlib.
+/// A valid single block's decompressed tx list is far smaller — a 45M-gas block holds at most
+/// ~11 MiB of zero-byte calldata — so this never rejects a legitimately proposed block.
+const MAX_TX_LIST_RAW_BYTES: usize = 16 * 1024 * 1024;
 
 /// RPC server trait for Taiko proof-history backed `debug_` witness methods.
 #[cfg_attr(not(test), rpc(server, namespace = "debug"))]
@@ -281,15 +298,45 @@ where
 
 /// Decode an RLP transaction list and recover each transaction signer for EVM execution.
 ///
-/// Uses the same lenient ingestion as the payload builder ([`decode_recovered_transactions`]):
-/// transactions whose signer cannot be recovered are skipped rather than failing the request, so
-/// the replayed witness matches what the node would have executed for the same tx list. A malformed
-/// top-level RLP list is still reported as an error.
+/// Rejects oversized inputs (see [`check_tx_list_size`]) before decoding. Uses the same lenient
+/// ingestion as the payload builder ([`decode_recovered_transactions`]): transactions whose signer
+/// cannot be recovered are skipped rather than failing the request, so the replayed witness matches
+/// what the node would have executed for the same tx list. A malformed top-level RLP list is still
+/// reported as an error.
 fn decode_recovered_tx_list(
     tx_list: Bytes,
 ) -> Result<Vec<Recovered<TransactionSigned>>, EthApiError> {
-    decode_recovered_transactions(tx_list.as_ref())
+    let raw = tx_list.as_ref();
+    check_tx_list_size(raw, MAX_TX_LIST_RAW_BYTES, MAX_TX_LIST_COMPRESSED_BYTES)?;
+    decode_recovered_transactions(raw)
         .map_err(|err| EthApiError::EvmCustom(format!("failed to decode tx list: {err}")))
+}
+
+/// Reject a tx list that is too large to be a valid block-level transaction list.
+///
+/// `raw` is the decompressed RLP tx list. The cheap `max_raw` byte check runs first to bound the
+/// work of the compression check; the authoritative limit is `max_compressed`, the zlib-compressed
+/// size that must fit the block DA budget (one blob).
+fn check_tx_list_size(
+    raw: &[u8],
+    max_raw: usize,
+    max_compressed: usize,
+) -> Result<(), EthApiError> {
+    if raw.len() > max_raw {
+        return Err(EthApiError::EvmCustom(format!(
+            "tx list size {} exceeds raw limit {max_raw}",
+            raw.len(),
+        )));
+    }
+
+    let compressed = zlib_compressed_len(raw);
+    if compressed > max_compressed as u64 {
+        return Err(EthApiError::EvmCustom(format!(
+            "tx list compressed size {compressed} exceeds block DA limit {max_compressed}",
+        )));
+    }
+
+    Ok(())
 }
 
 /// Replace a canonical block's transactions with the explicit replay transaction list.
@@ -394,5 +441,33 @@ mod tests {
             serde_json::from_value(json!({ "skipZkGasDifficultyCheck": true })).unwrap();
 
         assert!(options.skip_zk_gas_difficulty_check);
+    }
+
+    #[test]
+    fn check_tx_list_size_accepts_list_within_limits() {
+        assert!(check_tx_list_size(&[1, 2, 3], 1024, 1024).is_ok());
+    }
+
+    #[test]
+    fn check_tx_list_size_rejects_raw_over_limit() {
+        // The raw guard fires on length alone, before any compression.
+        let err = check_tx_list_size(&[0u8; 10], 4, usize::MAX)
+            .expect_err("raw byte limit must be enforced");
+
+        assert!(err.to_string().contains("raw limit"), "{err}");
+    }
+
+    #[test]
+    fn check_tx_list_size_rejects_compressed_over_limit() {
+        let raw = [7u8; 64];
+        let actual = zlib_compressed_len(&raw);
+        assert!(actual > 0);
+
+        // One byte below the actual compressed size is rejected; exactly at the size is accepted.
+        let err = check_tx_list_size(&raw, raw.len(), (actual - 1) as usize)
+            .expect_err("compressed size limit must be enforced");
+        assert!(err.to_string().contains("compressed size"), "{err}");
+
+        assert!(check_tx_list_size(&raw, raw.len(), actual as usize).is_ok());
     }
 }


### PR DESCRIPTION
Stacked on top of #189 (after #197). Hardens `debug_executionWitnessForTxList` against oversized inputs.

## Problem
The RPC accepted an arbitrarily large `tx_list`. The auth/engine RPC server accepts request bodies up to **128 MiB**, and decoding + per-tx ECDSA recovery of such an input is unbounded work — a cheap DoS vector on a debug endpoint.

## What I checked in taiko-client-rs
- **No per-block transaction *count* limit exists.** Tx count is bounded by `MAX_BLOCK_GAS_LIMIT` (45M) and the byte cap below. (The `768` = `UNZEN_DERIVATION_SOURCE_MAX_BLOCKS` is *blocks per proposal*, not txs.)
- **The block-level tx-list limit is a byte limit on the zlib-*compressed* size: `BYTES_PER_BLOB` (131072).** The proposer requests `max_bytes_per_tx_list = PROPOSAL_MAX_BLOB_BYTES`, and alethia-reth's own `tx_selection` already enforces `max_da_bytes_per_list = BYTES_PER_BLOB` during block building.

## Fix
Reject, before decoding, any tx list that could never have been a valid block:
- **Authoritative limit** — zlib-compressed size ≤ `BYTES_PER_BLOB`, mirroring `tx_selection`/the proposer. The zlib sizing primitive is extracted as `alethia_reth_block::tx_selection::zlib_compressed_len` and shared by both call sites so they can't drift.
- **Raw pre-guard** — `tx_list.len()` ≤ 16 MiB, checked first so an oversized body is never handed to the compressor. Not a protocol limit; just bounds the compression work. 16 MiB comfortably exceeds the largest valid single-block decompressed tx list (a 45M-gas block holds at most ~11 MiB of zero-calldata), so it never false-rejects a real block.
- **No tx-count cap** — none exists in the protocol; the compressed-byte limit is the right model.

The RPC targets the Unzen-era (blob) limit, per its activation context.

## Test plan
- `cargo test -p alethia-reth-rpc debug::tests` — 8 pass, incl. new `check_tx_list_size_*` boundary tests (within-limit ok, over-raw rejected, over-compressed rejected; the compressed case asserts against the measured zlib length so it's entropy-independent).
- `cargo test -p alethia-reth-block tx_selection` — passes, incl. `zlib_guard_rejects_when_actual_exceeds_limit` (exercises the refactored `zlib_tx_list_size_bytes` → `zlib_compressed_len`).
- `cargo clippy -p alethia-reth-block -p alethia-reth-rpc -p alethia-reth-node --all-targets --all-features -- -D warnings` — clean.
- `just fmt` — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)