### PR TITLE
feat(evm): key zk-gas precompile multipliers by full address (#200)

### DIFF
--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -139,9 +139,7 @@ where
         ContextError<<<Self::Context as ContextTr>::Db as Database>::Error>,
     > {
         let precompile_metering = match &frame_input.frame_input {
-            FrameInput::Call(inputs) => {
-                Some((inputs.gas_limit, inputs.bytecode_address.as_slice()[19]))
-            }
+            FrameInput::Call(inputs) => Some((inputs.gas_limit, inputs.bytecode_address)),
             FrameInput::Create(_) | FrameInput::Empty => None,
         };
 
@@ -161,12 +159,12 @@ where
 
         if let ItemOrResult::Result(FrameResult::Call(outcome)) = &result &&
             outcome.was_precompile_called &&
-            let Some((gas_limit, address_low_byte)) = precompile_metering &&
+            let Some((gas_limit, bytecode_address)) = precompile_metering &&
             let Some(meter) = self.zk_gas_meter.as_mut()
         {
             let gas_used = gas_limit.saturating_sub(outcome.result.gas.remaining());
             if let Err(ZkGasOutcome::LimitExceeded) =
-                meter.charge_precompile(address_low_byte, gas_used)
+                meter.charge_precompile(&bytecode_address, gas_used)
             {
                 set_custom_error(&mut self.inner.ctx);
             }

--- a/crates/evm/src/zk_gas/adapter.rs
+++ b/crates/evm/src/zk_gas/adapter.rs
@@ -189,12 +189,11 @@ where
                 return;
             }
             if was_precompile_called {
-                // Precompile usage is charged separately from the CALL opcode itself using the
-                // low-byte address lookup in the precompile multiplier table.
+                // Precompile usage is charged separately from the CALL opcode itself, keyed by the
+                // full precompile address.
                 let gas_used = inputs.gas_limit.saturating_sub(outcome.result.gas.remaining());
-                let address_low_byte = inputs.bytecode_address.as_slice()[19];
                 if let Err(ZkGasOutcome::LimitExceeded) =
-                    metering.meter.charge_precompile(address_low_byte, gas_used)
+                    metering.meter.charge_precompile(&inputs.bytecode_address, gas_used)
                 {
                     set_custom_error(context);
                 }

--- a/crates/evm/src/zk_gas/meter.rs
+++ b/crates/evm/src/zk_gas/meter.rs
@@ -1,5 +1,7 @@
 //! Checked zk gas accounting for a single metered block execution.
 
+use alloy_primitives::Address;
+
 use super::schedule::ZkGasSchedule;
 
 /// Outcome used when zk gas charging exceeds the active block budget.
@@ -85,11 +87,10 @@ impl<'a> ZkGasMeter<'a> {
     #[inline(always)]
     pub fn charge_precompile(
         &mut self,
-        address_low_byte: u8,
+        address: &Address,
         gas_used: u64,
     ) -> Result<(), ZkGasOutcome> {
-        let multiplier =
-            u64::from(self.schedule.precompile_multipliers[usize::from(address_low_byte)]);
+        let multiplier = u64::from(self.schedule.precompile_multiplier(address));
         let charge = gas_used.checked_mul(multiplier).ok_or(ZkGasOutcome::LimitExceeded)?;
         self.charge_amount(charge)
     }

--- a/crates/evm/src/zk_gas/schedule.rs
+++ b/crates/evm/src/zk_gas/schedule.rs
@@ -1,10 +1,15 @@
 //! Shared zk gas schedule types and fork selection helpers.
 
+use alloy_primitives::Address;
+
 use crate::spec::TaikoSpecId;
 
 use super::unzen::{MASAYA_UNZEN_ZK_GAS_SCHEDULE, UNZEN_ZK_GAS_SCHEDULE};
 
 pub use alethia_reth_chainspec::TAIKO_MASAYA_CHAIN_ID;
+
+/// Fail-safe multiplier applied to any precompile absent from a schedule's table.
+pub const FAILSAFE_MULTIPLIER: u16 = u16::MAX;
 
 /// Fixed raw-gas estimates for spawn opcodes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -34,10 +39,21 @@ pub struct ZkGasSchedule {
     pub tx_intrinsic_zk_gas: u64,
     /// Per-opcode proving-cost multipliers indexed by opcode byte.
     pub opcode_multipliers: [u16; 256],
-    /// Per-precompile proving-cost multipliers indexed by low-byte address.
-    pub precompile_multipliers: [u16; 256],
+    /// Per-precompile proving-cost multipliers keyed by full 20-byte precompile address.
+    pub precompile_multipliers: &'static [(Address, u16)],
     /// Fixed raw-gas estimates for spawn opcodes.
     pub spawn_estimates: SpawnEstimates,
+}
+
+impl ZkGasSchedule {
+    /// Returns the proving-cost multiplier for `address`, or [`FAILSAFE_MULTIPLIER`] when the
+    /// precompile is not listed in this schedule.
+    pub fn precompile_multiplier(&self, address: &Address) -> u16 {
+        self.precompile_multipliers
+            .iter()
+            .find(|(addr, _)| addr == address)
+            .map_or(FAILSAFE_MULTIPLIER, |&(_, multiplier)| multiplier)
+    }
 }
 
 /// Returns the consensus zk gas schedule for the active Taiko fork on the given chain, when

--- a/crates/evm/src/zk_gas/schedule.rs
+++ b/crates/evm/src/zk_gas/schedule.rs
@@ -48,6 +48,7 @@ pub struct ZkGasSchedule {
 impl ZkGasSchedule {
     /// Returns the proving-cost multiplier for `address`, or [`FAILSAFE_MULTIPLIER`] when the
     /// precompile is not listed in this schedule.
+    #[inline]
     pub fn precompile_multiplier(&self, address: &Address) -> u16 {
         self.precompile_multipliers
             .iter()

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -599,4 +599,104 @@ fn high_range_precompile_collision_resolves_to_failsafe_not_canonical() {
 
     assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&ecrecover), 81);
     assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&collider), FAILSAFE_MULTIPLIER);
+
+    // A second collider on a different low byte (identity, 0x04) — confirms the fix is not a
+    // one-off carve-out for 0x01: every canonical precompile had a potential high-range collider.
+    let identity_collider = address!("0x1670000000000000000000000000000000010004");
+    assert_eq!(
+        UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&identity_collider),
+        FAILSAFE_MULTIPLIER
+    );
+    assert_eq!(
+        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&identity_collider),
+        FAILSAFE_MULTIPLIER
+    );
+}
+
+#[test]
+fn full_address_lookup_preserves_canonical_precompile_multipliers() {
+    // Every canonical precompile (0x01..=0x13) keeps its exact pre-fix multiplier, so finalized
+    // blocks stay byte-identical — including Masaya, whose finalized block zk-gas total is
+    // committed to the header `difficulty` field.
+    let default_expected: [(u8, u16); 17] = [
+        (0x01, 47),
+        (0x02, 10),
+        (0x03, 4),
+        (0x04, 6),
+        (0x05, 923),
+        (0x06, 19),
+        (0x07, 58),
+        (0x08, 54),
+        (0x09, 166),
+        (0x0a, 859),
+        (0x0b, 201),
+        (0x0c, 93),
+        (0x0e, 230),
+        (0x0f, 71),
+        (0x11, 365),
+        (0x12, 246),
+        (0x13, 208),
+    ];
+    for (byte, multiplier) in default_expected {
+        assert_eq!(
+            UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(byte)),
+            multiplier,
+            "default precompile {byte:#04x}"
+        );
+    }
+
+    let masaya_expected: [(u8, u16); 17] = [
+        (0x01, 81),
+        (0x02, 10),
+        (0x03, 3),
+        (0x04, 2),
+        (0x05, 1363),
+        (0x06, 38),
+        (0x07, 87),
+        (0x08, 82),
+        (0x09, 243),
+        (0x0a, 398),
+        (0x0b, 112),
+        (0x0c, 52),
+        (0x0e, 111),
+        (0x0f, 39),
+        (0x11, 134),
+        (0x12, 159),
+        (0x13, 112),
+    ];
+    for (byte, multiplier) in masaya_expected {
+        assert_eq!(
+            MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(byte)),
+            multiplier,
+            "masaya precompile {byte:#04x}"
+        );
+    }
+
+    // Gaps in the canonical range (0x0d, 0x10 are unassigned in EIP-2537) and out-of-range bytes
+    // fall back to the fail-safe on both schedules.
+    for byte in [0x0d_u8, 0x10, 0x14] {
+        assert_eq!(
+            UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(byte)),
+            FAILSAFE_MULTIPLIER,
+            "default: unlisted byte {byte:#04x}"
+        );
+        assert_eq!(
+            MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(byte)),
+            FAILSAFE_MULTIPLIER,
+            "masaya: unlisted byte {byte:#04x}"
+        );
+    }
+}
+
+#[test]
+fn precompile_tables_have_no_duplicate_addresses() {
+    for (label, table) in [
+        ("default", UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers),
+        ("masaya", MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers),
+    ] {
+        let mut seen = std::collections::HashSet::new();
+        for (addr, _) in table {
+            assert!(seen.insert(addr), "{label} precompile table has duplicate address {addr}");
+        }
+    }
 }

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -594,22 +594,40 @@ fn high_range_precompile_collision_resolves_to_failsafe_not_canonical() {
     let collider = address!("0x1670000000000000000000000000000000010001");
     let ecrecover = Address::with_last_byte(0x01);
 
-    assert_eq!(UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&ecrecover), 47);
-    assert_eq!(UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&collider), FAILSAFE_MULTIPLIER);
+    assert_eq!(
+        UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&ecrecover),
+        47,
+        "canonical ecrecover should keep its multiplier"
+    );
+    assert_eq!(
+        UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&collider),
+        FAILSAFE_MULTIPLIER,
+        "high-range collider should resolve to the fail-safe, not ecrecover's multiplier"
+    );
 
