### PR TITLE
feat(chainspec): activate Unzen from genesis + drop special zk-gas schedule for Masaya

### DIFF
--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -397,8 +397,8 @@ where
         // Charge the per-transaction intrinsic zk gas before EVM execution begins, as required
         // by the Unzen zk gas spec (taikoxyz/taiko-mono#21669). The intrinsic sits in the
         // in-flight tx total so it is committed alongside opcode/precompile usage on success
-        // and discarded on revert/failure. A schedule with a zero intrinsic (Masaya) makes this
-        // a no-op. If the intrinsic alone would exceed the remaining block budget, mirror the
+        // and discarded on revert/failure. A schedule with a zero intrinsic makes this a no-op.
+        // If the intrinsic alone would exceed the remaining block budget, mirror the
         // mid-tx exhaustion path used by the inspector.
         if let Err(ZkGasOutcome::LimitExceeded) = self.evm.charge_tx_intrinsic_zk_gas() {
             self.zk_gas_exhausted = true;
@@ -558,11 +558,9 @@ mod test {
         state::AccountInfo,
     };
 
-    use alethia_reth_chainspec::TAIKO_MASAYA_CHAIN_ID;
     use alethia_reth_evm::{
-        alloy::decode_anchor_system_call_data,
-        factory::TaikoEvmFactory,
-        zk_gas::unzen::{MASAYA_TX_INTRINSIC_ZK_GAS, TX_INTRINSIC_ZK_GAS},
+        alloy::decode_anchor_system_call_data, factory::TaikoEvmFactory,
+        zk_gas::unzen::TX_INTRINSIC_ZK_GAS,
     };
 
     use super::*;
@@ -570,7 +568,7 @@ mod test {
         config::{TaikoEvmConfig, TaikoNextBlockEnvAttributes},
         testutil::{
             BENCH_LIMIT_TARGET, BENCH_SUCCESS_TARGET, db_with_contracts, recovered_tx,
-            recovered_tx_with_chain_id, unzen_chain_spec, unzen_evm_env, unzen_execution_ctx,
+            unzen_chain_spec, unzen_evm_env, unzen_execution_ctx,
         },
     };
     use alethia_reth_chainspec::spec::TaikoChainSpec;
@@ -663,39 +661,6 @@ mod test {
             finalized >= TX_INTRINSIC_ZK_GAS,
             "finalized block zk gas ({finalized}) must include the per-tx intrinsic charge ({TX_INTRINSIC_ZK_GAS})"
         );
-    }
-
-    #[test]
-    fn executor_does_not_charge_tx_intrinsic_on_masaya_schedule() {
-        let chain_spec = Arc::new(unzen_chain_spec());
-        let mut state = State::builder()
-            .with_database(db_with_contracts(&[(BENCH_CALLER, 0)]))
-            .with_bundle_update()
-            .build();
-        let mut env = unzen_evm_env();
-        env.cfg_env.chain_id = TAIKO_MASAYA_CHAIN_ID;
-        let evm = TaikoEvmFactory.create_evm(&mut state, env);
-        let ctx = unzen_execution_ctx();
-        let mut executor =
-            TaikoBlockExecutor::new(evm, ctx.clone(), chain_spec, RethReceiptBuilder::default());
-
-        executor
-            .execute_transaction(recovered_tx_with_chain_id(
-                BENCH_CALLER,
-                BENCH_SUCCESS_TARGET,
-                0,
-                1,
-                TAIKO_MASAYA_CHAIN_ID,
-            ))
-            .expect("successful tx should commit on Masaya");
-
-        let finalized = ctx.finalized_block_zk_gas();
-        assert_eq!(MASAYA_TX_INTRINSIC_ZK_GAS, 0);
-        assert!(
-            finalized < TX_INTRINSIC_ZK_GAS,
-            "Masaya finalized block zk gas ({finalized}) must not include any per-tx intrinsic charge"
-        );
-        assert!(finalized > 0, "successful tx must still record opcode-driven zk gas (got 0)");
     }
 
     #[cfg(feature = "prover")]

--- a/crates/block/src/testutil.rs
+++ b/crates/block/src/testutil.rs
@@ -75,7 +75,7 @@ pub fn recovered_tx(
 }
 
 /// Builds a recovered legacy transaction targeting `to` from `caller` with an explicit chain id,
-/// so tests can submit transactions against the Masaya chain id (`167_011`) and others.
+/// so tests can submit transactions against chain ids other than the default.
 pub fn recovered_tx_with_chain_id(
     caller: Address,
     to: Address,

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -102,7 +102,7 @@ pub static TAIKO_MASAYA_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         (TaikoHardfork::Ontake.boxed(), ForkCondition::Block(0)),
         (TaikoHardfork::Pacaya.boxed(), ForkCondition::Block(0)),
         (TaikoHardfork::Shasta.boxed(), ForkCondition::Timestamp(0)),
-        (TaikoHardfork::Unzen.boxed(), ForkCondition::Timestamp(1_778_158_800)),
+        (TaikoHardfork::Unzen.boxed(), ForkCondition::Timestamp(0)),
     ]))
 });
 
@@ -223,5 +223,15 @@ mod test {
         let shasta = TAIKO_MASAYA_HARDFORKS.fork(TaikoHardfork::Shasta);
         assert!(shasta.is_timestamp(), "shasta activation should be timestamp-based");
         assert_eq!(shasta, ForkCondition::Timestamp(0));
+    }
+
+    #[test]
+    fn test_masaya_unzen_activates_at_genesis() {
+        let unzen = TAIKO_MASAYA_HARDFORKS.fork(TaikoHardfork::Unzen);
+        assert_eq!(
+            unzen,
+            ForkCondition::Timestamp(0),
+            "post-reset Masaya forks into Unzen at genesis"
+        );
     }
 }

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -39,9 +39,10 @@ pub const TAIKO_HOODI_GENESIS_HASH: B256 =
 pub const TAIKO_MAINNET_GENESIS_HASH: B256 =
     b256!("0x90bc60466882de9637e269e87abab53c9108cf9113188bc4f80bcfcb10e489b9");
 
