### PR TITLE
feat(evm): single-dimension gas repricing primitives (1/3)

### DIFF
--- a/crates/evm/src/gas_reprice/intrinsic.rs
+++ b/crates/evm/src/gas_reprice/intrinsic.rs
@@ -1,0 +1,1 @@
+//! Placeholder; implemented in a later task.

--- a/crates/evm/src/gas_reprice/intrinsic.rs
+++ b/crates/evm/src/gas_reprice/intrinsic.rs
@@ -1,1 +1,53 @@
-//! Placeholder; implemented in a later task.
+//! Per-transaction intrinsic gas surcharge for the repriced fork.
+
+use reth_revm::{context::result::InvalidTransaction, interpreter::InitialAndFloorGas};
+
+/// Adds `surcharge` to `gas.initial_total_gas` and re-checks it against `gas_limit`.
+///
+/// The surcharge is a per-transaction intrinsic proving cost, so it lifts only
+/// `initial_total_gas`. `floor_gas` (the EIP-7623 calldata floor) is deliberately left
+/// unchanged — it is a separate lower bound, and because the surcharge is already part of
+/// `initial_total_gas` it is charged regardless of which bound dominates.
+///
+/// This re-runs only the same `initial_total_gas <= gas_limit` check revm performs (raising
+/// the identical `CallGasCostMoreThanGasLimit`); revm's separate `floor_gas` check is
+/// unaffected and still applies wherever this result is fed back into validation.
+pub fn add_tx_intrinsic_surcharge(
+    mut gas: InitialAndFloorGas,
+    surcharge: u64,
+    gas_limit: u64,
+) -> Result<InitialAndFloorGas, InvalidTransaction> {
+    gas.initial_total_gas = gas.initial_total_gas.saturating_add(surcharge);
+    if gas.initial_total_gas > gas_limit {
+        return Err(InvalidTransaction::CallGasCostMoreThanGasLimit {
+            gas_limit,
+            initial_gas: gas.initial_total_gas,
+        });
+    }
+    Ok(gas)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn surcharge_adds_to_initial_total_gas() {
+        let gas = InitialAndFloorGas::new(21_000, 0);
+        let out = add_tx_intrinsic_surcharge(gas, 243_000, 1_000_000).expect("fits");
+        assert_eq!(out.initial_total_gas, 264_000);
+    }
+
+    #[test]
+    fn surcharge_exceeding_limit_is_rejected() {
+        let gas = InitialAndFloorGas::new(21_000, 0);
+        let err = add_tx_intrinsic_surcharge(gas, 243_000, 100_000).expect_err("over limit");
+        assert!(matches!(
+            err,
+            InvalidTransaction::CallGasCostMoreThanGasLimit {
+                gas_limit: 100_000,
+                initial_gas: 264_000
+            }
+        ));
+    }
+}

--- a/crates/evm/src/gas_reprice/mod.rs
+++ b/crates/evm/src/gas_reprice/mod.rs
@@ -6,11 +6,11 @@
 //! on [`TaikoSpecId`](crate::spec::TaikoSpecId) activates them. All numeric values in
 //! [`schedule`] are non-consensus placeholders pending calibration.
 
-/// Per-opcode / per-tx surcharge schedule types and the example placeholder schedule.
-pub mod schedule;
+/// Per-transaction intrinsic gas surcharge helper.
+pub mod intrinsic;
 /// Repriced instruction-table builder (additive opcode `static_gas` surcharge).
 pub mod opcodes;
 /// Input-scaled precompile reprice via `PrecompilesMap` overrides.
 pub mod precompiles;
-/// Per-transaction intrinsic gas surcharge helper.
-pub mod intrinsic;
+/// Per-opcode / per-tx surcharge schedule types and the example placeholder schedule.
+pub mod schedule;