-    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&ecrecover), 81);
-    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&collider), FAILSAFE_MULTIPLIER);
+    assert_eq!(
+        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&ecrecover),
+        81,
+        "canonical ecrecover should keep its frozen Masaya multiplier"
+    );
+    assert_eq!(
+        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&collider),
+        FAILSAFE_MULTIPLIER,
+        "high-range collider should resolve to the fail-safe on Masaya too"
+    );
 
     // A second collider on a different low byte (identity, 0x04) — confirms the fix is not a
     // one-off carve-out for 0x01: every canonical precompile had a potential high-range collider.
     let identity_collider = address!("0x1670000000000000000000000000000000010004");
     assert_eq!(
         UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&identity_collider),
-        FAILSAFE_MULTIPLIER
+        FAILSAFE_MULTIPLIER,
+        "identity collider should resolve to the fail-safe"
     );
     assert_eq!(
         MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&identity_collider),
-        FAILSAFE_MULTIPLIER
+        FAILSAFE_MULTIPLIER,
+        "identity collider should resolve to the fail-safe on Masaya"
     );
 }
 

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -1,6 +1,7 @@
 //! Tests for fork-scoped zk gas schedule selection.
 
 use alloy_evm::{Evm as AlloyEvm, EvmEnv, EvmFactory};