-/// Genesis hash for the Taiko Masaya network.
+/// Genesis hash for the Taiko Masaya network. After the reset, Masaya activates Unzen at genesis
+/// (`Timestamp(0)`), which makes the genesis header an Osaka-era block.
 pub const TAIKO_MASAYA_GENESIS_HASH: B256 =
-    b256!("0xeef96dc254e1ac4a0044b116e38b16dface1a153d9299c056552898a43f8513e");
+    b256!("0xd3597fd63c823352526ce2a4cfafe0837d878e3c9ac8558129bc04ce900402ae");
 
 /// EVM chain id for the Taiko Devnet network.
 pub const TAIKO_DEVNET_CHAIN_ID: u64 = 167_001;

--- a/crates/evm/src/factory.rs
+++ b/crates/evm/src/factory.rs
@@ -48,7 +48,7 @@ impl EvmFactory for TaikoEvmFactory {
         input: EvmEnv<Self::Spec, Self::BlockEnv>,
     ) -> Self::Evm<DB, NoOpInspector> {
         let spec_id = input.cfg_env.spec;
-        let schedule = schedule_for(spec_id, input.cfg_env.chain_id);
+        let schedule = schedule_for(spec_id);
         let evm = Context::mainnet()
             .with_cfg(input.cfg_env)
             .with_block(input.block_env)
@@ -69,7 +69,7 @@ impl EvmFactory for TaikoEvmFactory {
         inspector: I,
     ) -> Self::Evm<DB, I> {
         let spec_id = input.cfg_env.spec;
-        let schedule = schedule_for(spec_id, input.cfg_env.chain_id);
+        let schedule = schedule_for(spec_id);
         let evm = Context::mainnet()
             .with_cfg(input.cfg_env)
             .with_block(input.block_env)

--- a/crates/evm/src/zk_gas/adapter.rs
+++ b/crates/evm/src/zk_gas/adapter.rs
@@ -62,16 +62,14 @@ impl<I> ZkGasInspector<I> {
 
     /// Returns a reference to the active zk gas meter, if metering is enabled.
     ///
-    /// Returns `None` when the active spec/chain combination has no zk gas schedule
-    /// (pre-Unzen specs).
+    /// Returns `None` when the active spec has no zk gas schedule (pre-Unzen specs).
     pub(crate) fn meter(&self) -> Option<&ZkGasMeter<'static>> {
         self.metering.as_ref().map(|state| &state.meter)
     }
 
     /// Returns a mutable reference to the active zk gas meter, if metering is enabled.
     ///
-    /// Returns `None` when the active spec/chain combination has no zk gas schedule
-    /// (pre-Unzen specs).
+    /// Returns `None` when the active spec has no zk gas schedule (pre-Unzen specs).
     pub(crate) fn meter_mut(&mut self) -> Option<&mut ZkGasMeter<'static>> {
         self.metering.as_mut().map(|state| &mut state.meter)
     }
@@ -413,17 +411,14 @@ fn parent_step_depth(depth: usize) -> usize {
 mod tests {
     use crate::{
         spec::TaikoSpecId,
-        zk_gas::{
-            schedule::schedule_for,
-            unzen::{MASAYA_UNZEN_ZK_GAS_SCHEDULE, UNZEN_ZK_GAS_SCHEDULE},
-        },
+        zk_gas::{schedule::schedule_for, unzen::UNZEN_ZK_GAS_SCHEDULE},
     };
 
     use super::{FinishedStep, ZkGasMeteringState};
 
     #[test]
     fn flush_deferred_steps_returns_immediately_when_empty() {
-        let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+        let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
         let mut metering = ZkGasMeteringState::new(schedule);
 
         metering.flush_deferred_steps().expect("empty flush should succeed");
@@ -434,7 +429,7 @@ mod tests {
 
     #[test]
     fn flush_deferred_steps_clears_flag_after_charging_deferred_step() {
-        let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+        let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
         let mut metering = ZkGasMeteringState::new(schedule);
 
         metering.defer_step(0, FinishedStep { opcode: 0x01, step_gas: 3, spawned: false });
@@ -449,13 +444,13 @@ mod tests {
 
     #[test]
     fn flush_deferred_steps_preserves_flag_when_later_deferred_step_remains_after_error() {
-        let mut metering = ZkGasMeteringState::new(&MASAYA_UNZEN_ZK_GAS_SCHEDULE);
+        let mut metering = ZkGasMeteringState::new(&UNZEN_ZK_GAS_SCHEDULE);
 
         metering.defer_step(
             0,
             FinishedStep {
                 opcode: 0xf0,
-                step_gas: MASAYA_UNZEN_ZK_GAS_SCHEDULE.block_limit + 1,
+                step_gas: UNZEN_ZK_GAS_SCHEDULE.block_limit + 1,
                 spawned: false,
             },
         );

--- a/crates/evm/src/zk_gas/meter.rs
+++ b/crates/evm/src/zk_gas/meter.rs
@@ -99,7 +99,7 @@ impl<'a> ZkGasMeter<'a> {
     ///
     /// Mirrors `TX_INTRINSIC_ZK_GAS` from the Unzen zk gas spec: the charge accumulates into the
     /// in-flight transaction total and is only promoted into the block total when the transaction
-    /// commits. A schedule value of `0` (Masaya) makes this a no-op.
+    /// commits. A schedule value of `0` makes this a no-op.
     pub fn charge_tx_intrinsic(&mut self) -> Result<(), ZkGasOutcome> {
         self.charge_amount(self.schedule.tx_intrinsic_zk_gas)
     }

--- a/crates/evm/src/zk_gas/schedule.rs
+++ b/crates/evm/src/zk_gas/schedule.rs
@@ -4,9 +4,7 @@ use alloy_primitives::Address;
 
 use crate::spec::TaikoSpecId;
 
-use super::unzen::{MASAYA_UNZEN_ZK_GAS_SCHEDULE, UNZEN_ZK_GAS_SCHEDULE};
-
-pub use alethia_reth_chainspec::TAIKO_MASAYA_CHAIN_ID;
+use super::unzen::UNZEN_ZK_GAS_SCHEDULE;
 
 /// Fail-safe multiplier applied to any precompile absent from a schedule's table.
 pub const FAILSAFE_MULTIPLIER: u16 = u16::MAX;
@@ -34,8 +32,7 @@ pub struct ZkGasSchedule {
     /// Maximum zk gas permitted across a single block.
     pub block_limit: u64,
     /// Fixed zk gas charged once per block transaction before opcode or precompile
-    /// metering begins. Set to `0` on chains whose Unzen activation predates this
-    /// field, to preserve historical block consensus.
+    /// metering begins.
     pub tx_intrinsic_zk_gas: u64,
     /// Per-opcode proving-cost multipliers indexed by opcode byte.
     pub opcode_multipliers: [u16; 256],
@@ -57,16 +54,11 @@ impl ZkGasSchedule {
     }
 }
 
-/// Returns the consensus zk gas schedule for the active Taiko fork on the given chain, when
-/// defined. Masaya runs Unzen with a 10× higher block budget than Devnet/Hoodi/Mainnet; all
-/// other chains share the default Unzen schedule.
-pub const fn schedule_for(spec: TaikoSpecId, chain_id: u64) -> Option<&'static ZkGasSchedule> {
+/// Returns the consensus zk gas schedule for the active Taiko fork, when defined. Only Unzen
+/// defines a schedule; every chain shares the single [`UNZEN_ZK_GAS_SCHEDULE`].
+pub const fn schedule_for(spec: TaikoSpecId) -> Option<&'static ZkGasSchedule> {
     match spec {
-        TaikoSpecId::UNZEN => Some(if chain_id == TAIKO_MASAYA_CHAIN_ID {
-            &MASAYA_UNZEN_ZK_GAS_SCHEDULE
-        } else {
-            &UNZEN_ZK_GAS_SCHEDULE
-        }),
+        TaikoSpecId::UNZEN => Some(&UNZEN_ZK_GAS_SCHEDULE),
         _ => None,
     }
 }

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -22,50 +22,28 @@ use crate::{factory::TaikoEvmFactory, spec::TaikoSpecId};
 use super::{
     adapter::ZK_GAS_LIMIT_ERR,
     meter::{ZkGasMeter, ZkGasOutcome},
-    schedule::{FAILSAFE_MULTIPLIER, TAIKO_MASAYA_CHAIN_ID, schedule_for},
-    unzen::{
-        MASAYA_BLOCK_ZK_GAS_LIMIT, MASAYA_TX_INTRINSIC_ZK_GAS, MASAYA_UNZEN_ZK_GAS_SCHEDULE,
-        TX_INTRINSIC_ZK_GAS, UNZEN_ZK_GAS_SCHEDULE,
-    },
+    schedule::{FAILSAFE_MULTIPLIER, schedule_for},
+    unzen::{TX_INTRINSIC_ZK_GAS, UNZEN_ZK_GAS_SCHEDULE},
 };
 
 #[test]
 fn unzen_schedule_is_selected_only_for_unzen() {
-    assert!(schedule_for(TaikoSpecId::UNZEN, 167).is_some());
-    assert!(schedule_for(TaikoSpecId::SHASTA, 167).is_none());
-}
-
-#[test]
-fn schedule_for_returns_masaya_schedule_on_masaya_chain_id() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, TAIKO_MASAYA_CHAIN_ID).expect("Unzen schedule");
-    assert_eq!(schedule.block_limit, 1_000_000_000);
-    assert!(std::ptr::eq(schedule, &MASAYA_UNZEN_ZK_GAS_SCHEDULE));
-}
-
-#[test]
-fn schedule_for_returns_default_schedule_on_non_masaya_chain_ids() {
-    for chain_id in [1u64, 167u64, 167_010u64, 167_009u64] {
-        let schedule = schedule_for(TaikoSpecId::UNZEN, chain_id).expect("Unzen schedule");
-        assert_eq!(schedule.block_limit, 100_000_000);
-        assert!(std::ptr::eq(schedule, &UNZEN_ZK_GAS_SCHEDULE));
-    }
-}
-
-#[test]
-fn schedule_for_returns_none_for_pre_unzen_regardless_of_chain_id() {
-    assert!(schedule_for(TaikoSpecId::SHASTA, TAIKO_MASAYA_CHAIN_ID).is_none());
-    assert!(schedule_for(TaikoSpecId::SHASTA, 167).is_none());
+    assert!(std::ptr::eq(
+        schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule"),
+        &UNZEN_ZK_GAS_SCHEDULE
+    ));
+    assert!(schedule_for(TaikoSpecId::SHASTA).is_none());
 }
 
 #[test]
 fn unzen_schedule_uses_the_spec_block_limit() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     assert_eq!(schedule.block_limit, 100_000_000);
 }
 
 #[test]
 fn unzen_schedule_uses_spec_opcode_and_precompile_multipliers() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
 
     assert_eq!(schedule.opcode_multipliers[0x20], 31); // keccak256
     assert_eq!(schedule.opcode_multipliers[0xf1], 20); // call
@@ -80,7 +58,7 @@ fn unzen_schedule_uses_spec_opcode_and_precompile_multipliers() {
 
 #[test]
 fn unzen_schedule_uses_spec_spawn_estimates() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
 
     assert_eq!(schedule.spawn_estimates.call, 12_500);
     assert_eq!(schedule.spawn_estimates.callcode, 12_500);
@@ -91,78 +69,14 @@ fn unzen_schedule_uses_spec_spawn_estimates() {
 }
 
 #[test]
-fn masaya_unzen_schedule_uses_one_billion_block_limit() {
-    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.block_limit, 1_000_000_000);
-    assert_eq!(MASAYA_BLOCK_ZK_GAS_LIMIT, 1_000_000_000);
-}
-
-#[test]
 fn unzen_schedule_pins_default_tx_intrinsic_zk_gas_at_243_000() {
     assert_eq!(UNZEN_ZK_GAS_SCHEDULE.tx_intrinsic_zk_gas, 243_000);
     assert_eq!(TX_INTRINSIC_ZK_GAS, 243_000);
 }
 
 #[test]
-fn masaya_unzen_schedule_pins_tx_intrinsic_zk_gas_at_zero() {
-    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.tx_intrinsic_zk_gas, 0);
-    assert_eq!(MASAYA_TX_INTRINSIC_ZK_GAS, 0);
-}
-
-#[test]
-fn masaya_unzen_schedule_freezes_pre_recalibration_multipliers() {
-    // The recalibration changes the default tables but Masaya stays frozen, so they must now
-    // differ.
-    assert_ne!(
-        UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers,
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers
-    );
-    assert_ne!(
-        UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers,
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers
-    );
-    // Spot-check a known recalibrated entry so this guard fails if the two tables ever realign:
-    // keccak256 went 85 -> 31 for the default schedule while Masaya stays at 85, and modexp went
-    // 1363 -> 154 while Masaya stays at 1363.
-    assert_ne!(
-        UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0x20],
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0x20]
-    );
-    assert_ne!(
-        UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(0x05)),
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(0x05))
-    );
-    // Spawn estimates were not recalibrated, so they remain identical across networks.
-    assert_eq!(UNZEN_ZK_GAS_SCHEDULE.spawn_estimates, MASAYA_UNZEN_ZK_GAS_SCHEDULE.spawn_estimates);
-}
-
-#[test]
-fn masaya_unzen_schedule_pins_spec_opcode_and_precompile_multipliers() {
-    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0x20], 85);
-    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0xf1], 25);
-    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0xfe], 0);
-    assert_eq!(MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0xac], u16::MAX);
-
-    assert_eq!(
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(0x05)),
-        1363
-    );
-    assert_eq!(
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(0x01)),
-        81
-    );
-    assert_eq!(
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(0x04)),
-        2
-    );
-    assert_eq!(
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(0x14)),
-        u16::MAX
-    );
-}
-
-#[test]
 fn meter_promotes_committed_tx_usage_into_block_usage() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
 
     meter.charge_opcode(0x01, 3).expect("charge");