--- a/crates/evm/src/gas_reprice/mod.rs
+++ b/crates/evm/src/gas_reprice/mod.rs
@@ -1,0 +1,16 @@
+//! Single-dimension gas repricing primitives for a future Taiko fork.
+//!
+//! Pure building blocks — an opcode `static_gas` surcharge table ([`opcodes`]), an
+//! input-scaled precompile reprice ([`precompiles`]), and a per-transaction intrinsic
+//! surcharge ([`intrinsic`]). They are not yet wired into execution; a future fork gate
+//! on [`TaikoSpecId`](crate::spec::TaikoSpecId) activates them. All numeric values in
+//! [`schedule`] are non-consensus placeholders pending calibration.
+
+/// Per-opcode / per-tx surcharge schedule types and the example placeholder schedule.
+pub mod schedule;
+/// Repriced instruction-table builder (additive opcode `static_gas` surcharge).
+pub mod opcodes;
+/// Input-scaled precompile reprice via `PrecompilesMap` overrides.
+pub mod precompiles;
+/// Per-transaction intrinsic gas surcharge helper.
+pub mod intrinsic;

--- a/crates/evm/src/gas_reprice/opcodes.rs
+++ b/crates/evm/src/gas_reprice/opcodes.rs
@@ -1,0 +1,1 @@
+//! Placeholder; implemented in a later task.

--- a/crates/evm/src/gas_reprice/opcodes.rs
+++ b/crates/evm/src/gas_reprice/opcodes.rs
@@ -21,7 +21,6 @@ use super::schedule::RepriceSchedule;
 /// Maintenance: the `(opcode, f)` pairs in [`repriced_instruction_table`] duplicate revm's
 /// own opcode-to-function mapping. When bumping the reth/revm pin, re-verify each pair
 /// against revm's instruction table — a fn that moved would otherwise be silently replaced.
-#[inline]
 fn reprice<W, H>(
     table: &mut InstructionTable<W, H>,
     opcode: usize,

--- a/crates/evm/src/gas_reprice/opcodes.rs
+++ b/crates/evm/src/gas_reprice/opcodes.rs
@@ -102,4 +102,22 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn surcharge_on_unwired_opcode_is_ignored() {
+        // The builder reprices only opcodes whose fn it names; a schedule entry for any
+        // other opcode (here SSTORE 0x55) is intentionally dropped, not applied. This pins
+        // that contract so extending coverage is a conscious change to the builder.
+        let spec = SpecId::OSAKA;
+        let mut schedule = example_reprice_schedule();
+        schedule.opcode_surcharge[0x55] = 999;
+        let base = instruction_table_gas_changes_spec::<EthInterpreter, Ctx>(spec);
+        let table = repriced_instruction_table::<EthInterpreter, Ctx>(spec, &schedule);
+
+        assert_eq!(
+            table[0x55].static_gas(),
+            base[0x55].static_gas(),
+            "surcharge on an unwired opcode (SSTORE) must be ignored"
+        );
+    }
 }