+use alloy_primitives::{Address, address};
 use reth_revm::{
     Inspector,
     context::TxEnv,
@@ -21,7 +22,7 @@ use crate::{factory::TaikoEvmFactory, spec::TaikoSpecId};
 use super::{
     adapter::ZK_GAS_LIMIT_ERR,
     meter::{ZkGasMeter, ZkGasOutcome},
-    schedule::{TAIKO_MASAYA_CHAIN_ID, schedule_for},
+    schedule::{FAILSAFE_MULTIPLIER, TAIKO_MASAYA_CHAIN_ID, schedule_for},
     unzen::{
         MASAYA_BLOCK_ZK_GAS_LIMIT, MASAYA_TX_INTRINSIC_ZK_GAS, MASAYA_UNZEN_ZK_GAS_SCHEDULE,
         TX_INTRINSIC_ZK_GAS, UNZEN_ZK_GAS_SCHEDULE,
@@ -71,10 +72,10 @@ fn unzen_schedule_uses_spec_opcode_and_precompile_multipliers() {
     assert_eq!(schedule.opcode_multipliers[0xfe], 0); // invalid (terminal)
     assert_eq!(schedule.opcode_multipliers[0xac], u16::MAX); // unlisted -> failsafe
 
-    assert_eq!(schedule.precompile_multipliers[0x05], 923); // modexp
-    assert_eq!(schedule.precompile_multipliers[0x01], 47); // ecrecover
-    assert_eq!(schedule.precompile_multipliers[0x04], 6); // identity
-    assert_eq!(schedule.precompile_multipliers[0x14], u16::MAX); // unlisted -> failsafe
+    assert_eq!(schedule.precompile_multiplier(&Address::with_last_byte(0x05)), 923); // modexp
+    assert_eq!(schedule.precompile_multiplier(&Address::with_last_byte(0x01)), 47); // ecrecover
+    assert_eq!(schedule.precompile_multiplier(&Address::with_last_byte(0x04)), 6); // identity
+    assert_eq!(schedule.precompile_multiplier(&Address::with_last_byte(0x14)), u16::MAX); // failsafe
 }
 
 #[test]
@@ -127,8 +128,8 @@ fn masaya_unzen_schedule_freezes_pre_recalibration_multipliers() {
         MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0x20]
     );
     assert_ne!(
-        UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers[0x05],
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers[0x05]
+        UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(0x05)),
+        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(0x05))
     );
     // Spawn estimates were not recalibrated, so they remain identical across networks.
     assert_eq!(UNZEN_ZK_GAS_SCHEDULE.spawn_estimates, MASAYA_UNZEN_ZK_GAS_SCHEDULE.spawn_estimates);
