### PR TITLE
feat(evm): meter p256verify zk gas at 163

### DIFF
--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -718,3 +718,27 @@ fn precompile_tables_have_no_duplicate_addresses() {
         }
     }
 }
+
+#[test]
+fn unzen_schedule_meters_p256verify_and_freezes_masaya() {
+    // p256verify (RIP-7212) lives at 0x0000…0100 — outside the canonical 0x..XX
+    // precompile range. revm's Osaka set (which Unzen maps to) makes it active, so
+    // it must carry a real multiplier on the default schedule instead of the
+    // fail-safe that would truncate any calling transaction.
+    let p256verify = address!("0x0000000000000000000000000000000000000100");
+
+    assert_eq!(
+        UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&p256verify),
+        163,
+        "default Unzen schedule must meter p256verify at 163"
+    );
+
+    // Masaya stays frozen: its finalized blocks committed their zk-gas total to the
+    // header `difficulty` field, so p256verify must keep resolving to the fail-safe
+    // there rather than adopting 163 retroactively.
+    assert_eq!(
+        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&p256verify),
+        FAILSAFE_MULTIPLIER,
+        "Masaya schedule must keep p256verify frozen at the fail-safe multiplier"
+    );
+}

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -235,8 +235,9 @@ const fn masaya_unzen_opcode_multipliers() -> [u16; 256] {
 
 /// Recalibrated Unzen precompile multipliers (Devnet / Hoodi / Mainnet), keyed by full address.
 /// Precompiles not listed here fall back to [`FAILSAFE_MULTIPLIER`]. The canonical EVM precompiles
-/// live at `0x0000…00XX`, so [`Address::with_last_byte`] spells their keys; p256verify (RIP-7212)
-/// sits at `0x0000…0100` and uses a full-address literal.
+/// set only their last byte (`0x…01` through `0x…13`), so [`Address::with_last_byte`] spells their
+/// keys; p256verify (RIP-7212) is at `0x100`, whose second-to-last byte is non-zero, so it needs a
+/// full-address literal.
 const UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
     (Address::with_last_byte(0x01), 47),  // ecrecover
     (Address::with_last_byte(0x02), 10),  // sha256

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -7,7 +7,7 @@
 //! Source:
 //! <https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/zk_gas_spec.md>
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, address};
 
 use super::schedule::{FAILSAFE_MULTIPLIER, SpawnEstimates, ZkGasSchedule};
 
@@ -235,7 +235,8 @@ const fn masaya_unzen_opcode_multipliers() -> [u16; 256] {
 
 /// Recalibrated Unzen precompile multipliers (Devnet / Hoodi / Mainnet), keyed by full address.
 /// Precompiles not listed here fall back to [`FAILSAFE_MULTIPLIER`]. The canonical EVM precompiles
-/// all live at `0x0000…00XX`, so [`Address::with_last_byte`] is sufficient to spell their keys.
+/// live at `0x0000…00XX`, so [`Address::with_last_byte`] spells their keys; p256verify (RIP-7212)
+/// sits at `0x0000…0100` and uses a full-address literal.
 const UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
     (Address::with_last_byte(0x01), 47),  // ecrecover
     (Address::with_last_byte(0x02), 10),  // sha256
@@ -254,6 +255,9 @@ const UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
     (Address::with_last_byte(0x11), 365), // bls12_pairing
     (Address::with_last_byte(0x12), 246), // bls12_map_fp_to_g1
     (Address::with_last_byte(0x13), 208), // bls12_map_fp2_to_g2
+    // p256verify (RIP-7212) at 0x0000…0100 — outside the canonical 0x..XX range, so it
+    // needs a full-address literal. Multiplier from taikoxyz/taiko-mono#21748.
+    (address!("0x0000000000000000000000000000000000000100"), 163),
 ];
 
 /// Frozen Masaya Unzen precompile multipliers, keyed by full address. Pinned at the


### PR DESCRIPTION
## What

Registers the `p256verify` precompile (RIP-7212, address `0x100`) in the default Unzen zk gas precompile multiplier table with multiplier **163**.

Ports [taikoxyz/taiko-mono#21748](https://github.com/taikoxyz/taiko-mono/pull/21748) (the protocol-spec entry) into the execution client.

## Why

Unzen maps to revm's `OSAKA` spec, and revm's `osaka()` precompile set includes `P256VERIFY` at `0x100` — so p256verify is **already active and callable** on every Unzen chain. But `0x100` was absent from `UNZEN_PRECOMPILE_MULTIPLIERS`, so `precompile_multiplier()` returned `FAILSAFE_MULTIPLIER` (`u16::MAX`) for it. That charges `gas_used × 65535` zk gas on any call, blowing the block limit and truncating the transaction — p256verify was effectively unusable.

It was missed in the original calibration sweep because RIP-7212 hadn't been added to the alethia-reth precompile set when benchmarking ran. The `163` value comes from the upstream PR (SP1 marginal-cycle measurement, ~4× ecrecover).

The full-address keying landed in #201 is what lets us spell `0x100` cleanly (it sits outside the canonical `0x..XX` range, so it uses an `address!` literal rather than `Address::with_last_byte`).

## Masaya stays frozen

p256verify is also active on Masaya, currently charged at the fail-safe. `MASAYA_UNZEN_PRECOMPILE_MULTIPLIERS` is **deliberately left untouched**: its finalized blocks committed their zk-gas total to the header `difficulty` field, so adopting `163` retroactively would break consensus. The new test asserts both halves — `163` on the default schedule, fail-safe on Masaya.

## Testing

- New test `unzen_schedule_meters_p256verify_and_freezes_masaya`.
- Full workspace suite: 194 passed, 0 failed.
- `just fmt` + `just clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)