--- a/crates/evm/src/gas_reprice/opcodes.rs
+++ b/crates/evm/src/gas_reprice/opcodes.rs
@@ -1,1 +1,105 @@
-//! Placeholder; implemented in a later task.
+//! Builds an instruction table whose repriced opcodes carry an additive `static_gas`
+//! surcharge on top of the Ethereum spec base table.
+
+use reth_revm::{
+    interpreter::{
+        Host, Instruction, InstructionContext, InstructionTable,
+        instructions::{arithmetic, host, instruction_table_gas_changes_spec, memory, system},
+        interpreter_types::InterpreterTypes,
+    },
+    revm::primitives::hardfork::SpecId,
+};
+
+use super::schedule::RepriceSchedule;
+
+/// Rebuilds one table entry as `Instruction::new(f, base_static_gas + surcharge)`.
+///
+/// `f` MUST be the same revm instruction fn the base table uses for `opcode`; only the
+/// static gas changes. `static_gas` is private with no setter, so the fn is named
+/// explicitly and the entry reconstructed.
+///
+/// Maintenance: the `(opcode, f)` pairs in [`repriced_instruction_table`] duplicate revm's
+/// own opcode-to-function mapping. When bumping the reth/revm pin, re-verify each pair
+/// against revm's instruction table — a fn that moved would otherwise be silently replaced.
+#[inline]
+fn reprice<W, H>(
+    table: &mut InstructionTable<W, H>,
+    opcode: usize,
+    f: fn(InstructionContext<'_, H, W>),
+    surcharge: u64,
+) where
+    W: InterpreterTypes,
+    H: Host,
+{
+    let base = table[opcode].static_gas();
+    table[opcode] = Instruction::new(f, base.saturating_add(surcharge));
+}
+
+/// Returns the Ethereum spec base table with the schedule's opcode surcharges added.
+///
+/// The repriced opcode set is the explicit list below. Calibration (out of scope) extends
+/// this list following the identical `reprice(...)` pattern.
+pub fn repriced_instruction_table<W, H>(
+    eth_spec: SpecId,
+    schedule: &RepriceSchedule,
+) -> InstructionTable<W, H>
+where
+    W: InterpreterTypes,
+    H: Host,
+{
+    let surcharges = &schedule.opcode_surcharge;
+    let mut table = instruction_table_gas_changes_spec::<W, H>(eth_spec);
+
+    reprice(&mut table, 0x01, arithmetic::add::<W, H>, surcharges[0x01]);
+    reprice(&mut table, 0x02, arithmetic::mul::<W, H>, surcharges[0x02]);
+    reprice(&mut table, 0x20, system::keccak256::<W, H>, surcharges[0x20]);
+    reprice(&mut table, 0x51, memory::mload::<W, H>, surcharges[0x51]);
+    reprice(&mut table, 0x54, host::sload::<W, H>, surcharges[0x54]);
+
+    table
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{alloy::TaikoEvmContext, gas_reprice::schedule::example_reprice_schedule};
+    use reth_revm::{db::EmptyDB, interpreter::interpreter::EthInterpreter};
+
+    type Ctx = TaikoEvmContext<EmptyDB>;
+
+    #[test]
+    fn repriced_entries_add_surcharge_over_base() {
+        let spec = SpecId::OSAKA;
+        let schedule = example_reprice_schedule();
+        let base = instruction_table_gas_changes_spec::<EthInterpreter, Ctx>(spec);
+        let table = repriced_instruction_table::<EthInterpreter, Ctx>(spec, &schedule);
+
+        for op in [0x01usize, 0x02, 0x20, 0x51, 0x54] {
+            assert_eq!(
+                table[op].static_gas(),
+                // Mirror the production arithmetic so the test stays correct in the
+                // saturating region (e.g. a future sentinel surcharge).
+                base[op].static_gas().saturating_add(schedule.opcode_surcharge[op]),
+                "opcode {op:#x} should be base + surcharge"
+            );
+        }
+    }
+
+    #[test]
+    fn unrepriced_entries_are_unchanged() {
+        let spec = SpecId::OSAKA;
+        let schedule = example_reprice_schedule();
+        let base = instruction_table_gas_changes_spec::<EthInterpreter, Ctx>(spec);
+        let table = repriced_instruction_table::<EthInterpreter, Ctx>(spec, &schedule);
+
+        // Spot-check non-contiguous opcodes outside the repriced set to catch an
+        // off-by-one that clobbers an adjacent slot: STOP, ISZERO, PUSH1.
+        for op in [0x00usize, 0x15, 0x60] {
+            assert_eq!(
+                table[op].static_gas(),
+                base[op].static_gas(),
+                "opcode {op:#x} should be unchanged"
+            );
+        }
+    }
+}

--- a/crates/evm/src/gas_reprice/precompiles.rs
+++ b/crates/evm/src/gas_reprice/precompiles.rs
@@ -1,0 +1,1 @@
+//! Placeholder; implemented in a later task.

--- a/crates/evm/src/gas_reprice/precompiles.rs
+++ b/crates/evm/src/gas_reprice/precompiles.rs
@@ -1,1 +1,173 @@
-//! Placeholder; implemented in a later task.
+//! Input-scaled precompile reprice via [`PrecompilesMap`] overrides.
+//!
+//! Wraps an existing precompile so each call pays an additive surcharge on top of the
+//! precompile's own gas. The surcharge is `base + per_word * ceil(len / 32)`, i.e. a fixed
+//! component plus a component that scales with the 32-byte word count of the input. This
+//! mirrors how the underlying precompiles already meter input (per-word), so proving cost
+//! that grows with input size can be charged without re-deriving each precompile's formula.
+//!
+//! The wrapper preserves the original output bytes and status; it only inflates `gas_used`.
+//! Saturating arithmetic guards against overflow on pathological inputs.
+
+use alloy_primitives::Address;
+use reth_evm::precompiles::{DynPrecompile, Precompile, PrecompilesMap};
+
+/// Additive, input-scaled gas surcharge for a single precompile.
+///
+/// Charged as `base + per_word * ceil(len / 32)`. NON-CONSENSUS placeholder values are
+/// supplied by tests/calibration; this type only carries them.
+#[derive(Clone, Copy, Debug)]
+pub struct PrecompileSurcharge {
+    /// Fixed gas added to every call regardless of input length.
+    pub base: u64,
+    /// Gas added per 32-byte input word (ceil), on top of [`base`](Self::base).
+    pub per_word: u64,
+}
+
+/// Number of 32-byte words spanning `len` bytes, rounding up (`ceil(len / 32)`).
+const fn words(len: usize) -> u64 {
+    (len as u64).div_ceil(32)
+}
+
+/// Wraps the precompile at `address` so each call pays `surcharge` on top of its own gas.
+///
+/// No-op if no precompile is registered at `address` (`map_precompile` only transforms an
+/// existing entry). The wrapper clones the original's `PrecompileId` and forwards every
+/// other field of the output unchanged, adjusting only `gas_used` (saturating).
+pub fn apply_precompile_surcharge(
+    precompiles: &mut PrecompilesMap,
+    address: Address,
+    surcharge: PrecompileSurcharge,
+) {
+    precompiles.map_precompile(&address, move |original| {
+        let id = original.precompile_id().clone();
+        DynPrecompile::new(id, move |input| {
+            let extra = surcharge
+                .base
+                .saturating_add(surcharge.per_word.saturating_mul(words(input.data.len())));
+            let mut out = original.call(input)?;
+            out.gas_used = out.gas_used.saturating_add(extra);
+            Ok(out)
+        })
+    });
+}
+
+#[cfg(test)]
+mod test_support {
+    use alloy_primitives::Address;
+    use reth_evm::precompiles::{Precompile, PrecompilesMap};
+    use reth_revm::{
+        MainContext,
+        context::Context,
+        db::EmptyDB,
+        precompile::{PrecompileSpecId, Precompiles},
+        primitives::hardfork::SpecId,
+    };
+
+    /// Builds an Osaka [`PrecompilesMap`], mirroring the precompile-set construction in
+    /// `factory.rs`.
+    pub(super) fn osaka_precompiles() -> PrecompilesMap {
+        PrecompilesMap::from_static(Precompiles::new(PrecompileSpecId::from_spec_id(SpecId::OSAKA)))
+    }
+
+    /// Resolves the precompile registered at `addr`.
+    ///
+    /// The returned value borrows `map` and exposes `.call(PrecompileInput) -> PrecompileResult`
+    /// via the [`Precompile`] trait. Drop it before mutating `map` (e.g. before applying a
+    /// surcharge), since the borrow is immutable.
+    pub(super) fn get_precompile<'a>(
+        map: &'a PrecompilesMap,
+        addr: &Address,
+    ) -> impl Precompile + 'a {
+        map.get(addr).expect("precompile registered at address")
+    }
+
+    /// A throwaway EVM context whose journal/db back the precompile call's `EvmInternals`.
+    ///
+    /// `EmptyDB` is sufficient because the surcharge wrapper and the identity precompile never
+    /// touch state; the context only satisfies `PrecompileInput`'s required fields.
+    pub(super) fn empty_context() -> Context<
+        reth_revm::context::BlockEnv,
+        reth_revm::context::TxEnv,
+        reth_revm::context::CfgEnv,
+        EmptyDB,
+    > {
+        Context::mainnet().with_db(EmptyDB::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        test_support::{empty_context, get_precompile, osaka_precompiles},
+        *,
+    };
+    use alloy_primitives::{Address, Bytes, U256};
+    use reth_evm::{
+        EvmInternals,
+        precompiles::{Precompile, PrecompileInput},
+    };
+
+    /// Identity precompile address (`0x..04`).
+    const IDENTITY: Address = Address::with_last_byte(0x04);
+
+    /// Calls `precompile` with `input_data` and `gas`, supplying the remaining
+    /// `PrecompileInput` fields from a throwaway context. Returns `gas_used` on success.
+    fn call_gas_used(precompile: &impl Precompile, input_data: &[u8], gas: u64) -> u64 {
+        let mut ctx = empty_context();
+        let data = Bytes::copy_from_slice(input_data);
+        precompile
+            .call(PrecompileInput {
+                data: &data,
+                gas,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                is_static: false,
+                internals: EvmInternals::from_context(&mut ctx),
+                target_address: IDENTITY,
+                bytecode_address: IDENTITY,
+            })
+            .expect("identity precompile call succeeds")
+            .gas_used
+    }
+
+    #[test]
+    fn words_rounds_up() {
+        assert_eq!(words(0), 0);
+        assert_eq!(words(1), 1);
+        assert_eq!(words(32), 1);
+        assert_eq!(words(33), 2);
+    }
+
+    #[test]
+    fn wrapped_call_adds_input_scaled_surcharge() {
+        // 64-byte input spans exactly two 32-byte words.
+        let input = [0u8; 64];
+
+        // Baseline: identity precompile gas for this input, before any surcharge.
+        let mut map = osaka_precompiles();
+        let unwrapped = {
+            let identity = get_precompile(&map, &IDENTITY);
+            call_gas_used(&identity, &input, 1_000_000)
+        };
+
+        // Apply base = 100, per_word = 7. For two words: 100 + 2 * 7 = 114.
+        apply_precompile_surcharge(
+            &mut map,
+            IDENTITY,
+            PrecompileSurcharge { base: 100, per_word: 7 },
+        );
+
+        let wrapped = {
+            let identity = get_precompile(&map, &IDENTITY);
+            call_gas_used(&identity, &input, 1_000_000)
+        };
+
+        assert_eq!(
+            wrapped,
+            unwrapped + 114,
+            "wrapped gas must be base precompile gas plus the input-scaled surcharge (100 + 2*7)"
+        );
+    }
+}