@@ -141,10 +142,22 @@ fn masaya_unzen_schedule_pins_spec_opcode_and_precompile_multipliers() {
     assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0xfe], 0);
     assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0xac], u16::MAX);
 
-    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers[0x05], 1363);
-    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers[0x01], 81);
-    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers[0x04], 2);
-    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers[0x14], u16::MAX);
+    assert_eq!(
+        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(0x05)),
+        1363
+    );
+    assert_eq!(
+        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(0x01)),
+        81
+    );
+    assert_eq!(
+        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(0x04)),
+        2
+    );
+    assert_eq!(
+        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(0x14)),
+        u16::MAX
+    );
 }
 
 #[test]
@@ -210,9 +223,13 @@ fn meter_treats_opcode_multiplication_overflow_as_limit_exceeded() {
 fn meter_treats_precompile_multiplication_overflow_as_limit_exceeded() {
     let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
-    let raw_gas = (u64::MAX / u64::from(schedule.precompile_multipliers[0x01])) + 1;
+    let raw_gas =
+        (u64::MAX / u64::from(schedule.precompile_multiplier(&Address::with_last_byte(0x01)))) + 1;
 
-    assert!(matches!(meter.charge_precompile(0x01, raw_gas), Err(ZkGasOutcome::LimitExceeded)));
+    assert!(matches!(
+        meter.charge_precompile(&Address::with_last_byte(0x01), raw_gas),
+        Err(ZkGasOutcome::LimitExceeded)
+    ));
 }
 
 #[test]
@@ -261,7 +278,7 @@ fn meter_returns_limit_exceeded_for_precompile_over_block_budget() {
     let mut meter = ZkGasMeter::new(schedule);
 
     assert!(matches!(
-        meter.charge_precompile(0x01, schedule.block_limit),
+        meter.charge_precompile(&Address::with_last_byte(0x01), schedule.block_limit),
         Err(ZkGasOutcome::LimitExceeded)
     ));
 }
@@ -322,7 +339,8 @@ fn unzen_adapter_uses_spawn_estimate_for_precompile_dispatch() {
     let precompile_gas_used = probe.precompile_gas_used.expect("precompile gas recorded");
 
     let expected = probe.step_costs.iter().fold(
-        u64::from(schedule.precompile_multipliers[0x04]) * precompile_gas_used,
+        u64::from(schedule.precompile_multiplier(&Address::with_last_byte(0x04))) *
+            precompile_gas_used,
         |acc, (opcode, step_gas)| {
             let raw_gas = if *opcode == opcode::STATICCALL {
                 schedule.spawn_estimates.staticcall
@@ -333,7 +351,8 @@ fn unzen_adapter_uses_spawn_estimate_for_precompile_dispatch() {
         },
     );
     let naive_expected = probe.step_costs.iter().fold(
-        u64::from(schedule.precompile_multipliers[0x04]) * precompile_gas_used,
+        u64::from(schedule.precompile_multiplier(&Address::with_last_byte(0x04))) *
+            precompile_gas_used,
         |acc, (opcode, step_gas)| {
             acc + (*step_gas * u64::from(schedule.opcode_multipliers[*opcode as usize]))
         },
@@ -564,4 +583,20 @@ fn simple_arithmetic_bytecode() -> Bytecode {
         opcode::ADD,
         opcode::STOP,
     ]))
+}
+
+#[test]
+fn high_range_precompile_collision_resolves_to_failsafe_not_canonical() {
+    // An `L1Sload`-style address whose low byte (0x01) collides with `ecrecover` but whose upper
+    // bytes differ. Under the old low-byte keying this was charged `ecrecover`'s multiplier; with
+    // full-address keying it must fall back to the fail-safe, since no such precompile exists in
+    // the Unzen fork.
+    let collider = address!("0x1670000000000000000000000000000000010001");
+    let ecrecover = Address::with_last_byte(0x01);
+
+    assert_eq!(UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&ecrecover), 47);
+    assert_eq!(UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&collider), FAILSAFE_MULTIPLIER);
+
+    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&ecrecover), 81);
+    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&collider), FAILSAFE_MULTIPLIER);
 }

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -7,7 +7,9 @@
 //! Source:
 //! <https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/zk_gas_spec.md>
 