@@ -173,7 +87,7 @@ fn meter_promotes_committed_tx_usage_into_block_usage() {
 
 #[test]
 fn meter_charge_tx_intrinsic_adds_schedule_value_to_in_flight_tx() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
 
     meter.charge_tx_intrinsic().expect("intrinsic should fit");
@@ -185,18 +99,8 @@ fn meter_charge_tx_intrinsic_adds_schedule_value_to_in_flight_tx() {
 }
 
 #[test]
-fn meter_charge_tx_intrinsic_is_noop_on_masaya_schedule() {
-    let schedule =
-        schedule_for(TaikoSpecId::UNZEN, TAIKO_MASAYA_CHAIN_ID).expect("Masaya Unzen schedule");
-    let mut meter = ZkGasMeter::new(schedule);
-
-    meter.charge_tx_intrinsic().expect("zero charge always fits");
-    assert_eq!(meter.tx_zk_gas_used(), 0);
-}
-
-#[test]
 fn meter_charge_tx_intrinsic_returns_limit_exceeded_when_remaining_budget_is_too_small() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
 
     // Fill the block budget to within (intrinsic - 1) of the limit so the next intrinsic
@@ -212,7 +116,7 @@ fn meter_charge_tx_intrinsic_returns_limit_exceeded_when_remaining_budget_is_too
 
 #[test]
 fn meter_treats_opcode_multiplication_overflow_as_limit_exceeded() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
     let raw_gas = (u64::MAX / u64::from(schedule.opcode_multipliers[0x01])) + 1;
 
@@ -221,7 +125,7 @@ fn meter_treats_opcode_multiplication_overflow_as_limit_exceeded() {
 
 #[test]
 fn meter_treats_precompile_multiplication_overflow_as_limit_exceeded() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
     let raw_gas =
         (u64::MAX / u64::from(schedule.precompile_multiplier(&Address::with_last_byte(0x01)))) + 1;
@@ -234,7 +138,7 @@ fn meter_treats_precompile_multiplication_overflow_as_limit_exceeded() {
 
 #[test]
 fn meter_resets_transaction_usage_without_affecting_block_usage() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
 
     meter.charge_opcode(0x01, 2).expect("charge");
@@ -247,7 +151,7 @@ fn meter_resets_transaction_usage_without_affecting_block_usage() {
 
 #[test]
 fn meter_allows_exactly_remaining_block_budget() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
 
     meter.charge_opcode(0xf0, schedule.block_limit - 1).expect("prefill");
@@ -263,7 +167,7 @@ fn meter_allows_exactly_remaining_block_budget() {
 
 #[test]
 fn meter_rejects_block_budget_plus_one() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
 
     meter.charge_opcode(0xf0, schedule.block_limit - 1).expect("prefill");
@@ -274,7 +178,7 @@ fn meter_rejects_block_budget_plus_one() {
 
 #[test]
 fn meter_returns_limit_exceeded_for_precompile_over_block_budget() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);
 
     assert!(matches!(
@@ -285,7 +189,7 @@ fn meter_returns_limit_exceeded_for_precompile_over_block_budget() {
 
 #[test]
 fn meter_exposes_its_schedule() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let meter = ZkGasMeter::new(schedule);
 
     assert!(std::ptr::eq(meter.schedule(), schedule));
@@ -325,7 +229,7 @@ impl<CTX> Inspector<CTX, EthInterpreter> for StepGasProbeInspector {
 
 #[test]
 fn unzen_adapter_uses_spawn_estimate_for_precompile_dispatch() {
-    let schedule = schedule_for(TaikoSpecId::UNZEN, 167).expect("Unzen schedule");
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut evm = TaikoEvmFactory.create_evm_with_inspector(
         db_with_contract(staticcall_identity_bytecode()),
         evm_env(TaikoSpecId::UNZEN),
@@ -448,21 +352,10 @@ fn production_metered_path_stays_metered_when_noop_inspector_is_enabled() {
 }
 
 #[test]
-fn factory_installs_masaya_schedule_when_chain_id_is_masaya() {
-    let mut env = evm_env(TaikoSpecId::UNZEN);
-    env.cfg_env.chain_id = TAIKO_MASAYA_CHAIN_ID;
+fn factory_installs_unzen_schedule() {
+    let env = evm_env(TaikoSpecId::UNZEN);
     let evm = TaikoEvmFactory.create_evm(db_with_contract(limit_exceeding_keccak_bytecode()), env);
-    let meter = evm.meter().expect("Masaya schedule should install a meter");
-
-    assert!(std::ptr::eq(meter.schedule(), &MASAYA_UNZEN_ZK_GAS_SCHEDULE));
-    assert_eq!(meter.schedule().block_limit, 1_000_000_000);
-}
-
-#[test]
-fn factory_installs_default_schedule_when_chain_id_is_not_masaya() {
-    let env = evm_env(TaikoSpecId::UNZEN); // helper sets chain_id = 167 (not Masaya)
-    let evm = TaikoEvmFactory.create_evm(db_with_contract(limit_exceeding_keccak_bytecode()), env);
-    let meter = evm.meter().expect("default Unzen schedule should install a meter");
+    let meter = evm.meter().expect("Unzen schedule should install a meter");
 
     assert!(std::ptr::eq(meter.schedule(), &UNZEN_ZK_GAS_SCHEDULE));
     assert_eq!(meter.schedule().block_limit, 100_000_000);
@@ -605,17 +498,6 @@ fn high_range_precompile_collision_resolves_to_failsafe_not_canonical() {
         "high-range collider should resolve to the fail-safe, not ecrecover's multiplier"
     );
 
-    assert_eq!(
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&ecrecover),
-        81,
-        "canonical ecrecover should keep its frozen Masaya multiplier"
-    );
-    assert_eq!(
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&collider),
-        FAILSAFE_MULTIPLIER,
-        "high-range collider should resolve to the fail-safe on Masaya too"
-    );
-
     // A second collider on a different low byte (identity, 0x04) — confirms the fix is not a
     // one-off carve-out for 0x01: every canonical precompile had a potential high-range collider.
     let identity_collider = address!("0x1670000000000000000000000000000000010004");
@@ -624,20 +506,13 @@ fn high_range_precompile_collision_resolves_to_failsafe_not_canonical() {
         FAILSAFE_MULTIPLIER,
         "identity collider should resolve to the fail-safe"
     );
-    assert_eq!(
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&identity_collider),
-        FAILSAFE_MULTIPLIER,
-        "identity collider should resolve to the fail-safe on Masaya"
-    );
 }
 
 #[test]
 fn full_address_lookup_preserves_canonical_precompile_multipliers() {
-    // Masaya stays byte-identical: every listed precompile keeps its frozen multiplier, so its
-    // finalized blocks' zk-gas total (committed to the header `difficulty` field) is preserved.
-    // On the default schedule the non-BLS precompiles (0x01..=0x0a) keep their pre-fix multipliers;
-    // the BLS12 precompiles keep the same values but now sit at their canonical Osaka addresses
-    // (0x0b..=0x11), so the stale draft keys 0x12/0x13 fall back to the fail-safe.
+    // The non-BLS precompiles (0x01..=0x0a) keep their pre-fix multipliers; the BLS12 precompiles
+    // keep the same values but now sit at their canonical Osaka addresses (0x0b..=0x11), so the
+    // stale draft keys 0x12/0x13 fall back to the fail-safe.
     let default_expected: [(u8, u16); 17] = [
         (0x01, 47),
         (0x02, 10),
@@ -665,36 +540,9 @@ fn full_address_lookup_preserves_canonical_precompile_multipliers() {
         );
     }
 
-    let masaya_expected: [(u8, u16); 17] = [
-        (0x01, 81),
-        (0x02, 10),
-        (0x03, 3),
-        (0x04, 2),
-        (0x05, 1363),
-        (0x06, 38),
-        (0x07, 87),
-        (0x08, 82),
-        (0x09, 243),
-        (0x0a, 398),
-        (0x0b, 112),
-        (0x0c, 52),
-        (0x0e, 111),
-        (0x0f, 39),
-        (0x11, 134),
-        (0x12, 159),
-        (0x13, 112),
-    ];
-    for (byte, multiplier) in masaya_expected {
-        assert_eq!(
-            MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(byte)),
-            multiplier,
-            "masaya precompile {byte:#04x}"
-        );
-    }
-
-    // Default schedule: the obsolete draft keys 0x12/0x13 are no longer listed — the spec moved
-    // the BLS12 precompiles down to their canonical Osaka addresses — and out-of-range bytes fall
-    // back to the fail-safe.
+    // The obsolete draft keys 0x12/0x13 are no longer listed — the spec moved the BLS12
+    // precompiles down to their canonical Osaka addresses — and out-of-range bytes fall back to
+    // the fail-safe.
     for byte in [0x12_u8, 0x13, 0x14] {
         assert_eq!(
             UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(byte)),
@@ -702,33 +550,18 @@ fn full_address_lookup_preserves_canonical_precompile_multipliers() {
             "default: unlisted byte {byte:#04x}"
         );
     }
-
-    // Masaya stays frozen on the draft addresses, so the canonical-only bytes 0x0d/0x10 it never
-    // adopted, plus out-of-range bytes, fall back to the fail-safe.
-    for byte in [0x0d_u8, 0x10, 0x14] {
-        assert_eq!(
-            MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&Address::with_last_byte(byte)),
-            FAILSAFE_MULTIPLIER,
-            "masaya: unlisted byte {byte:#04x}"
-        );
-    }
 }
 
 #[test]
 fn precompile_tables_have_no_duplicate_addresses() {
-    for (label, table) in [
-        ("default", UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers),
-        ("masaya", MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers),
-    ] {
-        let mut seen = std::collections::HashSet::new();
-        for (addr, _) in table {
-            assert!(seen.insert(addr), "{label} precompile table has duplicate address {addr}");
-        }
+    let mut seen = std::collections::HashSet::new();
+    for (addr, _) in UNZEN_ZK_GAS_SCHEDULE.precompile_multipliers {
+        assert!(seen.insert(addr), "default precompile table has duplicate address {addr}");
     }
 }
 
 #[test]
-fn unzen_schedule_meters_p256verify_and_freezes_masaya() {
+fn unzen_schedule_meters_p256verify() {
     // p256verify (RIP-7212) lives at 0x0000…0100 — outside the canonical 0x..XX
     // precompile range. revm's Osaka set (which Unzen maps to) makes it active, so
     // it must carry a real multiplier on the default schedule instead of the
@@ -740,32 +573,15 @@ fn unzen_schedule_meters_p256verify_and_freezes_masaya() {
         163,
         "default Unzen schedule must meter p256verify at 163"
     );
-
-    // Masaya stays frozen: its finalized blocks committed their zk-gas total to the
-    // header `difficulty` field, so p256verify must keep resolving to the fail-safe
-    // there rather than adopting 163 retroactively.
-    assert_eq!(
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.precompile_multiplier(&p256verify),
-        FAILSAFE_MULTIPLIER,
-        "Masaya schedule must keep p256verify frozen at the fail-safe multiplier"
-    );
 }
 
 #[test]
-fn unzen_schedule_meters_clz_and_freezes_masaya() {
+fn unzen_schedule_meters_clz() {
     // CLZ (EIP-7939) is added in Osaka at opcode 0x1e, which Unzen maps to. Without an explicit
     // entry the fail-safe multiplier (u16::MAX) would brick any block using the opcode, so the
     // default schedule must meter it at the spec value.
     assert_eq!(
         UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0x1e], 14,
         "default Unzen schedule must meter clz at 14"
-    );
-
-    // Masaya stays frozen: its finalized blocks committed their zk-gas total to the header
-    // `difficulty` field, so clz must keep resolving to the fail-safe there rather than adopting
-    // 14 retroactively.
-    assert_eq!(
-        MASAYA_UNZEN_ZK_GAS_SCHEDULE.opcode_multipliers[0x1e], FAILSAFE_MULTIPLIER,
-        "Masaya schedule must keep clz frozen at the fail-safe multiplier"
     );
 }

--- a/crates/evm/src/zk_gas/unzen.rs
+++ b/crates/evm/src/zk_gas/unzen.rs
@@ -1,9 +1,5 @@
 //! Fixed Unzen zk gas schedule constants copied from the approved protocol spec.
 //!
-//! The default schedule (Devnet / Hoodi / Mainnet) uses the recalibrated opcode and precompile
-//! multipliers. The Masaya schedule keeps the prior multipliers frozen to preserve consensus on
-//! its already-finalized Unzen blocks.
-//!
 //! Source:
 //! <https://github.com/taikoxyz/taiko-mono/blob/main/packages/protocol/docs/zk_gas_spec.md>
 
@@ -14,21 +10,11 @@ use super::schedule::{FAILSAFE_MULTIPLIER, SpawnEstimates, ZkGasSchedule};
 /// Maximum zk gas permitted within a single Unzen block on Devnet, Hoodi, and Mainnet.
 pub const BLOCK_ZK_GAS_LIMIT: u64 = 100_000_000;
 
-/// Maximum zk gas permitted within a single Unzen block on the Taiko Masaya network.
-pub const MASAYA_BLOCK_ZK_GAS_LIMIT: u64 = 1_000_000_000;
-
 /// Fixed zk gas charged once per block transaction on Devnet, Hoodi, and Mainnet Unzen.
 ///
 /// Value sourced from <https://github.com/taikoxyz/taiko-mono/pull/21669>; covers the proving
 /// cost of per-transaction sender ecrecovery.
 pub const TX_INTRINSIC_ZK_GAS: u64 = 243_000;
-
-/// Fixed zk gas charged once per block transaction on the Taiko Masaya network.
-///
-/// Pinned at `0` because Masaya activated Unzen before [taikoxyz/taiko-mono#21669] landed;
-/// adopting the non-zero value retroactively would break consensus on already-finalized
-/// blocks (their `difficulty` header equals the finalized block zk gas).
-pub const MASAYA_TX_INTRINSIC_ZK_GAS: u64 = 0;
 
 /// Builds an Unzen-shaped zk gas schedule from the requested block limit, per-transaction
 /// intrinsic charge, and opcode/precompile multiplier tables. Spawn estimates are identical
@@ -64,175 +50,6 @@ pub static UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = unzen_schedule_with(
     UNZEN_PRECOMPILE_MULTIPLIERS,
 );
 
-/// Unzen zk gas schedule used by the Taiko Masaya network: a 10× higher block budget, a zero
-/// intrinsic charge, and multipliers frozen at their pre-recalibration values to preserve
-/// consensus on already-finalized blocks.
-pub static MASAYA_UNZEN_ZK_GAS_SCHEDULE: ZkGasSchedule = unzen_schedule_with(
-    MASAYA_BLOCK_ZK_GAS_LIMIT,
-    MASAYA_TX_INTRINSIC_ZK_GAS,
-    masaya_unzen_opcode_multipliers(),
-    MASAYA_UNZEN_PRECOMPILE_MULTIPLIERS,
-);
-
-/// Returns the frozen Masaya Unzen opcode multiplier table, pinned at the pre-recalibration values.
-///
-/// Recalibrating these retroactively would break consensus on Masaya's already-finalized Unzen
-/// blocks (their `difficulty` header equals the finalized block zk gas), so they stay frozen —
-/// same rationale as [`MASAYA_TX_INTRINSIC_ZK_GAS`].
-const fn masaya_unzen_opcode_multipliers() -> [u16; 256] {
-    let mut array = [FAILSAFE_MULTIPLIER; 256];
-    array[0x09] = 152; // mulmod
-    array[0x04] = 110; // div
-    array[0x06] = 95; // mod
-    array[0x05] = 93; // sdiv
-    array[0x47] = 85; // selfbalance
-    array[0x20] = 85; // keccak256
-    array[0x08] = 71; // addmod
-    array[0x14] = 35; // eq
-    array[0x0a] = 33; // exp
-    array[0x07] = 29; // smod
-    array[0x1d] = 29; // sar
-    array[0x44] = 28; // prevrandao
-    array[0xf1] = 25; // call
-    array[0xf2] = 24; // callcode
-    array[0xfa] = 24; // staticcall
-    array[0x52] = 22; // mstore
-    array[0x30] = 22; // address
-    array[0x32] = 21; // origin
-    array[0x33] = 21; // caller
-    array[0x02] = 21; // mul
-    array[0xf4] = 21; // delegatecall
-    array[0x41] = 21; // coinbase
-    array[0x0b] = 21; // signextend
-    array[0x1b] = 20; // shl
-    array[0x35] = 20; // calldataload
-    array[0x51] = 20; // mload
-    array[0x93] = 19; // swap4
-    array[0x9c] = 19; // swap13
-    array[0x1c] = 19; // shr
-    array[0x9b] = 19; // swap12
-    array[0x9a] = 18; // swap11
-    array[0x92] = 18; // swap3
-    array[0x9d] = 18; // swap14
-    array[0x98] = 18; // swap9
-    array[0x91] = 18; // swap2
-    array[0x7e] = 18; // push31
-    array[0x9f] = 18; // swap16
-    array[0x9e] = 17; // swap15
-    array[0x7c] = 17; // push29
-    array[0x7b] = 17; // push28
-    array[0x96] = 17; // swap7
-    array[0x95] = 17; // swap6
-    array[0x99] = 17; // swap10
-    array[0x7f] = 17; // push32
-    array[0x90] = 16; // swap1
-    array[0x77] = 16; // push24
-    array[0x94] = 16; // swap5
-    array[0x75] = 16; // push22
-    array[0x97] = 15; // swap8
-    array[0x7a] = 15; // push27
-    array[0x4a] = 15; // blobbasefee
-    array[0x3a] = 14; // gasprice
-    array[0x79] = 14; // push26
-    array[0x12] = 14; // slt
-    array[0x74] = 14; // push21
-    array[0x13] = 14; // sgt
-    array[0x03] = 13; // sub
-    array[0x34] = 13; // callvalue
-    array[0x78] = 13; // push25
-    array[0x70] = 13; // push17
-    array[0x73] = 13; // push20
-    array[0x39] = 13; // codecopy
-    array[0x55] = 13; // sstore
-    array[0x6d] = 12; // push14
-    array[0x37] = 12; // calldatacopy
-    array[0x7d] = 12; // push30
-    array[0x76] = 12; // push23
-    array[0x58] = 12; // pc
-    array[0x01] = 12; // add
-    array[0x72] = 11; // push19
-    array[0x5a] = 11; // gas
-    array[0x42] = 11; // timestamp
-    array[0x48] = 11; // basefee
-    array[0x43] = 11; // number
-    array[0x71] = 11; // push18
-    array[0x36] = 11; // calldatasize
-    array[0x6f] = 11; // push16
-    array[0x38] = 11; // codesize
-    array[0x46] = 11; // chainid
-    array[0x10] = 11; // lt
-    array[0x45] = 11; // gaslimit
-    array[0x59] = 11; // msize
-    array[0x3d] = 10; // returndatasize
-    array[0x5f] = 10; // push0
-    array[0x6e] = 10; // push15
-    array[0x11] = 10; // gt
-    array[0x69] = 10; // push10
-    array[0x49] = 10; // blobhash
-    array[0x6b] = 9; // push12
-    array[0x68] = 9; // push9
-    array[0x17] = 9; // or
-    array[0x53] = 9; // mstore8
-    array[0x1a] = 9; // byte
-    array[0x18] = 9; // xor
-    array[0x5b] = 9; // jumpdest
-    array[0x3e] = 9; // returndatacopy
-    array[0x6a] = 8; // push11
-    array[0x16] = 8; // and
-    array[0x8b] = 8; // dup12
-    array[0x8e] = 8; // dup15
-    array[0x65] = 8; // push6
-    array[0x63] = 8; // push4
-    array[0x15] = 8; // iszero
-    array[0x3f] = 8; // extcodehash
-    array[0x6c] = 7; // push13
-    array[0x66] = 7; // push7
-    array[0x40] = 7; // blockhash
-    array[0x88] = 7; // dup9
-    array[0x67] = 7; // push8
-    array[0x8d] = 7; // dup14
-    array[0xa1] = 7; // log1
-    array[0xa0] = 6; // log0
-    array[0x19] = 6; // not
-    array[0x8f] = 6; // dup16
-    array[0x84] = 6; // dup5
-    array[0x62] = 6; // push3
-    array[0x85] = 6; // dup6
-    array[0x87] = 6; // dup8
-    array[0x3b] = 6; // extcodesize
-    array[0x31] = 6; // balance
-    array[0x80] = 6; // dup1
-    array[0x82] = 6; // dup3
-    array[0x5d] = 6; // tstore
-    array[0x8c] = 6; // dup13
-    array[0x8a] = 6; // dup11
-    array[0x3c] = 6; // extcodecopy
-    array[0x83] = 6; // dup4
-    array[0x64] = 6; // push5
-    array[0x50] = 5; // pop
-    array[0x54] = 5; // sload
-    array[0x5e] = 5; // mcopy
-    array[0x60] = 5; // push1
-    array[0x89] = 5; // dup10
-    array[0x61] = 5; // push2
-    array[0x86] = 5; // dup7
-    array[0xa3] = 5; // log3
-    array[0x81] = 5; // dup2
-    array[0xa4] = 5; // log4
-    array[0x57] = 5; // jumpi
-    array[0xa2] = 4; // log2
-    array[0x56] = 3; // jump
-    array[0x5c] = 1; // tload
-    array[0xf0] = 1; // create
-    array[0xf5] = 1; // create2
-    array[0x00] = 0; // stop
-    array[0xf3] = 0; // return
-    array[0xfd] = 0; // revert
-    array[0xff] = 0; // selfdestruct
-    array[0xfe] = 0; // invalid
-    array
-}
-
 /// Recalibrated Unzen precompile multipliers (Devnet / Hoodi / Mainnet), keyed by full address.
 /// Precompiles not listed here fall back to [`FAILSAFE_MULTIPLIER`]. The canonical EVM precompiles
 /// set only their last byte (`0x…01` through `0x…11`), so [`Address::with_last_byte`] spells their
@@ -259,30 +76,6 @@ const UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
     // p256verify (RIP-7212) at 0x0000…0100 — outside the canonical 0x..XX range, so it
     // needs a full-address literal. Multiplier from taikoxyz/taiko-mono#21748.
     (address!("0x0000000000000000000000000000000000000100"), 163),
-];
-
-/// Frozen Masaya Unzen precompile multipliers, keyed by full address. Pinned at the
-/// pre-recalibration values to preserve consensus on already-finalized Masaya blocks (their
-/// `difficulty` header equals the finalized block zk gas). As above, canonical precompiles live at
-/// `0x0000…00XX`, so [`Address::with_last_byte`] spells their keys.
-const MASAYA_UNZEN_PRECOMPILE_MULTIPLIERS: &[(Address, u16)] = &[
-    (Address::with_last_byte(0x01), 81),   // ecrecover
-    (Address::with_last_byte(0x02), 10),   // sha256
-    (Address::with_last_byte(0x03), 3),    // ripemd160
-    (Address::with_last_byte(0x04), 2),    // identity
-    (Address::with_last_byte(0x05), 1363), // modexp
-    (Address::with_last_byte(0x06), 38),   // bn128_add
-    (Address::with_last_byte(0x07), 87),   // bn128_mul
-    (Address::with_last_byte(0x08), 82),   // bn128_pairing
-    (Address::with_last_byte(0x09), 243),  // blake2f
-    (Address::with_last_byte(0x0a), 398),  // point_evaluation
-    (Address::with_last_byte(0x0b), 112),  // bls12_g1add
-    (Address::with_last_byte(0x0c), 52),   // bls12_g1msm
-    (Address::with_last_byte(0x0e), 111),  // bls12_g2add
-    (Address::with_last_byte(0x0f), 39),   // bls12_g2msm
-    (Address::with_last_byte(0x11), 134),  // bls12_pairing
-    (Address::with_last_byte(0x12), 159),  // bls12_map_fp_to_g1
-    (Address::with_last_byte(0x13), 112),  // bls12_map_fp2_to_g2
 ];
 
 /// Returns the recalibrated Unzen opcode multiplier table, with fail-safe defaults for unlisted


### PR DESCRIPTION
## Why

The Masaya network is being **reset**. Masaya had activated Unzen *early* — before the zk-gas recalibration and the per-tx intrinsic charge ([taiko-mono#21669](https://github.com/taikoxyz/taiko-mono/pull/21669)) landed — so the codebase carried a **frozen Masaya-specific zk-gas schedule** (10× block budget, zero intrinsic, pre-recalibration multiplier tables) purely to preserve consensus on its already-finalized blocks. The reset discards those blocks, so the special-casing is now dead, and Masaya will fork into Unzen **from genesis** using the standard schedule.

## What changed

**1. Chainspec — Masaya forks Unzen from genesis** (`crates/chainspec`)
- `TAIKO_MASAYA_HARDFORKS`: Unzen activation `Timestamp(1_778_158_800)` → `Timestamp(0)`. Masaya's table now matches Devnet's.
- Re-pinned `TAIKO_MASAYA_GENESIS_HASH` to the new Osaka-era genesis hash `0xd3597fd63c823352526ce2a4cfafe0837d878e3c9ac8558129bc04ce900402ae` (Unzen-at-genesis makes the header Osaka-era, adding blob/requests fields). Computed and validated by the existing `test_taiko_genesis_json_hashes`. The `genesis/masaya.json` **content is unchanged**.
- Added `test_masaya_unzen_activates_at_genesis`.

**2. EVM — collapse the zk-gas schedule** (`crates/evm`, `crates/block`)
- Deleted `MASAYA_BLOCK_ZK_GAS_LIMIT`, `MASAYA_TX_INTRINSIC_ZK_GAS`, `MASAYA_UNZEN_ZK_GAS_SCHEDULE`, `masaya_unzen_opcode_multipliers()`, and `MASAYA_UNZEN_PRECOMPILE_MULTIPLIERS`.
- Simplified `schedule_for(spec, chain_id)` → `schedule_for(spec)` — every chain now uses the single `UNZEN_ZK_GAS_SCHEDULE`. Updated both `factory.rs` call sites.
- Pruned the Masaya-specific tests and reworded the few comments that referenced the frozen-Masaya / zero-intrinsic case.

## Out of scope (intentionally untouched)
- `crates/rpc/src/eth/auth/lookup.rs` `TAIKO_MASAYA_CHAIN_ID` branch — Pacaya batch-lookup filtering, unrelated to zk gas, and already equivalent to its fallback.

## Verification
- `just fmt`, `just clippy` (warnings = errors) — clean.
- `just test` — **186 passed, 0 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)