--- a/crates/evm/src/gas_reprice/schedule.rs
+++ b/crates/evm/src/gas_reprice/schedule.rs
@@ -7,6 +7,11 @@
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RepriceSchedule {
     /// Per-opcode additive `static_gas` surcharge, indexed by opcode byte. `0` = unchanged.
+    ///
+    /// Only opcodes explicitly wired in `repriced_instruction_table` take effect; a surcharge
+    /// on any other index is silently ignored (the builder can reprice an opcode only if it
+    /// also names that opcode's instruction fn). Extending coverage means adding to that
+    /// builder, not just setting an entry here.
     pub opcode_surcharge: [u64; 256],
     /// Fixed gas added to every transaction's intrinsic gas (covers ecrecover proving).
     pub tx_intrinsic_surcharge: u64,

--- a/crates/evm/src/gas_reprice/schedule.rs
+++ b/crates/evm/src/gas_reprice/schedule.rs
@@ -1,0 +1,45 @@
+//! Surcharge schedule types for the next-fork gas reprice.
+//!
+//! NON-CONSENSUS: the example values exist only to exercise the builders. Real
+//! surcharges are a separate calibration effort and must match taiko-geth + the prover.
+
+/// Additive gas surcharges applied on top of Ethereum gas for the repriced fork.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RepriceSchedule {
+    /// Per-opcode additive `static_gas` surcharge, indexed by opcode byte. `0` = unchanged.
+    pub opcode_surcharge: [u64; 256],
+    /// Fixed gas added to every transaction's intrinsic gas (covers ecrecover proving).
+    pub tx_intrinsic_surcharge: u64,
+}
+
+/// Returns the example schedule used by tests.
+///
+/// Non-consensus: the values exist only to exercise the builders and must not be used in
+/// production. Real surcharges are derived during calibration.
+pub const fn example_reprice_schedule() -> RepriceSchedule {
+    let mut opcode_surcharge = [0u64; 256];
+    opcode_surcharge[0x01] = 17; // ADD
+    opcode_surcharge[0x02] = 16; // MUL
+    opcode_surcharge[0x20] = 200; // KECCAK256
+    opcode_surcharge[0x51] = 15; // MLOAD
+    opcode_surcharge[0x54] = 6; // SLOAD
+    RepriceSchedule { opcode_surcharge, tx_intrinsic_surcharge: 243_000 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn example_schedule_sets_expected_surcharges() {
+        let s = example_reprice_schedule();
+        assert_eq!(s.opcode_surcharge[0x01], 17); // ADD
+        assert_eq!(s.opcode_surcharge[0x02], 16); // MUL
+        assert_eq!(s.opcode_surcharge[0x20], 200); // KECCAK256
+        assert_eq!(s.opcode_surcharge[0x51], 15); // MLOAD
+        assert_eq!(s.opcode_surcharge[0x54], 6); // SLOAD
+        assert_eq!(s.tx_intrinsic_surcharge, 243_000);
+        // Unlisted opcodes default to zero (unchanged).
+        assert_eq!(s.opcode_surcharge[0xfe], 0);
+    }
+}

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -16,3 +16,5 @@ pub mod handler;
 pub mod spec;
 /// Fork-scoped zk gas schedules for Taiko consensus.
 pub mod zk_gas;
+/// Next-fork single-dimension gas repricing primitives.
+pub mod gas_reprice;

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -10,11 +10,11 @@ pub mod evm;
 pub mod execution;
 /// Factory wiring for Taiko EVM builders.
 pub mod factory;
+/// Next-fork single-dimension gas repricing primitives.
+pub mod gas_reprice;
 /// Taiko-specific handler behavior for fee sharing and anchor processing.
 pub mod handler;
 /// Taiko hardfork spec identifiers and conversions.
 pub mod spec;
 /// Fork-scoped zk gas schedules for Taiko consensus.
 pub mod zk_gas;
-/// Next-fork single-dimension gas repricing primitives.
-pub mod gas_reprice;


### PR DESCRIPTION
## What

Foundational, **pure additive** primitives for a future Taiko fork that folds proving cost into a single repriced gas dimension — the eventual replacement for the current Unzen `raw_gas × multiplier` zk-gas meter. This is the first of three PRs:

1. **This PR — primitives** (no wiring, no behavior change)
2. Fork wiring + gating — introduce the new `TaikoSpecId`, wire these into the factory/handler, and gate the `difficulty`/zk-gas path to end at the new fork (proving cost then commits via the standard `gasUsed`)
3. Teardown of the Unzen zk-gas subsystem once Unzen retires

## Scope / safety

- **Not wired into execution.** Nothing calls this code yet; every existing fork (including Unzen) behaves identically. The only change outside the new module is one `pub mod gas_reprice;` line.
- **Numbers are non-consensus placeholders.** Real opcode/precompile/intrinsic values are a separate calibration effort and must be mirrored in taiko-geth + the prover.
- All 45 evm-crate tests pass (8 new + 37 existing, including every `zk_gas` test — confirming zero behavior change).

## The primitives (`crates/evm/src/gas_reprice/`)

- **`schedule.rs`** — `RepriceSchedule { opcode_surcharge: [u64; 256], tx_intrinsic_surcharge }`.
- **`opcodes.rs`** — `repriced_instruction_table`: an additive `static_gas` surcharge over revm's spec base table (the same mechanism revm itself uses for EIP-150/2929), charged before the opcode body so OOG, the `GAS` opcode, and 63/64 call-forwarding stay self-consistent. No revm fork required.
- **`precompiles.rs`** — `apply_precompile_surcharge`: an input-scaled gas surcharge via `PrecompilesMap::map_precompile` (mutates only `gas_used`, forwards everything else).
- **`intrinsic.rs`** — `add_tx_intrinsic_surcharge`: a per-transaction intrinsic addition (covers ecrecover proving) with the same over-limit check revm raises.

## Notes for the wiring PR

- The opcode→fn pairings in `opcodes.rs` duplicate revm's internal table (because `Instruction::static_gas` is private) — re-audit them on every reth/revm pin bump (documented in-code).
- Only a small example opcode set is wired; a surcharge on an unwired opcode is silently ignored by design (documented on the field + pinned by a test).
- `floor_gas` (EIP-7623 calldata floor) is intentionally untouched by the intrinsic surcharge.
- Precompile OOG is carried via `PrecompileOutput.status`, not always as `Err` — the wiring layer owns gas-limit re-validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