-use super::schedule::{SpawnEstimates, ZkGasSchedule};
+use alloy_primitives::Address;
+
+use super::schedule::{FAILSAFE_MULTIPLIER, SpawnEstimates, ZkGasSchedule};
 
 /// Maximum zk gas permitted within a single Unzen block on Devnet, Hoodi, and Mainnet.
 pub const BLOCK_ZK_GAS_LIMIT: u64 = 100_000_000;
@@ -28,9 +30,6 @@ pub const TX_INTRINSIC_ZK_GAS: u64 = 243_000;
 /// blocks (their `difficulty` header equals the finalized block zk gas).
 pub const MASAYA_TX_INTRINSIC_ZK_GAS: u64 = 0;
 
-/// Fail-safe multiplier used for any opcode or precompile missing from the Unzen table.
-const FAILSAFE_MULTIPLIER: u16 = u16::MAX;
-
 /// Builds an Unzen-shaped zk gas schedule from the requested block limit, per-transaction
 /// intrinsic charge, and opcode/precompile multiplier tables. Spawn estimates are identical
 /// across all networks.
@@ -38,7 +37,7 @@ const fn unzen_schedule_with(
     block_limit: u64,
     tx_intrinsic_zk_gas: u64,
     opcode_multipliers: [u16; 256],
-    precompile_multipliers: [u16; 256],
+    precompile_multipliers: &'static [(Address, u16)],
 ) -> ZkGasSchedule {
     ZkGasSchedule {
         block_limit,
@@ -62,7 +61,7 @@ pub static UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = unzen_schedule_with(
     BLOCK_ZK_GAS_LIMIT,
     TX_INTRINSIC_ZK_GAS,
     unzen_opcode_multipliers(),
-    unzen_precompile_multipliers(),
+    UNZEN_PRECOMPILE_MULTIPLIERS,
 );
 
 /// Unzen zk gas schedule used by the Taiko Masaya network: a 10× higher block budget, a zero
@@ -72,7 +71,7 @@ pub static MASAYA_UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = unzen_schedule_with(
     MASAYA_BLOCK_ZK_GAS_LIMIT,
     MASAYA_TX_INTRINSIC_ZK_GAS,
     masaya_unzen_opcode_multipliers(),
-    masaya_unzen_precompile_multipliers(),
+    MASAYA_UNZEN_PRECOMPILE_MULTIPLIERS,
 );
 
 /// Returns the frozen Masaya Unzen opcode multiplier table, pinned at the pre-recalibration values.
@@ -234,31 +233,50 @@ const fn masaya_unzen_opcode_multipliers() -> [u16; 256] {
     array
 }
 
-/// Returns the frozen Masaya Unzen precompile multiplier table, pinned at the pre-recalibration
-/// values.
-///
-/// Frozen for the same consensus reason as [`masaya_unzen_opcode_multipliers`].
-const fn masaya_unzen_precompile_multipliers() -> [u16; 256] {
-    let mut array = [FAILSAFE_MULTIPLIER; 256];
-    array[0x05] = 1363; // modexp
-    array[0x0a] = 398; // point_evaluation
-    array[0x09] = 243; // blake2f
-    array[0x12] = 159; // bls12_map_fp_to_g1
-    array[0x11] = 134; // bls12_pairing
-    array[0x0b] = 112; // bls12_g1add
-    array[0x13] = 112; // bls12_map_fp2_to_g2
-    array[0x0e] = 111; // bls12_g2add
-    array[0x07] = 87; // bn128_mul
-    array[0x08] = 82; // bn128_pairing
-    array[0x01] = 81; // ecrecover
-    array[0x0c] = 52; // bls12_g1msm
-    array[0x0f] = 39; // bls12_g2msm
-    array[0x06] = 38; // bn128_add
-    array[0x02] = 10; // sha256
-    array[0x03] = 3; // ripemd160
-    array[0x04] = 2; // identity
-    array
-}
+/// Recalibrated Unzen precompile multipliers (Devnet / Hoodi / Mainnet), keyed by full address.
+/// Precompiles not listed here fall back to [`FAILSAFE_MULTIPLIER`].
+const UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
+    (Address::with_last_byte(0x01), 47),  // ecrecover
+    (Address::with_last_byte(0x02), 10),  // sha256
+    (Address::with_last_byte(0x03), 4),   // ripemd160
+    (Address::with_last_byte(0x04), 6),   // identity
+    (Address::with_last_byte(0x05), 923), // modexp
+    (Address::with_last_byte(0x06), 19),  // bn128_add
+    (Address::with_last_byte(0x07), 58),  // bn128_mul
+    (Address::with_last_byte(0x08), 54),  // bn128_pairing
+    (Address::with_last_byte(0x09), 166), // blake2f
+    (Address::with_last_byte(0x0a), 859), // point_evaluation
+    (Address::with_last_byte(0x0b), 201), // bls12_g1add
+    (Address::with_last_byte(0x0c), 93),  // bls12_g1msm
+    (Address::with_last_byte(0x0e), 230), // bls12_g2add
+    (Address::with_last_byte(0x0f), 71),  // bls12_g2msm
+    (Address::with_last_byte(0x11), 365), // bls12_pairing
+    (Address::with_last_byte(0x12), 246), // bls12_map_fp_to_g1
+    (Address::with_last_byte(0x13), 208), // bls12_map_fp2_to_g2
+];
+
+/// Frozen Masaya Unzen precompile multipliers, keyed by full address. Pinned at the
+/// pre-recalibration values to preserve consensus on already-finalized Masaya blocks (their
+/// `difficulty` header equals the finalized block zk gas).
+const MASAYA_UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
+    (Address::with_last_byte(0x01), 81),   // ecrecover
+    (Address::with_last_byte(0x02), 10),   // sha256
+    (Address::with_last_byte(0x03), 3),    // ripemd160
+    (Address::with_last_byte(0x04), 2),    // identity
+    (Address::with_last_byte(0x05), 1363), // modexp
+    (Address::with_last_byte(0x06), 38),   // bn128_add
+    (Address::with_last_byte(0x07), 87),   // bn128_mul
+    (Address::with_last_byte(0x08), 82),   // bn128_pairing
+    (Address::with_last_byte(0x09), 243),  // blake2f
+    (Address::with_last_byte(0x0a), 398),  // point_evaluation
+    (Address::with_last_byte(0x0b), 112),  // bls12_g1add
+    (Address::with_last_byte(0x0c), 52),   // bls12_g1msm
+    (Address::with_last_byte(0x0e), 111),  // bls12_g2add
+    (Address::with_last_byte(0x0f), 39),   // bls12_g2msm
+    (Address::with_last_byte(0x11), 134),  // bls12_pairing
+    (Address::with_last_byte(0x12), 159),  // bls12_map_fp_to_g1
+    (Address::with_last_byte(0x13), 112),  // bls12_map_fp2_to_g2
+];
 
 /// Returns the recalibrated Unzen opcode multiplier table, with fail-safe defaults for unlisted
 /// opcodes.
