### PR TITLE
feat(evm): lower modexp zk-gas multiplier to 154

### DIFF
--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -72,7 +72,7 @@ fn unzen_schedule_uses_spec_opcode_and_precompile_multipliers() {
     assert_eq!(schedule.opcode_multipliers[0xfe], 0); // invalid (terminal)
     assert_eq!(schedule.opcode_multipliers[0xac], u16::MAX); // unlisted -> failsafe
 
-    assert_eq!(schedule.precompile_multiplier(&Address::with_last_byte(0x05)), 923); // modexp
+    assert_eq!(schedule.precompile_multiplier(&Address::with_last_byte(0x05)), 154); // modexp
     assert_eq!(schedule.precompile_multiplier(&Address::with_last_byte(0x01)), 47); // ecrecover
     assert_eq!(schedule.precompile_multiplier(&Address::with_last_byte(0x04)), 6); // identity
     assert_eq!(schedule.precompile_multiplier(&Address::with_last_byte(0x14)), u16::MAX); // failsafe
@@ -122,7 +122,7 @@ fn masaya_unzen_schedule_freezes_pre_recalibration_multipliers() {
     );
     // Spot-check a known recalibrated entry so this guard fails if the two tables ever realign:
     // keccak256 went 85 -> 31 for the default schedule while Masaya stays at 85, and modexp went
-    // 1363 -> 923 while Masaya stays at 1363.
+    // 1363 -> 154 while Masaya stays at 1363.
     assert_ne!(
         UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0x20],
         MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0x20]
@@ -643,7 +643,7 @@ fn full_address_lookup_preserves_canonical_precompile_multipliers() {
         (0x02, 10),
         (0x03, 4),
         (0x04, 6),
-        (0x05, 923),
+        (0x05, 154),
         (0x06, 19),
         (0x07, 58),
         (0x08, 54),

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -243,7 +243,7 @@ const UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
     (Address::with_last_byte(0x02), 10),  // sha256
     (Address::with_last_byte(0x03), 4),   // ripemd160
     (Address::with_last_byte(0x04), 6),   // identity
-    (Address::with_last_byte(0x05), 923), // modexp
+    (Address::with_last_byte(0x05), 154), // modexp
     (Address::with_last_byte(0x06), 19),  // bn128_add
     (Address::with_last_byte(0x07), 58),  // bn128_mul
     (Address::with_last_byte(0x08), 54),  // bn128_pairing


### PR DESCRIPTION
## What

Lower the **default** Unzen `modexp` precompile zk-gas multiplier from `923` to `154` in `crates/evm/src/zk_gas/unzen.rs`, and update the mirroring test assertions/comment in `crates/evm/src/zk_gas/tests.rs`.

Mirrors [taikoxyz/taiko-mono#21754](https://github.com/taikoxyz/taiko-mono/pull/21754).

## Why

`modexp`'s worst-case EVM gas cost increased ~6× in Osaka, but the zk-gas slopes were benchmarked using **pre-Osaka** gas pricing — so the per-gas proving time of `modexp` was over-estimated by ~6×. Dividing by 6 brings `modexp` proving time on-par with the other stress tests: `923 / 6 ≈ 153.8 → 154`.

## Masaya stays frozen

Only the default schedule (Devnet / Hoodi / Mainnet) changes. The Masaya schedule's `modexp` entry stays at `1363`: Masaya already activated Unzen and its blocks are finalized, with each block's zk-gas total committed to the header `difficulty` field — moving the multiplier would break consensus on those blocks. The `assert_ne!` divergence guard remains green (`154 != 1363`).

## Test plan

- `just test` — full workspace suite: **195 passed, 0 skipped**.
- `just clippy` — clean (warnings-as-errors).
- `just fmt` — no changes.

Note: upstream PR 21754 is currently open; `154 = round(923 / 6)`.