### PR TITLE
refactor(block): simplify `TaikoBlockAssembler` and `StoredL1Origin` conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-bin"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alethia-reth-cli",
  "alethia-reth-node",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-block"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-evm",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-chainspec"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-cli"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alethia-reth-block",
  "alethia-reth-chainspec",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-consensus"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-evm",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-db"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alethia-reth-primitives",
  "alloy-primitives",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-evm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alethia-reth-chainspec",
  "alethia-reth-primitives",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-node"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alethia-reth-block",
  "alethia-reth-chainspec",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-payload"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alethia-reth-block",
  "alethia-reth-chainspec",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-primitives"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-rpc"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alethia-reth-block",
  "alethia-reth-chainspec",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "alethia-reth-rpc-types"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-primitives",
  "serde",

--- a/crates/block/src/assembler.rs
+++ b/crates/block/src/assembler.rs
@@ -1,6 +1,4 @@
 //! Block assembler implementation for Taiko headers and block bodies.
-use std::sync::Arc;
-
 use alloy_consensus::{
     BlockBody, EMPTY_OMMER_ROOT_HASH, Header, TxReceipt, constants::EMPTY_WITHDRAWALS, proofs,
 };
@@ -12,32 +10,18 @@ use reth_evm::{
     block::{BlockExecutionError, BlockExecutorFactory},
     execute::{BlockAssembler, BlockAssemblerInput},
 };
-use reth_evm_ethereum::EthBlockAssembler;
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::logs_bloom;
 use reth_revm::context::Block as _;
 
 use crate::factory::TaikoBlockExecutionCtx;
-use alethia_reth_chainspec::spec::TaikoChainSpec;
 
 /// A block assembler for the Taiko network that implements the `BlockAssembler` trait.
-#[derive(Clone, Debug)]
-pub struct TaikoBlockAssembler {
-    /// Underlying Ethereum block assembler configured with Taiko chain spec.
-    block_assembler: EthBlockAssembler<TaikoChainSpec>,
-}
-
-impl TaikoBlockAssembler {
-    /// Creates a new instance of the [`TaikoBlockAssembler`] with the given chain specification.
-    pub fn new(chain_spec: Arc<TaikoChainSpec>) -> Self {
-        Self { block_assembler: EthBlockAssembler::new(chain_spec) }
-    }
-
-    /// Returns a reference to the chain specification.
-    pub fn chain_spec(&self) -> Arc<TaikoChainSpec> {
-        self.block_assembler.chain_spec.clone()
-    }
-}
+///
+/// Taiko headers are assembled entirely from the execution context and EVM environment, so the
+/// assembler carries no state.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TaikoBlockAssembler;
 
 impl<F> BlockAssembler<F> for TaikoBlockAssembler
 where
@@ -118,7 +102,6 @@ where
 mod test {
     use alloy_consensus::{Header, Signed, TxLegacy};
     use alloy_eips::eip7685::{EMPTY_REQUESTS_HASH, Requests};
-    use alloy_hardforks::ForkCondition;
     use alloy_primitives::{Address, B256, Bytes, ChainId, Signature, TxKind, U256};
     use reth_evm::{
         EvmEnv,
@@ -131,20 +114,11 @@ mod test {
 
     use super::*;
     use crate::factory::{TaikoBlockExecutionCtx, TaikoBlockExecutorFactory};
-    use alethia_reth_chainspec::{TAIKO_DEVNET, hardfork::TaikoHardfork};
     use alethia_reth_evm::spec::TaikoSpecId;
 
     #[test]
-    fn test_get_chain_spec() {
-        let chain_spec = Arc::new(TaikoChainSpec::default());
-        let assembler = TaikoBlockAssembler::new(chain_spec.clone());
-
-        assert_eq!(assembler.chain_spec(), chain_spec);
-    }
-
-    #[test]
     fn assembled_unzen_block_uses_final_zk_gas_as_difficulty() {
-        let assembler = TaikoBlockAssembler::new(Arc::new(TaikoChainSpec::default()));
+        let assembler = TaikoBlockAssembler;
         let mut evm_env: EvmEnv<TaikoSpecId> = EvmEnv::default();
         evm_env.cfg_env.spec = TaikoSpecId::UNZEN;
         evm_env.block_env.number = U256::from(1);
@@ -193,9 +167,7 @@ mod test {
 
     #[test]
     fn assembled_unzen_block_sets_requests_hash() {
-        let mut chain_spec = (*TAIKO_DEVNET).as_ref().clone();
-        chain_spec.inner.hardforks.insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(0));
-        let assembler = TaikoBlockAssembler::new(Arc::new(chain_spec));
+        let assembler = TaikoBlockAssembler;
         let mut evm_env: EvmEnv<TaikoSpecId> = EvmEnv::default();
         evm_env.cfg_env.spec = TaikoSpecId::UNZEN;
         evm_env.block_env.number = U256::from(1);

--- a/crates/block/src/config.rs
+++ b/crates/block/src/config.rs
@@ -99,7 +99,7 @@ impl TaikoEvmConfig {
         evm_factory: TaikoEvmFactory,
     ) -> Self {
         Self {
-            block_assembler: TaikoBlockAssembler::new(chain_spec.clone()),
+            block_assembler: TaikoBlockAssembler,
             executor_factory: TaikoBlockExecutorFactory::new(
                 RethReceiptBuilder::default(),
                 chain_spec,

--- a/crates/db/src/model.rs
+++ b/crates/db/src/model.rs
@@ -38,15 +38,7 @@ pub struct StoredL1Origin {
 impl From<RpcL1Origin> for StoredL1Origin {
     // Converts an `RpcL1Origin` into a `StoredL1Origin`.
     fn from(rpc_l1_origin: RpcL1Origin) -> Self {
-        StoredL1Origin {
-            block_id: rpc_l1_origin.block_id,
-            l2_block_hash: rpc_l1_origin.l2_block_hash,
-            l1_block_height: rpc_l1_origin.l1_block_height.unwrap_or(U256::ZERO),
-            l1_block_hash: rpc_l1_origin.l1_block_hash.unwrap_or(B256::ZERO),
-            build_payload_args_id: rpc_l1_origin.build_payload_args_id,
-            is_forced_inclusion: rpc_l1_origin.is_forced_inclusion,
-            signature: rpc_l1_origin.signature,
-        }
+        Self::from(&rpc_l1_origin)
     }
 }
 


### PR DESCRIPTION
## Summary

Two small over-design cleanups from a workspace-wide simplification scan:

- **`TaikoBlockAssembler` is now a stateless unit struct.** It previously held an `EthBlockAssembler<TaikoChainSpec>` that was never used for assembly — `assemble_block` builds the Taiko header entirely from the execution context and EVM environment. The inner assembler's only reader was the `chain_spec()` accessor, whose only caller was the struct's own unit test. `TaikoEvmConfig` no longer clones a chain spec into the assembler. Note: `TaikoBlockAssembler::new(chain_spec)` is removed; construct `TaikoBlockAssembler` directly.
- **`StoredL1Origin`'s owned `From<RpcL1Origin>` impl delegates to the borrowed impl** instead of duplicating the seven-field mapping verbatim.
- `Cargo.lock` syncs the workspace crate versions left behind by the 1.2.0 release commit (any cargo invocation regenerates this).

## Test plan

- `just fmt` — clean
- `just clippy` — clean (warnings denied)
- `just test` — 196 tests run: 196 passed, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)