@@ -413,29 +431,5 @@ const fn unzen_opcode_multipliers() -> [u16; 256] {
     array[0xfd] = 0; // revert
     array[0xfe] = 0; // invalid
     array[0xff] = 0; // selfdestruct
-    array
-}
-
-/// Returns the recalibrated Unzen precompile multiplier table, with fail-safe defaults for unlisted
-/// entries.
-const fn unzen_precompile_multipliers() -> [u16; 256] {
-    let mut array = [FAILSAFE_MULTIPLIER; 256];
-    array[0x01] = 47; // ecrecover
-    array[0x02] = 10; // sha256
-    array[0x03] = 4; // ripemd160
-    array[0x04] = 6; // identity
-    array[0x05] = 923; // modexp
-    array[0x06] = 19; // bn128_add
-    array[0x07] = 58; // bn128_mul
-    array[0x08] = 54; // bn128_pairing
-    array[0x09] = 166; // blake2f
-    array[0x0a] = 859; // point_evaluation
-    array[0x0b] = 201; // bls12_g1add
-    array[0x0c] = 93; // bls12_g1msm
-    array[0x0e] = 230; // bls12_g2add
-    array[0x0f] = 71; // bls12_g2msm
-    array[0x11] = 365; // bls12_pairing
-    array[0x12] = 246; // bls12_map_fp_to_g1
-    array[0x13] = 208; // bls12_map_fp2_to_g2
     array
 }

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -234,7 +234,8 @@ const fn masaya_unzen_opcode_multipliers() -> [u16; 256] {
 }
 
 /// Recalibrated Unzen precompile multipliers (Devnet / Hoodi / Mainnet), keyed by full address.
