### PR TITLE
fix(evm): apply taiko-mono #21749 to zk-gas — canonical BLS12 addresses + CLZ opcode

### DIFF
--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -649,11 +649,11 @@ fn full_address_lookup_preserves_canonical_precompile_multipliers() {
         (0x0a, 859),
         (0x0b, 201),
         (0x0c, 93),
-        (0x0e, 230),
-        (0x0f, 71),
-        (0x11, 365),
-        (0x12, 246),
-        (0x13, 208),
+        (0x0d, 230),
+        (0x0e, 71),
+        (0x0f, 365),
+        (0x10, 246),
+        (0x11, 208),
     ];
     for (byte, multiplier) in default_expected {
         assert_eq!(
@@ -690,14 +690,20 @@ fn full_address_lookup_preserves_canonical_precompile_multipliers() {
         );
     }
 
-    // Gaps in the canonical range (0x0d, 0x10 are unassigned in EIP-2537) and out-of-range bytes
-    // fall back to the fail-safe on both schedules.
-    for byte in [0x0d_u8, 0x10, 0x14] {
+    // Default schedule: the obsolete draft keys 0x12/0x13 are no longer listed — the spec moved
+    // the BLS12 precompiles down to their canonical Osaka addresses — and out-of-range bytes fall
+    // back to the fail-safe.
+    for byte in [0x12_u8, 0x13, 0x14] {
         assert_eq!(
             UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(byte)),
             FAILSAFE_MULTIPLIER,
             "default: unlisted byte {byte:#04x}"
         );
+    }
+
+    // Masaya stays frozen on the draft addresses, so the canonical-only bytes 0x0d/0x10 it never
+    // adopted, plus out-of-range bytes, fall back to the fail-safe.
+    for byte in [0x0d_u8, 0x10, 0x14] {
         assert_eq!(
             MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(byte)),
             FAILSAFE_MULTIPLIER,

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -748,3 +748,22 @@ fn unzen_schedule_meters_p256verify_and_freezes_masaya() {
         "Masaya schedule must keep p256verify frozen at the fail-safe multiplier"
     );
 }
+
+#[test]
+fn unzen_schedule_meters_clz_and_freezes_masaya() {
+    // CLZ (EIP-7939) is added in Osaka at opcode 0x1e, which Unzen maps to. Without an explicit
+    // entry the fail-safe multiplier (u16::MAX) would brick any block using the opcode, so the
+    // default schedule must meter it at the spec value.
+    assert_eq!(
+        UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0x1e], 14,
+        "default Unzen schedule must meter clz at 14"
+    );
+
+    // Masaya stays frozen: its finalized blocks committed their zk-gas total to the header
+    // `difficulty` field, so clz must keep resolving to the fail-safe there rather than adopting
+    // 14 retroactively.
+    assert_eq!(
+        MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0x1e], FAILSAFE_MULTIPLIER,
+        "Masaya schedule must keep clz frozen at the fail-safe multiplier"
+    );
+}

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -633,9 +633,11 @@ fn high_range_precompile_collision_resolves_to_failsafe_not_canonical() {
 
 #[test]
 fn full_address_lookup_preserves_canonical_precompile_multipliers() {
-    // Every canonical precompile (0x01..=0x13) keeps its exact pre-fix multiplier, so finalized
-    // blocks stay byte-identical — including Masaya, whose finalized block zk-gas total is
-    // committed to the header `difficulty` field.
+    // Masaya stays byte-identical: every listed precompile keeps its frozen multiplier, so its
+    // finalized blocks' zk-gas total (committed to the header `difficulty` field) is preserved.
+    // On the default schedule the non-BLS precompiles (0x01..=0x0a) keep their pre-fix multipliers;
+    // the BLS12 precompiles keep the same values but now sit at their canonical Osaka addresses
+    // (0x0b..=0x11), so the stale draft keys 0x12/0x13 fall back to the fail-safe.
     let default_expected: [(u8, u16); 17] = [
         (0x01, 47),
         (0x02, 10),

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -315,6 +315,7 @@ const fn unzen_opcode_multipliers() -> [u16; 256] {
     array[0x1b] = 24; // shl
     array[0x1c] = 22; // shr
     array[0x1d] = 21; // sar
+    array[0x1e] = 14; // clz
     array[0x20] = 31; // keccak256
     array[0x30] = 19; // address
     array[0x31] = 4; // balance

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -235,7 +235,7 @@ const fn masaya_unzen_opcode_multipliers() -> [u16; 256] {
 
 /// Recalibrated Unzen precompile multipliers (Devnet / Hoodi / Mainnet), keyed by full address.
 /// Precompiles not listed here fall back to [`FAILSAFE_MULTIPLIER`]. The canonical EVM precompiles
-/// set only their last byte (`0x…01` through `0x…13`), so [`Address::with_last_byte`] spells their
+/// set only their last byte (`0x…01` through `0x…11`), so [`Address::with_last_byte`] spells their
 /// keys; p256verify (RIP-7212) is at `0x100`, whose second-to-last byte is non-zero, so it needs a
 /// full-address literal.
 const UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
@@ -251,11 +251,11 @@ const UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
     (Address::with_last_byte(0x0a), 859), // point_evaluation
     (Address::with_last_byte(0x0b), 201), // bls12_g1add
     (Address::with_last_byte(0x0c), 93),  // bls12_g1msm
-    (Address::with_last_byte(0x0e), 230), // bls12_g2add
-    (Address::with_last_byte(0x0f), 71),  // bls12_g2msm
-    (Address::with_last_byte(0x11), 365), // bls12_pairing
-    (Address::with_last_byte(0x12), 246), // bls12_map_fp_to_g1
-    (Address::with_last_byte(0x13), 208), // bls12_map_fp2_to_g2
+    (Address::with_last_byte(0x0d), 230), // bls12_g2add
+    (Address::with_last_byte(0x0e), 71),  // bls12_g2msm
+    (Address::with_last_byte(0x0f), 365), // bls12_pairing
+    (Address::with_last_byte(0x10), 246), // bls12_map_fp_to_g1
+    (Address::with_last_byte(0x11), 208), // bls12_map_fp2_to_g2
     // p256verify (RIP-7212) at 0x0000…0100 — outside the canonical 0x..XX range, so it
     // needs a full-address literal. Multiplier from taikoxyz/taiko-mono#21748.
     (address!("0x0000000000000000000000000000000000000100"), 163),


### PR DESCRIPTION
## Summary

Mirrors [taikoxyz/taiko-mono#21749](https://github.com/taikoxyz/taiko-mono/pull/21749) in the zk-gas schedule. Two independent fixes, applied to the **default** Unzen schedule (Devnet/Hoodi/Mainnet) only. The Masaya schedule is left byte-for-byte frozen.

### 1. BLS12-381 precompile addresses

Five BLS12 precompiles in `UNZEN_PRECOMPILE_MULTIPLIERS` were keyed at obsolete pre-final EIP-2537 draft addresses. Re-keyed to the canonical Osaka addresses (multiplier values unchanged — only the address key moves):

| precompile | before | after |
| --- | --- | --- |
| `bls12_g2add` | 0x0e | **0x0d** |
| `bls12_g2msm` | 0x0f | **0x0e** |
| `bls12_pairing` | 0x11 | **0x0f** |
| `bls12_map_fp_to_g1` | 0x12 | **0x10** |
| `bls12_map_fp2_to_g2` | 0x13 | **0x11** |

`bls12_g1add` (0x0b) / `bls12_g1msm` (0x0c) were already canonical. Net effect: the real precompiles at 0x0d/0x10 stop resolving to the fail-safe (which would have bricked them), and the stale draft keys 0x12/0x13 now correctly fall back to the fail-safe.

### 2. CLZ opcode (EIP-7939)

Added `clz` (0x1e = 14) to `unzen_opcode_multipliers()`. CLZ is live in revm's Osaka set that Unzen maps to; without an explicit entry the fail-safe `max(u16)` multiplier would brick any block using the opcode.

## Masaya stays frozen

`MASAYA_UNZEN_PRECOMPILE_MULTIPLIERS` and `masaya_unzen_opcode_multipliers()` are unchanged. Masaya has already finalized Unzen blocks whose zk-gas total is committed to the header `difficulty` field, so adopting these corrections retroactively would break consensus on those blocks. This matches the precedent set for p256verify (#202) and the recalibration (#187).

## Testing

- Updated `full_address_lookup_preserves_canonical_precompile_multipliers` (canonical default addresses; Masaya expectations unchanged; per-schedule fail-safe gap checks).
- Added `unzen_schedule_meters_clz_and_freezes_masaya` (default `[0x1e] == 14`, Masaya `[0x1e] == u16::MAX`), mirroring the p256verify freeze test.
- `just clippy` clean; `just test` → 195/195 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)