-/// Precompiles not listed here fall back to [`FAILSAFE_MULTIPLIER`].
+/// Precompiles not listed here fall back to [`FAILSAFE_MULTIPLIER`]. The canonical EVM precompiles
+/// all live at `0x0000…00XX`, so [`Address::with_last_byte`] is sufficient to spell their keys.
 const UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
     (Address::with_last_byte(0x01), 47),  // ecrecover
     (Address::with_last_byte(0x02), 10),  // sha256
@@ -257,7 +258,8 @@ const UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
 
 /// Frozen Masaya Unzen precompile multipliers, keyed by full address. Pinned at the
 /// pre-recalibration values to preserve consensus on already-finalized Masaya blocks (their
-/// `difficulty` header equals the finalized block zk gas).
+/// `difficulty` header equals the finalized block zk gas). As above, canonical precompiles live at
+/// `0x0000…00XX`, so [`Address::with_last_byte`] spells their keys.
 const MASAYA_UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
     (Address::with_last_byte(0x01), 81),   // ecrecover
     (Address::with_last_byte(0x02), 10),   // sha256


### PR DESCRIPTION
## Summary

Fixes the precompile multiplier collision reported in #200.

The Unzen zk-gas meter selected a precompile's proving-cost multiplier using only the **low byte** of the called address — `precompile_multipliers: [u16; 256]` indexed by `bytecode_address[19]`. This is fine for the canonical EVM precompiles (`0x00…0001`..`0x00…0013`), but a high-range precompile collides on its low byte with a canonical one:

| Precompile | Address | Low byte | Collides with |
|---|---|---|---|
| `L1Sload` (RIP-7728) | `0x…010001` | `0x01` | `ecrecover` |
| `L1StaticCall` | `0x…010002` | `0x02` | `sha256` |

If such a precompile were ever metered through this path it would be charged the canonical multiplier sitting at the colliding low byte, and the `u16::MAX` fail-safe wouldn't help because those slots are already populated.

## Change

Replace the low-byte `[u16; 256]` table with a `&'static [(Address, u16)]` const slice keyed by the **full 20-byte address**, looked up via `ZkGasSchedule::precompile_multiplier(&Address)` (linear scan, `FAILSAFE_MULTIPLIER` fallback). `charge_precompile` now takes `&Address`, and both metering call sites — the production frame-init path (`evm.rs`) and the inspector path (`adapter.rs`) — pass the full `bytecode_address`. Opcode multipliers and spawn estimates are untouched (opcodes are genuinely single-byte).

This implements the full-address keying direction agreed in the issue thread.

## Consensus safety (no Masaya/Mainnet/Hoodi impact, no reset)

Every multiplier value is transcribed **bit-identically** from the prior arrays. The only addresses that reach `charge_precompile` are the canonical precompiles (the registered revm set; `L1Sload`/`L1StaticCall` are **not** in the Unzen fork), all of which live at `0x00…00XX` — so full-address keying returns the exact same multiplier for every precompile that can actually be reached today. The two schemes only diverge on addresses that don't exist in the fork.

Masaya commits its finalized block zk-gas total to the header `difficulty` field (the reason the frozen Masaya tables exist), so byte-identical charges mean **no change to any finalized block** and no devnet reset. A high-range collider now resolves to the fail-safe instead of a wrong canonical value, hardening the path before any high-range precompile is ever introduced.

## Tests

- `high_range_precompile_collision_resolves_to_failsafe_not_canonical` — the regression guard: two high-range colliders (`…010001`/`…010004`) resolve to the fail-safe on both schedules, while the canonical `ecrecover` still returns its real multiplier.
- `full_address_lookup_preserves_canonical_precompile_multipliers` — pins all 17 canonical multipliers for both the default and frozen Masaya schedules, plus fail-safe for the `0x0d`/`0x10`/`0x14` gaps.
- `precompile_tables_have_no_duplicate_addresses` — guards the linear-scan tables against duplicate keys (which the old array made impossible by construction).
- Existing production/inspector parity and value-pin tests stay green with unchanged numbers.

`just fmt` / `cargo sort` / `just clippy` (deny warnings + missing-docs) / `just test` — **193/193 passing**.

## Out of scope

No `L1Sload`/`L1StaticCall` multiplier entries (they don't exist in the fork), no chainspec or dependency changes, no opcode/spawn-estimate changes.

Refs #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
