### PR TITLE
chore(block): harden proof-history recovery and proof RPCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,6 @@ dependencies = [
  "reth-ethereum",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-exex",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-ethereum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,6 @@ reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953e
 reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
 reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
 reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
 reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
 reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
 reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }

--- a/bin/alethia-reth/src/main.rs
+++ b/bin/alethia-reth/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
         async move |builder, ext_args| {
             info!(target: "reth::taiko::cli", "Launching Taiko node");
             let node_builder = builder.node(TaikoNode);
-            let (node_builder, proof_history_storage) =
+            let (node_builder, proof_history_handles) =
                 install_proof_history(node_builder, ext_args.proof_history_config())?;
             let handle = node_builder
                 .extend_rpc_modules(move |mut ctx| {
@@ -49,8 +49,8 @@ fn main() {
                     );
                     ctx.auth_module.merge_auth_methods(taiko_auth_rpc_ext.into_rpc())?;
 
-                    if let Some(storage) = proof_history_storage {
-                        install_proof_history_rpc(&mut ctx, storage)?;
+                    if let Some(handles) = proof_history_handles {
+                        install_proof_history_rpc(&mut ctx, handles)?;
                     }
 
                     Ok(())

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -49,6 +49,7 @@ impl TaikoNodeExtArgs for TaikoCliExtArgs {
             backfill_window_only: self.proof_history.backfill_window_only,
             prune_interval: self.proof_history.prune_interval,
             verification_interval: self.proof_history.verification_interval,
+            max_startup_prune_blocks: self.proof_history.max_startup_prune_blocks,
         }
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -25,7 +25,10 @@ use alethia_reth_node::{
     TaikoNode,
     components::ProviderTaikoBlockReader,
     consensus::validation::TaikoBeaconConsensus,
-    proof_history::{DEFAULT_PROOF_HISTORY_VERIFICATION_INTERVAL, DEFAULT_PROOF_HISTORY_WINDOW},
+    proof_history::{
+        DEFAULT_PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS,
+        DEFAULT_PROOF_HISTORY_VERIFICATION_INTERVAL, DEFAULT_PROOF_HISTORY_WINDOW,
+    },
 };
 use reth_ethereum::EthPrimitives;
 use reth_storage_api::noop::NoopProvider;
@@ -109,6 +112,16 @@ pub struct TaikoProofHistoryArgs {
         help_heading = "Taiko Proof History"
     )]
     pub verification_interval: u64,
+
+    /// Maximum number of retained blocks startup may prune automatically, e.g. after lowering
+    /// the retention window. Startup refuses to prune more than this many blocks.
+    #[arg(
+        long = "proofs-history.max-startup-prune-blocks",
+        value_name = "BLOCKS",
+        default_value_t = DEFAULT_PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS,
+        help_heading = "Taiko Proof History"
+    )]
+    pub max_startup_prune_blocks: u64,
 }
 
 /// The main alethia-reth cli interface.
@@ -271,6 +284,7 @@ mod tests {
     use clap::Parser;
 
     use super::{
+        DEFAULT_PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS,
         DEFAULT_PROOF_HISTORY_VERIFICATION_INTERVAL, DEFAULT_PROOF_HISTORY_WINDOW, TaikoCliExtArgs,
     };
     use crate::command::TaikoNodeExtArgs;
@@ -329,6 +343,8 @@ mod tests {
             "30s",
             "--proofs-history.verification-interval",
             "16",
+            "--proofs-history.max-startup-prune-blocks",
+            "5000",
         ])
         .expect("proof-history args should parse");
 
@@ -338,6 +354,7 @@ mod tests {
         assert!(cli.ext.proof_history.backfill_window_only);
         assert_eq!(cli.ext.proof_history.prune_interval, Duration::from_secs(30));
         assert_eq!(cli.ext.proof_history.verification_interval, 16);
+        assert_eq!(cli.ext.proof_history.max_startup_prune_blocks, 5000);
     }
 
     #[test]
@@ -351,6 +368,7 @@ mod tests {
         assert!(!config.backfill_window_only);
         assert_eq!(config.prune_interval, Duration::from_secs(15));
         assert_eq!(config.verification_interval, DEFAULT_PROOF_HISTORY_VERIFICATION_INTERVAL);
+        assert_eq!(config.max_startup_prune_blocks, DEFAULT_PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS);
     }
 
     #[test]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -37,7 +37,6 @@ reth-engine-primitives = { workspace = true }
 reth-ethereum = { workspace = true }
 reth-ethereum-primitives = { workspace = true }
 reth-execution-types = { workspace = true }
-reth-exex = { workspace = true }
 reth-node-api = { workspace = true }
 reth-node-builder = { workspace = true }
 reth-node-ethereum = { workspace = true }

--- a/crates/node/src/proof_history/config.rs
+++ b/crates/node/src/proof_history/config.rs
@@ -12,6 +12,13 @@ const DEFAULT_PROOF_HISTORY_PRUNE_INTERVAL: Duration = Duration::from_secs(15);
 /// Default interval, in blocks, between proof-history consistency checks.
 pub const DEFAULT_PROOF_HISTORY_VERIFICATION_INTERVAL: u64 = 1024;
 
+/// Default safety threshold for automatic proof-history pruning on startup.
+///
+/// Startup refuses to prune more than this many blocks (e.g. after the retention window was
+/// lowered) unless the operator raises the limit explicitly, so a fat-fingered window cannot
+/// silently destroy retained history.
+pub const DEFAULT_PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS: u64 = 1000;
+
 /// Configuration for the optional proof-history execution extension.
 #[derive(Debug, Clone)]
 pub struct ProofHistoryConfig {
@@ -27,6 +34,8 @@ pub struct ProofHistoryConfig {
     pub prune_interval: Duration,
     /// Block interval between proof-history consistency checks; zero disables verification.
     pub verification_interval: u64,
+    /// Maximum number of blocks startup reconciliation may prune automatically.
+    pub max_startup_prune_blocks: u64,
 }
 
 impl ProofHistoryConfig {
@@ -39,6 +48,7 @@ impl ProofHistoryConfig {
             backfill_window_only: false,
             prune_interval: DEFAULT_PROOF_HISTORY_PRUNE_INTERVAL,
             verification_interval: DEFAULT_PROOF_HISTORY_VERIFICATION_INTERVAL,
+            max_startup_prune_blocks: DEFAULT_PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS,
         }
     }
 
@@ -62,6 +72,14 @@ mod tests {
         assert!(!config.backfill_window_only);
         assert!(config.storage_path.is_none());
         assert!(config.required_storage_path().is_err());
+    }
+
+    #[test]
+    fn default_startup_prune_threshold_is_conservative() {
+        let config = ProofHistoryConfig::disabled();
+
+        assert_eq!(config.max_startup_prune_blocks, DEFAULT_PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS);
+        assert_eq!(config.max_startup_prune_blocks, 1000);
     }
 
     #[test]

--- a/crates/node/src/proof_history/init.rs
+++ b/crates/node/src/proof_history/init.rs
@@ -254,7 +254,7 @@ where
 
         if block.number != best_number || block.hash != best_hash {
             return Err(eyre!(
-                "proof-history initialization anchor mismatch: stored=({:?}, {:?}) current=({:?}, {:?})",
+                "proof-history initialization anchor mismatch: stored=({:?}, {:?}) current=({:?}, {:?}); wipe proof-history storage and restart initialization",
                 block.number,
                 block.hash,
                 best_number,

--- a/crates/node/src/proof_history/mod.rs
+++ b/crates/node/src/proof_history/mod.rs
@@ -1,14 +1,15 @@
 //! Proof-history sidecar configuration and startup wiring for Taiko nodes.
 
 mod config;
-mod exex;
 mod init;
+mod sidecar;
 mod storage_init;
 
 pub use config::{
-    DEFAULT_PROOF_HISTORY_VERIFICATION_INTERVAL, DEFAULT_PROOF_HISTORY_WINDOW, ProofHistoryConfig,
+    DEFAULT_PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS, DEFAULT_PROOF_HISTORY_VERIFICATION_INTERVAL,
+    DEFAULT_PROOF_HISTORY_WINDOW, ProofHistoryConfig,
 };
-use exex::{ProofHistorySidecar, ProofHistorySidecarConfig};
+use sidecar::ProofHistorySidecar;
 use storage_init::proof_history_historical_init_metadata_path;
 
 use crate::TaikoNode;
@@ -103,13 +104,8 @@ where
                 task_executor.clone(),
                 storage_for_sidecar,
                 storage_for_init,
-                ProofHistorySidecarConfig {
-                    proofs_history_window: config.window,
-                    proofs_history_prune_interval: config.prune_interval,
-                    verification_interval: config.verification_interval,
-                    backfill_window_only: config.backfill_window_only,
-                    historical_init_metadata_path: Some(historical_init_metadata_path),
-                },
+                config,
+                Some(historical_init_metadata_path),
             );
             task_executor.spawn_critical_with_graceful_shutdown_signal(
                 "taiko::proof_history::sidecar",

--- a/crates/node/src/proof_history/mod.rs
+++ b/crates/node/src/proof_history/mod.rs
@@ -10,12 +10,12 @@ pub use config::{
     DEFAULT_PROOF_HISTORY_WINDOW, ProofHistoryConfig,
 };
 use sidecar::ProofHistorySidecar;
-use storage_init::proof_history_historical_init_metadata_path;
 
 use crate::TaikoNode;
 use alethia_reth_rpc::{
     debug::{TaikoDebugWitnessApiServer, TaikoDebugWitnessExt},
     eth::proofs::{TaikoEthProofApiServer, TaikoEthProofExt},
+    proof_state::ProofHistoryReadiness,
 };
 use eyre::WrapErr;
 use reth::{
@@ -45,11 +45,14 @@ use tracing::info;
 /// Shared storage type used by proof-history indexing and debug RPC overrides.
 pub type ProofHistoryStorage = OpProofsStorage<Arc<MdbxProofsStorage>>;
 
+/// Storage and reconciliation-readiness handles shared with the proof-history RPC overrides.
+pub type ProofHistoryRpcHandles = (ProofHistoryStorage, ProofHistoryReadiness);
+
 /// Result returned by proof-history installation with the updated node builder and optional
-/// storage.
+/// RPC handles.
 pub type ProofHistoryInstallResult<T, CB, AO> = eyre::Result<(
     WithLaunchContext<NodeBuilderWithComponents<T, CB, AO>>,
-    Option<ProofHistoryStorage>,
+    Option<ProofHistoryRpcHandles>,
 )>;
 
 /// Installs the proof-history sidecar and proof database metrics task on a Taiko node builder.
@@ -88,7 +91,10 @@ where
     let storage: ProofHistoryStorage = Arc::clone(&mdbx).into();
     let storage_for_sidecar = storage.clone();
     let storage_for_init = Arc::clone(&mdbx);
-    let historical_init_metadata_path = proof_history_historical_init_metadata_path(&storage_path);
+    // Starts not-ready: the RPC layer must not serve proof-history state until the sidecar has
+    // reconciled the stored bounds against canonical block hashes.
+    let readiness = ProofHistoryReadiness::new();
+    let readiness_for_sidecar = readiness.clone();
 
     Ok((
         node_builder.on_node_started(move |node| {
@@ -105,7 +111,7 @@ where
                 storage_for_sidecar,
                 storage_for_init,
                 config,
-                Some(historical_init_metadata_path),
+                readiness_for_sidecar,
             );
             task_executor.spawn_critical_with_graceful_shutdown_signal(
                 "taiko::proof_history::sidecar",
@@ -119,14 +125,14 @@ where
             );
             Ok(())
         }),
-        Some(storage),
+        Some((storage, readiness)),
     ))
 }
 
 /// Installs proof-history backed replacements for configured `eth_` and `debug_` RPC methods.
 pub fn install_proof_history_rpc<Node, EthApi>(
     ctx: &mut RpcContext<'_, Node, EthApi>,
-    storage: ProofHistoryStorage,
+    handles: ProofHistoryRpcHandles,
 ) -> eyre::Result<()>
 where
     Node: FullNodeComponents,
@@ -134,13 +140,16 @@ where
     Node::Provider:
         HeaderProvider<Header = reth::primitives::Header> + Clone + Send + Sync + 'static,
 {
-    let eth_ext = TaikoEthProofExt::new(ctx.registry.eth_api().clone(), storage.clone());
+    let (storage, readiness) = handles;
+    let eth_ext =
+        TaikoEthProofExt::new(ctx.registry.eth_api().clone(), storage.clone(), readiness.clone());
     ctx.modules.add_or_replace_if_module_configured(RethRpcModule::Eth, eth_ext.into_rpc())?;
 
     let debug_ext = TaikoDebugWitnessExt::new(
         ctx.node().provider().clone(),
         ctx.registry.eth_api().clone(),
         storage,
+        readiness,
     );
     ctx.modules.add_or_replace_if_module_configured(RethRpcModule::Debug, debug_ext.into_rpc())?;
     Ok(())

--- a/crates/node/src/proof_history/sidecar.rs
+++ b/crates/node/src/proof_history/sidecar.rs
@@ -5,10 +5,12 @@ use super::{
     storage_init::{
         DelayedProofHistoryStart, ProofHistoryInitializationAction, delayed_proof_history_start,
         finalized_block_number, initialize_historical_proof_history_storage,
-        initialize_proof_history_storage, proof_history_storage_needs_initialization,
-        proof_history_sync_target, read_historical_init_metadata,
+        initialize_proof_history_storage, proof_history_historical_init_metadata_path,
+        proof_history_storage_needs_initialization, proof_history_sync_target,
+        read_historical_init_metadata,
     },
 };
+use alethia_reth_rpc::proof_state::ProofHistoryReadiness;
 use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockNumHash, eip1898::BlockWithParent};
 use alloy_primitives::B256;
@@ -197,6 +199,8 @@ where
     config: ProofHistoryConfig,
     /// Sidecar file that records historical initialization target metadata.
     historical_init_metadata_path: Option<PathBuf>,
+    /// Readiness flag consumed by the RPC layer; set only while storage is reconciled.
+    readiness: ProofHistoryReadiness,
     /// Serializes proof-history writers across live notifications, background sync, and pruning.
     write_lock: Arc<Mutex<()>>,
 }
@@ -238,8 +242,10 @@ where
         storage: OpProofsStorage<Storage>,
         init_storage: Storage,
         config: ProofHistoryConfig,
-        historical_init_metadata_path: Option<PathBuf>,
+        readiness: ProofHistoryReadiness,
     ) -> Self {
+        let historical_init_metadata_path =
+            config.storage_path.as_deref().map(proof_history_historical_init_metadata_path);
         Self {
             provider,
             evm_config,
@@ -248,6 +254,7 @@ where
             init_storage,
             config,
             historical_init_metadata_path,
+            readiness,
             write_lock: Arc::new(Mutex::new(())),
         }
     }
@@ -332,6 +339,9 @@ where
         if !self.reconcile_or_wait().await? {
             return Ok(None);
         }
+        // Storage bounds are now validated against canonical hashes: allow the RPC layer to
+        // serve from proof-history. Workers only extend storage consistently from here on.
+        self.readiness.set_ready();
         let sync_wake = self.spawn_sync_task();
         self.spawn_pruner_task();
         Ok(Some(sync_wake))
@@ -340,6 +350,9 @@ where
     /// Reconciles proof-history storage after missing canonical notifications.
     async fn recover_from_lag(&self, sync_wake: &Notify) -> eyre::Result<()> {
         let _write_guard = self.write_lock.lock().await;
+        // Notifications were missed, so the stored bounds are unvalidated until reconciliation
+        // succeeds; stop serving proof-history state in the meantime.
+        self.readiness.set_not_ready();
         if !self.reconcile_or_wait().await? {
             return Err(eyre!(
                 "proof-history reconciliation cannot proceed while sync workers are running \
@@ -347,6 +360,7 @@ where
                  recover"
             ));
         }
+        self.readiness.set_ready();
         sync_wake.notify_one();
         Ok(())
     }

--- a/crates/node/src/proof_history/sidecar.rs
+++ b/crates/node/src/proof_history/sidecar.rs
@@ -1,10 +1,13 @@
 //! Proof-history sidecar: notification handling, sync loop, pruner task.
 
-use super::storage_init::{
-    DelayedProofHistoryStart, PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS,
-    ProofHistoryInitializationAction, delayed_proof_history_start, finalized_block_number,
-    initialize_historical_proof_history_storage, initialize_proof_history_storage,
-    proof_history_storage_needs_initialization, proof_history_sync_target,
+use super::{
+    config::ProofHistoryConfig,
+    storage_init::{
+        DelayedProofHistoryStart, ProofHistoryInitializationAction, delayed_proof_history_start,
+        finalized_block_number, initialize_historical_proof_history_storage,
+        initialize_proof_history_storage, proof_history_storage_needs_initialization,
+        proof_history_sync_target, read_historical_init_metadata,
+    },
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockNumHash, eip1898::BlockWithParent};
@@ -20,27 +23,19 @@ use reth::{
 };
 use reth_db::Database;
 use reth_execution_types::Chain;
-use reth_exex::ExExNotification;
 use reth_node_api::{FullNodeComponents, NodePrimitives, NodeTypes};
 use reth_optimism_trie::{
-    OpProofStoragePruner, OpProofsStorage, OpProofsStore, api::OpProofsProviderRO,
+    OpProofStoragePruner, OpProofsStorage, OpProofsStorageError, OpProofsStore,
+    api::{OpProofsProviderRO, OpProofsProviderRw},
     live::LiveTrieCollector,
 };
 use reth_storage_api::{
     ChainStateBlockReader, ChangeSetReader, StorageChangeSetReader, StorageSettingsCache,
 };
 use reth_trie_common::{HashedPostStateSorted, SortedTrieData, updates::TrieUpdatesSorted};
-use std::{
-    panic,
-    path::PathBuf,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-    time::Duration,
-};
+use std::{panic, path::PathBuf, sync::Arc, time::Duration};
 use tokio::{
-    sync::{Mutex, broadcast, watch},
+    sync::{Mutex, Notify, broadcast},
     task,
     time::{self, MissedTickBehavior},
 };
@@ -88,22 +83,6 @@ const PROOF_HISTORY_HEAD_POLL_INTERVAL: Duration = Duration::from_secs(5);
 /// Number of proof-history blocks pruned in one pruning transaction.
 const PROOF_HISTORY_PRUNE_BATCH_SIZE: u64 = 200;
 
-/// Converts canonical notifications into the ExEx notification shape used internally.
-fn canonical_notification_to_exex<Primitives>(
-    notification: CanonStateNotification<Primitives>,
-) -> ExExNotification<Primitives>
-where
-    Primitives: NodePrimitives,
-{
-    match notification {
-        CanonStateNotification::Commit { new } => ExExNotification::ChainCommitted { new },
-        CanonStateNotification::Reorg { old, new } if new.is_empty() => {
-            ExExNotification::ChainReverted { old }
-        }
-        CanonStateNotification::Reorg { old, new } => ExExNotification::ChainReorged { old, new },
-    }
-}
-
 /// Startup reconciliation action for existing proof-history storage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ProofHistoryStartupAction {
@@ -116,6 +95,22 @@ pub(super) enum ProofHistoryStartupAction {
     UnwindToEarliest {
         /// Earliest retained proof-history block that still matches canonical state.
         earliest: BlockNumHash,
+    },
+    /// Canonical chain has not yet reached the stored earliest block; reconciliation must retry
+    /// once the chain database catches up (e.g. a chain re-sync that kept proof-history storage).
+    WaitForCanonicalEarliest {
+        /// Earliest retained proof-history block number missing from the canonical chain.
+        earliest: u64,
+    },
+    /// Canonical chain is still behind the stored latest block; reconciliation must retry once
+    /// the node catches back up (e.g. right after a restart where the persisted head lags the
+    /// previously indexed in-memory tip), and only then compare hashes to decide between serving
+    /// as-is and unwinding.
+    WaitForCanonicalLatest {
+        /// Latest retained proof-history block number.
+        latest: u64,
+        /// Canonical chain height observed at reconciliation time.
+        canonical_best: u64,
     },
 }
 
@@ -139,36 +134,47 @@ pub(super) fn proof_history_startup_action(
         ));
     }
 
-    if canonical_earliest_hash.is_none_or(|canonical_hash| canonical_hash != earliest_hash) {
+    // No canonical header at the earliest height yet: the chain database is (re-)syncing and has
+    // not reached the retained range. Failing here would crash the node before it could ever sync
+    // past this point, so wait instead; a *mismatching* hash stays a hard error below.
+    let Some(canonical_earliest) = canonical_earliest_hash else {
+        return Ok(ProofHistoryStartupAction::WaitForCanonicalEarliest {
+            earliest: earliest_number,
+        });
+    };
+    if canonical_earliest != earliest_hash {
         return Err(eyre!(
-            "proof-history earliest stored block {earliest_number} hash {earliest_hash:?} is not canonical"
+            "proof-history earliest stored block {earliest_number} hash {earliest_hash:?} is not canonical; wipe proof-history storage and restart initialization"
         ));
     }
 
-    if latest_number <= canonical_best &&
-        canonical_latest_hash.is_some_and(|canonical_hash| canonical_hash == latest_hash)
-    {
+    // The stored head runs ahead of the canonical chain. This is the normal aftermath of an
+    // ungraceful restart: live indexing follows in-memory commits, which outpace the persisted
+    // head by up to the engine persistence threshold. Wait for canonical state to catch back up
+    // and only then decide between `Ready` and an unwind — discarding the retained window here
+    // would trade a few seconds of catch-up for days of re-execution.
+    if latest_number > canonical_best {
+        return Ok(ProofHistoryStartupAction::WaitForCanonicalLatest {
+            latest: latest_number,
+            canonical_best,
+        });
+    }
+
+    let Some(canonical_latest) = canonical_latest_hash else {
+        return Err(eyre!(
+            "canonical chain has no canonical hash for stored proof-history latest block {latest_number} at or below canonical best {canonical_best}"
+        ));
+    };
+
+    if canonical_latest == latest_hash {
         return Ok(ProofHistoryStartupAction::Ready);
     }
 
+    // The canonical chain reached the stored height with a different block: real divergence
+    // (a reorg happened while the sidecar was down). Rewind to the validated earliest anchor.
     Ok(ProofHistoryStartupAction::UnwindToEarliest {
         earliest: BlockNumHash::new(earliest_number, earliest_hash),
     })
-}
-
-/// Runtime settings passed into the proof-history sidecar.
-#[derive(Debug)]
-pub(super) struct ProofHistorySidecarConfig {
-    /// Number of recent blocks retained in proof-history storage.
-    pub(super) proofs_history_window: u64,
-    /// Wall-clock interval between proof-history prune passes.
-    pub(super) proofs_history_prune_interval: Duration,
-    /// Block interval between full execution verification checks.
-    pub(super) verification_interval: u64,
-    /// Whether empty proof-history storage waits for the finalized retention window.
-    pub(super) backfill_window_only: bool,
-    /// Sidecar file that records historical initialization target metadata.
-    pub(super) historical_init_metadata_path: Option<PathBuf>,
 }
 
 /// Taiko proof-history sidecar that keeps OP proofs storage behind locally executed state.
@@ -188,11 +194,17 @@ where
     /// Raw proof-history storage handle used for the initial current-state snapshot.
     init_storage: Storage,
     /// Runtime settings that govern proof-history retention and startup behavior.
-    config: ProofHistorySidecarConfig,
-    /// Whether a delayed-start miss has already been reported for this sidecar run.
-    missed_start_logged: AtomicBool,
+    config: ProofHistoryConfig,
+    /// Sidecar file that records historical initialization target metadata.
+    historical_init_metadata_path: Option<PathBuf>,
     /// Serializes proof-history writers across live notifications, background sync, and pruning.
     write_lock: Arc<Mutex<()>>,
+}
+
+/// Returns whether a committed chain starting at `first_block` leaves no gap above the stored
+/// proof-history head, so its blocks can be consumed directly from the notification.
+const fn committed_chain_is_contiguous(first_block: u64, latest_stored: u64) -> bool {
+    first_block <= latest_stored.saturating_add(1)
 }
 
 /// Ensures a canonical reorg or revert does not replace the retained proof-history anchor.
@@ -225,7 +237,8 @@ where
         task_executor: TaskExecutor,
         storage: OpProofsStorage<Storage>,
         init_storage: Storage,
-        config: ProofHistorySidecarConfig,
+        config: ProofHistoryConfig,
+        historical_init_metadata_path: Option<PathBuf>,
     ) -> Self {
         Self {
             provider,
@@ -234,7 +247,7 @@ where
             storage,
             init_storage,
             config,
-            missed_start_logged: AtomicBool::new(false),
+            historical_init_metadata_path,
             write_lock: Arc::new(Mutex::new(())),
         }
     }
@@ -265,7 +278,7 @@ where
         let collector =
             LiveTrieCollector::new(self.evm_config.clone(), self.provider.clone(), &self.storage);
         let mut notifications = self.provider.subscribe_to_canonical_state();
-        let mut sync_target_tx = self.try_start(&collector)?;
+        let mut sync_wake = self.try_start().await?;
         let mut retry_interval = time::interval(PROOF_HISTORY_DELAYED_START_RETRY_INTERVAL);
         retry_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
@@ -284,34 +297,29 @@ where
                             // Replace the lagged receiver before reconciliation. The old
                             // receiver's retained suffix is no longer useful after storage is
                             // reconciled, and the fresh receiver buffers commits published while
-                            // recovery advances the sync target to canonical best.
+                            // recovery brings storage back in line with canonical state.
                             notifications = self.provider.subscribe_to_canonical_state();
-                            if let Some(target_tx) = sync_target_tx.as_ref() {
-                                self.recover_from_lag(&collector, target_tx).await?;
+                            if let Some(wake) = sync_wake.as_ref() {
+                                self.recover_from_lag(wake).await?;
                             } else {
-                                sync_target_tx = self.try_start(&collector)?;
+                                sync_wake = self.try_start().await?;
                             }
                             continue;
                         }
                     };
-                    if sync_target_tx.is_none() {
-                        sync_target_tx = self.try_start(&collector)?;
+                    if sync_wake.is_none() {
+                        sync_wake = self.try_start().await?;
                     }
 
-                    let Some(target_tx) = sync_target_tx.as_ref() else {
+                    let Some(wake) = sync_wake.as_ref() else {
                         continue;
                     };
 
-                    self.handle_notification(
-                        canonical_notification_to_exex(notification),
-                        &collector,
-                        target_tx,
-                    )
-                    .await?;
+                    self.handle_notification(notification, &collector, wake).await?;
                 }
                 _ = &mut shutdown => break,
-                _ = retry_interval.tick(), if sync_target_tx.is_none() => {
-                    sync_target_tx = self.try_start(&collector)?;
+                _ = retry_interval.tick(), if sync_wake.is_none() => {
+                    sync_wake = self.try_start().await?;
                 }
             }
         }
@@ -320,51 +328,62 @@ where
     }
 
     /// Reconciles storage if possible and spawns the sync and pruner tasks on first success.
-    fn try_start(
-        &self,
-        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
-    ) -> eyre::Result<Option<watch::Sender<u64>>> {
-        if !self.reconcile_or_wait(collector)? {
+    async fn try_start(&self) -> eyre::Result<Option<Arc<Notify>>> {
+        if !self.reconcile_or_wait().await? {
             return Ok(None);
         }
-        let initial_sync_target = self.provider.best_block_number()?;
-        let sync_target_tx = self.spawn_sync_task(initial_sync_target);
+        let sync_wake = self.spawn_sync_task();
         self.spawn_pruner_task();
-        Ok(Some(sync_target_tx))
+        Ok(Some(sync_wake))
     }
 
     /// Reconciles proof-history storage after missing canonical notifications.
-    async fn recover_from_lag(
-        &self,
-        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
-        sync_target_tx: &watch::Sender<u64>,
-    ) -> eyre::Result<()> {
+    async fn recover_from_lag(&self, sync_wake: &Notify) -> eyre::Result<()> {
         let _write_guard = self.write_lock.lock().await;
-        if !self.reconcile_or_wait(collector)? {
+        if !self.reconcile_or_wait().await? {
             return Err(eyre!(
-                "proof-history storage became uninitialized after sync workers started"
+                "proof-history reconciliation cannot proceed while sync workers are running \
+                 (canonical state moved backwards during a notification lag); restart the node to \
+                 recover"
             ));
         }
-        let target = self.provider.best_block_number()?;
-        sync_target_tx.send(target)?;
+        sync_wake.notify_one();
         Ok(())
     }
 
     /// Reconciles current proof-history bounds against the canonical database.
-    fn reconcile_or_wait(
-        &self,
-        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
-    ) -> eyre::Result<bool> {
+    async fn reconcile_or_wait(&self) -> eyre::Result<bool> {
         match self.startup_action()? {
-            ProofHistoryStartupAction::Uninitialized => self.initialize_or_wait(),
+            ProofHistoryStartupAction::Uninitialized => self.initialize_or_wait().await,
             ProofHistoryStartupAction::Ready => {
                 self.ensure_initialized()?;
                 Ok(true)
             }
             ProofHistoryStartupAction::UnwindToEarliest { earliest } => {
-                self.unwind_to_earliest(collector, earliest)?;
+                self.unwind_to_earliest(earliest).await?;
                 self.ensure_initialized()?;
                 Ok(true)
+            }
+            ProofHistoryStartupAction::WaitForCanonicalEarliest { earliest } => {
+                // Common during a chain re-sync that kept proof-history storage: stay quiet at
+                // debug level, this state can last for days and resolves on its own.
+                debug!(
+                    target: "reth::taiko::proof_history",
+                    earliest,
+                    "canonical chain has not reached the proof-history earliest block; waiting for sync"
+                );
+                Ok(false)
+            }
+            ProofHistoryStartupAction::WaitForCanonicalLatest { latest, canonical_best } => {
+                // Expected briefly after an ungraceful restart while the driver re-derives the
+                // gap; warn so a *stuck* wait (chain unwound for good) stays visible.
+                warn!(
+                    target: "reth::taiko::proof_history",
+                    latest,
+                    canonical_best,
+                    "canonical chain is behind the stored proof-history head; waiting for the node to catch up before reconciling"
+                );
+                Ok(false)
             }
         }
     }
@@ -393,11 +412,7 @@ where
     }
 
     /// Unwinds proof-history storage so its latest retained block is the canonical earliest block.
-    fn unwind_to_earliest(
-        &self,
-        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
-        earliest: BlockNumHash,
-    ) -> eyre::Result<()> {
+    async fn unwind_to_earliest(&self, earliest: BlockNumHash) -> eyre::Result<()> {
         let latest = self
             .storage
             .provider_ro()?
@@ -423,17 +438,27 @@ where
             .provider
             .block_hash(unwind_block_number)?
             .ok_or_else(|| eyre!("missing proof-history unwind block {unwind_block_number}"))?;
-        collector.unwind_history(BlockWithParent::new(
+        let unwind_to = BlockWithParent::new(
             earliest.hash,
             BlockNumHash::new(unwind_block_number, unwind_block_hash),
-        ))?;
+        );
+
+        let storage = self.storage.clone();
+        let unwind_task = task::spawn_blocking(move || -> Result<(), OpProofsStorageError> {
+            let provider_rw = storage.provider_rw()?;
+            provider_rw.unwind_history(unwind_to)?;
+            provider_rw.commit()
+        });
+        blocking_join_result(unwind_task.await, "proof-history unwind worker")??;
         Ok(())
     }
 
     /// Initializes proof-history storage immediately or waits for the finalized window.
-    fn initialize_or_wait(&self) -> eyre::Result<bool> {
+    async fn initialize_or_wait(&self) -> eyre::Result<bool> {
         if proof_history_storage_needs_initialization(&self.storage)? {
-            let action = if self.config.backfill_window_only {
+            let action = if let Some(resume) = self.historical_init_resume_action()? {
+                resume
+            } else if self.config.backfill_window_only {
                 self.finalized_window_initialization_action()?
             } else {
                 ProofHistoryInitializationAction::CurrentState
@@ -442,22 +467,64 @@ where
             match action {
                 ProofHistoryInitializationAction::Wait => return Ok(false),
                 ProofHistoryInitializationAction::CurrentState => {
-                    initialize_proof_history_storage(&self.provider, self.init_storage.clone())?
+                    let provider = self.provider.clone();
+                    let storage = self.init_storage.clone();
+                    let init_task = task::spawn_blocking(move || {
+                        initialize_proof_history_storage(&provider, storage)
+                    });
+                    blocking_join_result(init_task.await, "proof-history init worker")??;
                 }
                 ProofHistoryInitializationAction::HistoricalWindow {
                     start_block,
                     target_block,
-                } => initialize_historical_proof_history_storage(
-                    &self.provider,
-                    self.init_storage.clone(),
-                    self.config.historical_init_metadata_path.as_deref(),
-                    start_block,
-                    target_block,
-                )?,
+                } => {
+                    let provider = self.provider.clone();
+                    let storage = self.init_storage.clone();
+                    let metadata_path = self.historical_init_metadata_path.clone();
+                    let init_task = task::spawn_blocking(move || {
+                        initialize_historical_proof_history_storage(
+                            &provider,
+                            storage,
+                            metadata_path.as_deref(),
+                            start_block,
+                            target_block,
+                        )
+                    });
+                    blocking_join_result(init_task.await, "proof-history historical init worker")??;
+                }
             }
         }
         self.ensure_initialized()?;
         Ok(true)
+    }
+
+    /// Returns the initialization action that resumes an interrupted historical initialization.
+    ///
+    /// The recorded metadata pins the anchor start block of the interrupted attempt; the target is
+    /// recomputed from the current on-disk executed head because the reverse-changeset overlay is
+    /// rebuilt against the current tables (and re-verified against the anchor state root), so an
+    /// interrupted initialization survives node restarts on a live chain.
+    fn historical_init_resume_action(
+        &self,
+    ) -> eyre::Result<Option<ProofHistoryInitializationAction>> {
+        let Some(path) = self.historical_init_metadata_path.as_deref() else {
+            return Ok(None);
+        };
+        let Some(metadata) = read_historical_init_metadata(path)? else {
+            return Ok(None);
+        };
+
+        let executed_head = self.provider.database_provider_ro()?.best_block_number()?;
+        info!(
+            target: "reth::taiko::proof_history",
+            start_block = metadata.start_block.number,
+            executed_head,
+            "resuming interrupted historical proof-history initialization from recorded metadata"
+        );
+        Ok(Some(ProofHistoryInitializationAction::HistoricalWindow {
+            start_block: metadata.start_block.number,
+            target_block: executed_head,
+        }))
     }
 
     /// Returns how empty storage should initialize for a finalized proof-history window.
@@ -471,11 +538,7 @@ where
         // blocks, which previously caused the historical init to panic on a missing target header.
         let executed_head = self.provider.database_provider_ro()?.best_block_number()?;
 
-        match delayed_proof_history_start(
-            finalized_block,
-            executed_head,
-            self.config.proofs_history_window,
-        ) {
+        match delayed_proof_history_start(finalized_block, executed_head, self.config.window) {
             DelayedProofHistoryStart::WaitForFinalized => {
                 debug!(
                     target: "reth::taiko::proof_history",
@@ -495,23 +558,13 @@ where
                 Ok(ProofHistoryInitializationAction::Wait)
             }
             DelayedProofHistoryStart::MissedStart { start_block } => {
-                if self.missed_start_logged.swap(true, Ordering::Relaxed) {
-                    debug!(
-                        target: "reth::taiko::proof_history",
-                        ?finalized_block,
-                        executed_head,
-                        start_block,
-                        "waiting for proof-history window start to match local execution"
-                    );
-                } else {
-                    info!(
-                        target: "reth::taiko::proof_history",
-                        ?finalized_block,
-                        executed_head,
-                        start_block,
-                        "empty proof-history storage missed the finalized window start; building historical proof-history anchor"
-                    );
-                }
+                info!(
+                    target: "reth::taiko::proof_history",
+                    ?finalized_block,
+                    executed_head,
+                    start_block,
+                    "empty proof-history storage missed the finalized window start; building historical proof-history anchor"
+                );
                 Ok(ProofHistoryInitializationAction::HistoricalWindow {
                     start_block,
                     target_block: executed_head,
@@ -542,14 +595,14 @@ where
             .ok_or_else(|| eyre!("proof-history storage is not initialized"))?
             .0;
 
-        let target_earliest = latest_block_number.saturating_sub(self.config.proofs_history_window);
+        let target_earliest = latest_block_number.saturating_sub(self.config.window);
         if target_earliest > earliest_block_number {
             let blocks_to_prune = target_earliest - earliest_block_number;
-            if blocks_to_prune > PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS {
+            if blocks_to_prune > self.config.max_startup_prune_blocks {
                 return Err(eyre!(
-                    "configuration requires pruning {} proof-history blocks, which exceeds the safety threshold of {}",
+                    "configuration requires pruning {} proof-history blocks, which exceeds the safety threshold of {}; raise --proofs-history.max-startup-prune-blocks or restore the previous --proofs-history.window to proceed",
                     blocks_to_prune,
-                    PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS
+                    self.config.max_startup_prune_blocks
                 ));
             }
         }
@@ -562,11 +615,11 @@ where
         let pruner = Arc::new(OpProofStoragePruner::new(
             self.storage.clone(),
             self.provider.clone(),
-            self.config.proofs_history_window,
+            self.config.window,
             PROOF_HISTORY_PRUNE_BATCH_SIZE,
         ));
-        let prune_interval = self.config.proofs_history_prune_interval;
-        let retention_window = self.config.proofs_history_window;
+        let prune_interval = self.config.prune_interval;
+        let retention_window = self.config.window;
         let write_lock = self.write_lock.clone();
 
         self.task_executor
@@ -616,31 +669,43 @@ where
             );
     }
 
-    /// Spawns the guarded proof-history backfill task.
-    fn spawn_sync_task(&self, initial_sync_target: u64) -> watch::Sender<u64> {
-        let (sync_target_tx, sync_target_rx) = watch::channel(initial_sync_target);
+    /// Spawns the guarded proof-history backfill task and returns its wake-up handle.
+    fn spawn_sync_task(&self) -> Arc<Notify> {
+        let sync_wake = Arc::new(Notify::new());
+        let task_wake = sync_wake.clone();
         let task_storage = self.storage.clone();
         let task_provider = self.provider.clone();
         let task_evm_config = self.evm_config.clone();
         let task_write_lock = self.write_lock.clone();
 
-        self.task_executor.spawn_critical_task("taiko::proof_history::sync_loop", async move {
-            Self::sync_loop(
-                sync_target_rx,
-                task_storage,
-                task_provider,
-                task_evm_config,
-                task_write_lock,
-            )
-            .await;
-        });
+        self.task_executor.spawn_critical_with_graceful_shutdown_signal(
+            "taiko::proof_history::sync_loop",
+            move |shutdown| {
+                Box::pin(async move {
+                    Self::sync_loop(
+                        shutdown,
+                        task_wake,
+                        task_storage,
+                        task_provider,
+                        task_evm_config,
+                        task_write_lock,
+                    )
+                    .await;
+                })
+            },
+        );
 
-        sync_target_tx
+        sync_wake
     }
 
     /// Backfills proof-history only through blocks the node has locally executed.
+    ///
+    /// Live notifications only wake this loop up; the backfill target is always re-derived from
+    /// the node's on-disk executed head, so re-execution never reads unpersisted blocks and a
+    /// staged-sync gap is caught up even when no notification arrives.
     async fn sync_loop(
-        mut sync_target_rx: watch::Receiver<u64>,
+        mut shutdown: GracefulShutdown,
+        wake: Arc<Notify>,
         storage: OpProofsStorage<Storage>,
         provider: Node::Provider,
         evm_config: Node::Evm,
@@ -653,7 +718,6 @@ where
         let mut divergence_logged = false;
 
         loop {
-            let requested_target = *sync_target_rx.borrow_and_update();
             let write_guard = write_lock.lock().await;
             let latest = match storage.provider_ro().and_then(|p| p.get_latest_block_number()) {
                 Ok(Some((number, _))) => number,
@@ -664,7 +728,9 @@ where
                 Err(error) => {
                     error!(target: "reth::taiko::proof_history", ?error, "failed to read proof-history latest block");
                     drop(write_guard);
-                    time::sleep(PROOF_HISTORY_SYNC_IDLE_SLEEP).await;
+                    if Self::sleep_or_shutdown(&mut shutdown, PROOF_HISTORY_SYNC_IDLE_SLEEP).await {
+                        return;
+                    }
                     continue;
                 }
             };
@@ -672,7 +738,7 @@ where
             // Track the node's on-disk executed head, not just the last notified canonical tip.
             // Using the on-disk head (rather than the in-memory tip) guarantees the blocks the
             // backfill re-executes are persisted, and lets proof-history catch up across a
-            // staged-sync gap even when no live notification advances `requested_target`.
+            // staged-sync gap even when no live notification arrives.
             let executed_head = match provider
                 .database_provider_ro()
                 .and_then(|p| p.best_block_number())
@@ -681,7 +747,9 @@ where
                 Err(error) => {
                     error!(target: "reth::taiko::proof_history", ?error, "failed to read executed head for proof-history sync");
                     drop(write_guard);
-                    time::sleep(PROOF_HISTORY_SYNC_IDLE_SLEEP).await;
+                    if Self::sleep_or_shutdown(&mut shutdown, PROOF_HISTORY_SYNC_IDLE_SLEEP).await {
+                        return;
+                    }
                     continue;
                 }
             };
@@ -706,22 +774,17 @@ where
                 divergence_logged = false;
             }
 
-            let Some(target) = proof_history_sync_target(latest, requested_target, executed_head)
-            else {
+            let Some(target) = proof_history_sync_target(latest, executed_head) else {
                 // Caught up to the locally executed head. Wake on the next live notification (fast
                 // path) or after a poll delay, so a staged-sync gap is still picked up with no
                 // notifications.
                 drop(write_guard);
                 tokio::select! {
-                    result = sync_target_rx.changed() => {
-                        if result.is_err() {
-                            debug!(
-                                target: "reth::taiko::proof_history",
-                                "proof-history sync target sender dropped; stopping sync loop"
-                            );
-                            return;
-                        }
+                    _ = &mut shutdown => {
+                        info!(target: "reth::taiko::proof_history", "proof-history sync loop stopped");
+                        return;
                     }
+                    _ = wake.notified() => {}
                     _ = time::sleep(PROOF_HISTORY_HEAD_POLL_INTERVAL) => {}
                 }
                 continue;
@@ -732,7 +795,7 @@ where
             let batch_evm_config = evm_config.clone();
             // Each block write commits independently; if this batch fails part-way through, the
             // next loop rereads `latest` and resumes after the last committed block.
-            let batch_task = task::spawn_blocking(move || {
+            let mut batch_task = task::spawn_blocking(move || {
                 let collector_storage = batch_storage.clone();
                 let collector = LiveTrieCollector::new(
                     batch_evm_config,
@@ -747,8 +810,28 @@ where
                     PROOF_HISTORY_SYNC_BATCH_SIZE,
                 )
             });
-            let batch_result = blocking_join_result(batch_task.await, "proof-history batch worker")
-                .and_then(|result| result);
+            let batch_result = tokio::select! {
+                result = &mut batch_task => {
+                    blocking_join_result(result, "proof-history batch worker")
+                        .and_then(|result| result)
+                }
+                _ = &mut shutdown => {
+                    // `spawn_blocking` workers cannot be aborted; wait for the in-flight batch so
+                    // its per-block commits finish cleanly before stopping.
+                    info!(
+                        target: "reth::taiko::proof_history",
+                        "shutdown requested while proof-history backfill batch is running; waiting for batch to finish"
+                    );
+                    let result = blocking_join_result(batch_task.await, "proof-history batch worker")
+                        .and_then(|result| result);
+                    drop(write_guard);
+                    if let Err(error) = result {
+                        error!(target: "reth::taiko::proof_history", ?error, "proof-history batch processing failed");
+                    }
+                    info!(target: "reth::taiko::proof_history", "proof-history sync loop stopped");
+                    return;
+                }
+            };
             drop(write_guard);
 
             match batch_result {
@@ -762,11 +845,24 @@ where
                 }
                 Err(error) => {
                     error!(target: "reth::taiko::proof_history", ?error, "proof-history batch processing failed");
-                    time::sleep(PROOF_HISTORY_SYNC_IDLE_SLEEP).await;
+                    if Self::sleep_or_shutdown(&mut shutdown, PROOF_HISTORY_SYNC_IDLE_SLEEP).await {
+                        return;
+                    }
                 }
             }
 
             task::yield_now().await;
+        }
+    }
+
+    /// Sleeps for `duration` unless shutdown is requested first; returns whether to stop.
+    async fn sleep_or_shutdown(shutdown: &mut GracefulShutdown, duration: Duration) -> bool {
+        tokio::select! {
+            _ = shutdown => {
+                info!(target: "reth::taiko::proof_history", "proof-history sync loop stopped");
+                true
+            }
+            _ = time::sleep(duration) => false,
         }
     }
 
@@ -793,12 +889,12 @@ where
         Ok(end)
     }
 
-    /// Handles a canonical notification and advances proof-history storage or its backfill target.
+    /// Handles a canonical notification and advances proof-history storage or wakes the backfill.
     async fn handle_notification(
         &self,
-        notification: ExExNotification<Primitives>,
+        notification: CanonStateNotification<Primitives>,
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
-        sync_target_tx: &watch::Sender<u64>,
+        sync_wake: &Notify,
     ) -> eyre::Result<()> {
         let _write_guard = self.write_lock.lock().await;
         let provider_ro = self.storage.provider_ro()?;
@@ -812,14 +908,15 @@ where
         let earliest_stored = BlockNumHash::new(earliest_stored.0, earliest_stored.1);
 
         match &notification {
-            ExExNotification::ChainCommitted { new } => {
-                self.handle_chain_committed(new, latest_stored, collector, sync_target_tx)?
+            CanonStateNotification::Commit { new } => {
+                self.handle_chain_committed(new, latest_stored, collector, sync_wake)?
             }
-            ExExNotification::ChainReorged { old, new } => {
-                self.handle_chain_reorged(old, new, earliest_stored, latest_stored, collector)?
-            }
-            ExExNotification::ChainReverted { old } => {
+            // A reorg that replaces the old blocks with nothing is a plain revert.
+            CanonStateNotification::Reorg { old, new } if new.is_empty() => {
                 self.handle_chain_reverted(old, earliest_stored, latest_stored, collector)?
+            }
+            CanonStateNotification::Reorg { old, new } => {
+                self.handle_chain_reorged(old, new, earliest_stored, latest_stored, collector)?
             }
         }
 
@@ -832,23 +929,23 @@ where
         new: &Chain<Primitives>,
         latest_stored: u64,
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
-        sync_target_tx: &watch::Sender<u64>,
+        sync_wake: &Notify,
     ) -> eyre::Result<()> {
         if new.tip().number() <= latest_stored {
             return Ok(());
         }
 
         let best_block = self.provider.best_block_number()?;
-        let is_sequential = new.tip().number() == latest_stored + 1;
+        let is_contiguous = committed_chain_is_contiguous(new.first().number(), latest_stored);
         let is_near_tip = best_block.saturating_sub(new.tip().number()) <
             PROOF_HISTORY_REAL_TIME_BLOCKS_THRESHOLD;
 
-        if is_sequential && is_near_tip {
+        if is_contiguous && is_near_tip {
             for block_number in latest_stored.saturating_add(1)..=new.tip().number() {
                 self.process_block(block_number, new, collector)?;
             }
         } else {
-            sync_target_tx.send(new.tip().number())?;
+            sync_wake.notify_one();
         }
 
         Ok(())
@@ -971,19 +1068,34 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        ProofHistoryStartupAction, canonical_notification_to_exex,
+        ProofHistoryStartupAction, committed_chain_is_contiguous,
         ensure_canonical_update_above_earliest, proof_history_startup_action,
     };
     use alloy_eips::BlockNumHash;
     use alloy_primitives::B256;
-    use reth::providers::CanonStateNotification;
-    use reth_ethereum_primitives::EthPrimitives;
-    use reth_execution_types::Chain;
-    use reth_exex::ExExNotification;
-    use std::sync::Arc;
 
     fn hash(byte: u8) -> B256 {
         B256::with_last_byte(byte)
+    }
+
+    #[test]
+    fn committed_chain_contiguity_accepts_next_block_and_overlaps() {
+        // The next block extends stored history directly.
+        assert!(committed_chain_is_contiguous(101, 100));
+        // A commit whose chain starts at or below the stored head (e.g. buffered notifications
+        // overlapping blocks the backfill already stored) leaves no gap either; the per-block
+        // loop starts above the stored head and consumes only the new suffix.
+        assert!(committed_chain_is_contiguous(95, 100));
+    }
+
+    #[test]
+    fn committed_chain_contiguity_rejects_gaps() {
+        assert!(!committed_chain_is_contiguous(102, 100));
+    }
+
+    #[test]
+    fn committed_chain_contiguity_saturates_at_max_height() {
+        assert!(committed_chain_is_contiguous(u64::MAX, u64::MAX));
     }
 
     #[test]
@@ -1072,7 +1184,10 @@ mod tests {
     }
 
     #[test]
-    fn proof_history_startup_action_unwinds_when_latest_is_ahead_and_earliest_is_canonical() {
+    fn proof_history_startup_action_waits_when_latest_is_ahead_of_canonical_best() {
+        // An ungraceful restart leaves the persisted head a few blocks behind the previously
+        // indexed in-memory tip. The driver re-derives the same blocks within seconds, so wait
+        // for canonical state to catch up instead of discarding the whole retained window.
         let action = proof_history_startup_action(
             Some((10, hash(10))),
             Some((25, hash(25))),
@@ -1080,14 +1195,24 @@ mod tests {
             Some(hash(10)),
             None,
         )
-        .expect("canonical earliest should allow rewind when latest is ahead");
+        .expect("latest ahead of canonical best should wait for the node to catch up");
 
         assert_eq!(
             action,
-            ProofHistoryStartupAction::UnwindToEarliest {
-                earliest: BlockNumHash::new(10, hash(10))
-            }
+            ProofHistoryStartupAction::WaitForCanonicalLatest { latest: 25, canonical_best: 20 }
         );
+    }
+
+    #[test]
+    fn proof_history_startup_action_waits_when_canonical_has_not_reached_earliest() {
+        // A re-synced chain database (with retained proof-history storage) has no header at the
+        // stored earliest height yet. Wait for sync instead of failing: the node could never
+        // sync past this point if reconciliation kept crashing it.
+        let action =
+            proof_history_startup_action(Some((10, hash(10))), Some((20, hash(20))), 5, None, None)
+                .expect("canonical chain below stored earliest should wait for sync");
+
+        assert_eq!(action, ProofHistoryStartupAction::WaitForCanonicalEarliest { earliest: 10 });
     }
 
     #[test]
@@ -1101,17 +1226,24 @@ mod tests {
         )
         .expect_err("noncanonical earliest must not be served");
 
-        assert!(error.to_string().contains("earliest stored block"));
+        let message = error.to_string();
+        assert!(message.contains("earliest stored block"));
+        assert!(message.contains("wipe proof-history storage"));
     }
 
     #[test]
-    fn canonical_notification_to_exex_maps_empty_reorg_to_revert() {
-        let old = Arc::new(Chain::<EthPrimitives>::default());
-        let notification: CanonStateNotification<EthPrimitives> =
-            CanonStateNotification::Reorg { old: old.clone(), new: Arc::new(Chain::default()) };
+    fn proof_history_startup_action_errors_when_latest_hash_is_missing_within_canonical_range() {
+        // The stored latest height is within the canonical chain, yet the canonical hash lookup
+        // returned nothing: a provider inconsistency that waiting cannot repair. Fail closed.
+        let error = proof_history_startup_action(
+            Some((10, hash(10))),
+            Some((20, hash(20))),
+            20,
+            Some(hash(10)),
+            None,
+        )
+        .expect_err("missing canonical hash below best must fail closed");
 
-        let converted = canonical_notification_to_exex(notification);
-
-        assert_eq!(converted, ExExNotification::ChainReverted { old });
+        assert!(error.to_string().contains("no canonical hash"));
     }
 }

--- a/crates/node/src/proof_history/storage_init.rs
+++ b/crates/node/src/proof_history/storage_init.rs
@@ -18,7 +18,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-use tracing::info;
+use tracing::{info, warn};
 
 /// Returns whether proof-history storage needs an initial current-state snapshot.
 pub(super) fn proof_history_storage_needs_initialization<Storage>(
@@ -32,11 +32,11 @@ where
         provider_ro.get_latest_block_number()?.is_none())
 }
 
-/// Safety threshold for automatic proof-history pruning on startup.
-pub(super) const PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS: u64 = 1000;
-
 /// File stored beside the proof-history MDBX database to validate historical init resume targets.
 pub(super) const PROOF_HISTORY_HISTORICAL_INIT_METADATA_FILE: &str = "taiko-historical-init-target";
+
+/// Revert span above which historical initialization warns about its in-memory changeset size.
+const PROOF_HISTORY_REVERT_SPAN_WARN_BLOCKS: u64 = 100_000;
 
 /// Returns the metadata file path used to validate in-progress historical initialization.
 pub(super) fn proof_history_historical_init_metadata_path(storage_path: &Path) -> PathBuf {
@@ -150,7 +150,14 @@ pub(super) fn remove_historical_init_metadata(path: &Path) -> eyre::Result<()> {
     }
 }
 
-/// Validates that in-progress historical initialization is resuming the same source state.
+/// Validates that in-progress historical initialization is resuming the same anchor state.
+///
+/// Only the anchor start block must match the recorded metadata: every copied row is the current
+/// table row rewound to the anchor state by the reverse-changeset overlay, so rows copied before
+/// and after an interruption agree as long as the anchor is unchanged (and the recomputed overlay
+/// is re-verified against the anchor state root before any row is written). The target is
+/// expected to move between attempts on a live chain; refresh the recorded target instead of
+/// failing the resume.
 pub(super) fn validate_historical_init_metadata_file(
     metadata_path: Option<&Path>,
     expected_metadata: HistoricalInitMetadata,
@@ -166,45 +173,30 @@ pub(super) fn validate_historical_init_metadata_file(
         ));
     };
 
-    if stored_metadata != expected_metadata {
+    if stored_metadata.start_block != expected_metadata.start_block {
         return Err(eyre!(
-            "historical proof-history initialization target changed: stored={stored_metadata:?} current={expected_metadata:?}; wipe proof-history storage and restart initialization"
+            "historical proof-history initialization start block changed: stored={:?} current={:?}; wipe proof-history storage and restart initialization",
+            stored_metadata.start_block,
+            expected_metadata.start_block
         ));
+    }
+
+    if stored_metadata != expected_metadata {
+        write_historical_init_metadata(path, expected_metadata)?;
     }
 
     Ok(())
 }
 
-/// Returns the highest block proof-history may backfill without running ahead of execution.
-pub(super) fn proof_history_backfill_target(
-    latest_stored: u64,
-    requested_target: u64,
-    executed_head: u64,
-) -> Option<u64> {
-    let target = requested_target.min(executed_head);
-    (target > latest_stored).then_some(target)
-}
-
-/// Returns the next block proof-history should backfill toward, tracking the node's locally
-/// executed head.
+/// Returns the next block proof-history should backfill toward, or `None` when caught up.
 ///
-/// A target derived only from the last canonical notification stalls when the node advances via
-/// pipeline/staged sync without delivering a live notification (e.g. after a restart) or when the
-/// consensus feed is down: `notified_target` then lags `executed_head`, yet proof-history must
-/// still index everything the node has executed. Folding in `executed_head` fixes that, while the
-/// inner `proof_history_backfill_target` still clamps the result to `executed_head` so re-execution
-/// only ever reads persisted blocks. `None` means caught up (nothing new to backfill).
-///
-/// Because that inner clamp re-bounds the result to `executed_head`, `notified_target` is currently
-/// inert (the result reduces to `executed_head` once it exceeds `latest_stored`); it is retained as
-/// the seam for the planned notified-target demotion follow-up.
-pub(super) fn proof_history_sync_target(
-    latest_stored: u64,
-    notified_target: u64,
-    executed_head: u64,
-) -> Option<u64> {
-    let effective_target = notified_target.max(executed_head);
-    proof_history_backfill_target(latest_stored, effective_target, executed_head)
+/// The target is always the node's locally executed on-disk head: canonical notifications only
+/// wake the sync loop, they never extend its target, so re-execution can never read a block that
+/// is not yet persisted. Deriving the target from the executed head (rather than the last
+/// notification) also means a pipeline/staged-sync gap is backfilled even when no live
+/// notification arrives, e.g. right after a restart or while the consensus feed is down.
+pub(super) fn proof_history_sync_target(latest_stored: u64, executed_head: u64) -> Option<u64> {
+    (executed_head > latest_stored).then_some(executed_head)
 }
 
 /// Decision for delayed proof-history initialization.
@@ -372,6 +364,20 @@ where
         "initializing proof-history storage from historical canonical state"
     );
 
+    // The reverse changesets for the whole span are materialized in memory before the copy
+    // starts; call out unusually wide spans (e.g. enabling backfill-window-only on a node that
+    // is already far past the window start) since they can require many GiB of RAM.
+    let revert_span = target_block.saturating_sub(start_block);
+    if revert_span > PROOF_HISTORY_REVERT_SPAN_WARN_BLOCKS {
+        warn!(
+            target: "reth::taiko::proof_history",
+            start_block,
+            target_block,
+            revert_span,
+            "historical proof-history initialization spans many blocks; building its in-memory reverse changesets may require a lot of RAM"
+        );
+    }
+
     let historical_post_state =
         HashedPostStateSorted::from_reverts(&db_provider, start_block.saturating_add(1)..=target_block)
             .wrap_err_with(|| {
@@ -456,7 +462,9 @@ mod tests {
 
     #[test]
     fn proof_history_backfill_waits_when_executed_head_has_no_next_parent_state() {
-        assert_eq!(proof_history_backfill_target(0, 350_000, 0), None);
+        // Nothing is executed locally beyond the stored anchor, so there is nothing to backfill
+        // regardless of how far ahead the notified canonical tip is.
+        assert_eq!(proof_history_sync_target(0, 0), None);
     }
 
     #[test]
@@ -512,7 +520,11 @@ mod tests {
     }
 
     #[test]
-    fn historical_init_metadata_validation_rejects_target_mismatch() {
+    fn historical_init_metadata_validation_refreshes_target_on_resume() {
+        // The node executed further while initialization was interrupted, so the recomputed
+        // target differs from the recorded one. The overlay is rebuilt against the current
+        // tables and re-verified against the anchor state root, so the resume is safe: accept
+        // it and refresh the recorded target.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(PROOF_HISTORY_HISTORICAL_INIT_METADATA_FILE);
 
@@ -522,38 +534,55 @@ mod tests {
         };
         let current = HistoricalInitMetadata {
             start_block: stored.start_block,
-            target_block: BlockNumHash::new(999_999, B256::with_last_byte(3)),
+            target_block: BlockNumHash::new(1_000_123, B256::with_last_byte(3)),
+        };
+
+        write_historical_init_metadata(&path, stored).unwrap();
+        validate_historical_init_metadata_file(Some(&path), current)
+            .expect("moved target must be accepted on resume");
+
+        assert_eq!(read_historical_init_metadata(&path).unwrap(), Some(current));
+    }
+
+    #[test]
+    fn historical_init_metadata_validation_rejects_start_mismatch() {
+        // A different anchor start block means the resumed copy would mix rows rewound to two
+        // different anchor states; that must stay a hard error.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(PROOF_HISTORY_HISTORICAL_INIT_METADATA_FILE);
+
+        let stored = HistoricalInitMetadata {
+            start_block: BlockNumHash::new(650_000, B256::with_last_byte(1)),
+            target_block: BlockNumHash::new(1_000_000, B256::with_last_byte(2)),
+        };
+        let current = HistoricalInitMetadata {
+            start_block: BlockNumHash::new(650_001, B256::with_last_byte(4)),
+            target_block: stored.target_block,
         };
 
         write_historical_init_metadata(&path, stored).unwrap();
         let error =
             validate_historical_init_metadata_file(Some(&path), current).unwrap_err().to_string();
 
-        assert!(error.contains("initialization target changed"));
+        assert!(error.contains("start block changed"));
+        assert!(error.contains("wipe proof-history storage"));
     }
 
     #[test]
     fn proof_history_sync_target_tracks_executed_head_when_notification_is_stale() {
-        // Incident: the last notified canonical tip is frozen at the pre-stall height, but the node
-        // pipeline-synced ahead. Proof-history must still backfill up to the executed head.
-        assert_eq!(proof_history_sync_target(8_108_771, 8_108_771, 8_110_008), Some(8_110_008));
+        // Incident: no live notification arrived after a stall, but the node pipeline-synced
+        // ahead. Proof-history must still backfill up to the executed head.
+        assert_eq!(proof_history_sync_target(8_108_771, 8_110_008), Some(8_110_008));
     }
 
     #[test]
     fn proof_history_sync_target_waits_when_caught_up_to_executed_head() {
-        assert_eq!(proof_history_sync_target(8_110_008, 8_110_008, 8_110_008), None);
+        assert_eq!(proof_history_sync_target(8_110_008, 8_110_008), None);
     }
 
     #[test]
-    fn proof_history_sync_target_never_runs_ahead_of_executed_head() {
-        // Notified tip is ahead of what is executed locally; do not backfill unexecuted blocks.
-        assert_eq!(proof_history_sync_target(100, 200, 100), None);
-    }
-
-    #[test]
-    fn proof_history_sync_target_backfills_to_executed_head_below_notified_tip() {
-        // Executed head sits between latest_stored and the notified tip.
-        assert_eq!(proof_history_sync_target(100, 200, 150), Some(150));
+    fn proof_history_sync_target_backfills_to_executed_head() {
+        assert_eq!(proof_history_sync_target(100, 150), Some(150));
     }
 
     #[test]
@@ -562,6 +591,6 @@ mod tests {
         // stored. There is nothing to backfill (`None`), but this is a divergence, not healthy
         // idle: the sync loop logs it because the notification-driven reorg handlers that would
         // unwind `latest_stored` only run on live notifications.
-        assert_eq!(proof_history_sync_target(200, 200, 150), None);
+        assert_eq!(proof_history_sync_target(200, 150), None);
     }
 }

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -1,6 +1,6 @@
 //! Proof-history backed overrides for selected `debug_` RPC methods.
 
-use crate::proof_state::ProofHistoryStateProviderFactory;
+use crate::proof_state::{ProofHistoryStateProviderFactory, flatten_blocking_task};
 use alethia_reth_block::{
     executor::{
         is_recoverable_non_anchor_tx_error, is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded,
@@ -33,6 +33,7 @@ use reth_rpc_eth_api::helpers::FullEthApi;
 use reth_rpc_eth_types::EthApiError;
 use reth_trie_common::ExecutionWitnessMode;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tokio::sync::Semaphore;
 
 /// Maximum number of concurrent proof-history witness requests.
@@ -137,7 +138,7 @@ where
             .recovered_block(block_id)
             .await?
             .ok_or(EthApiError::HeaderNotFound(block_id))?;
-        self.execution_witness_for_block(block.as_ref(), mode).await
+        self.execution_witness_for_block(block, mode).await
     }
 
     /// Replays the explicit transaction list on top of the requested block's parent state.
@@ -155,107 +156,133 @@ where
             .ok_or(EthApiError::HeaderNotFound(block_id))?;
         let txs = decode_recovered_tx_list(tx_list)?;
         let block = block_with_tx_list(block.as_ref().clone(), txs);
-        self.execution_witness_for_tx_list_block(&block, mode, options).await
+        self.execution_witness_for_tx_list_block(block, mode, options).await
     }
 
     /// Re-executes the provided block against proof-history backed parent state and returns the
     /// generated witness.
     async fn execution_witness_for_block(
         &self,
-        block: &RecoveredBlock<Block>,
+        block: Arc<RecoveredBlock<Block>>,
         mode: ExecutionWitnessMode,
     ) -> Result<ExecutionWitness, Eth::Error> {
         let block_number = block.header().number();
         let parent_block = BlockId::Hash(block.parent_hash().into());
-        let state_provider = self
+        let (parent_number, canonical_state) = self
             .state_provider_factory
-            .state_provider(parent_block)
+            .resolve_block_state(parent_block)
             .await
             .map_err(EthApiError::from)?;
-        let db = StateProviderDatabase::new(&*state_provider);
-        let block_executor = self.eth_api.evm_config().executor(db);
-        let mut witness_record = ExecutionWitnessRecord::default();
+        let factory = self.state_provider_factory.clone();
+        let evm_config = self.eth_api.evm_config().clone();
+        let header_provider = self.provider.clone();
 
-        block_executor
-            .execute_with_state_closure(block, |statedb: &State<_>| {
-                witness_record.record_executed_state(statedb, mode);
-            })
-            .map_err(EthApiError::from)?;
+        // Block re-execution and witness assembly are CPU/I/O heavy; keep them off the async
+        // RPC workers.
+        let witness_task = tokio::task::spawn_blocking(move || {
+            let state_provider = factory
+                .state_provider_at(canonical_state, parent_number)
+                .map_err(EthApiError::from)?;
+            let db = StateProviderDatabase::new(&*state_provider);
+            let block_executor = evm_config.executor(db);
+            let mut witness_record = ExecutionWitnessRecord::default();
 
-        Ok(witness_record
-            .into_execution_witness(&*state_provider, &self.provider, block_number, mode)
-            .map_err(EthApiError::from)?)
+            block_executor
+                .execute_with_state_closure(&*block, |statedb: &State<_>| {
+                    witness_record.record_executed_state(statedb, mode);
+                })
+                .map_err(EthApiError::from)?;
+
+            witness_record
+                .into_execution_witness(&*state_provider, &header_provider, block_number, mode)
+                .map_err(EthApiError::from)
+        })
+        .await;
+
+        Ok(flatten_blocking_task(witness_task)?)
     }
 
     /// Replays the explicit transaction-list block with prover-style filtering, without enabling
     /// the block crate's global `prover` feature for normal node execution.
     async fn execution_witness_for_tx_list_block(
         &self,
-        block: &RecoveredBlock<Block>,
+        block: RecoveredBlock<Block>,
         mode: ExecutionWitnessMode,
         options: TxListWitnessOptions,
     ) -> Result<ExecutionWitness, Eth::Error> {
         let block_number = block.header().number();
         let parent_block = BlockId::Hash(block.parent_hash().into());
-        let state_provider = self
+        let (parent_number, canonical_state) = self
             .state_provider_factory
-            .state_provider(parent_block)
+            .resolve_block_state(parent_block)
             .await
             .map_err(EthApiError::from)?;
-        let db = StateProviderDatabase::new(&*state_provider);
-        let mut state = State::builder().with_database(db).with_bundle_update().build();
-        let mut witness_record = ExecutionWitnessRecord::default();
+        let factory = self.state_provider_factory.clone();
+        let evm_config = self.eth_api.evm_config().clone();
+        let header_provider = self.provider.clone();
 
-        {
-            let mut block_executor = self
-                .eth_api
-                .evm_config()
-                .executor_for_block(&mut state, block.sealed_block())
-                .map_err(|err| EthApiError::EvmCustom(err.to_string()))?;
+        // Transaction replay and witness assembly are CPU/I/O heavy; keep them off the async
+        // RPC workers.
+        let witness_task = tokio::task::spawn_blocking(move || {
+            let state_provider = factory
+                .state_provider_at(canonical_state, parent_number)
+                .map_err(EthApiError::from)?;
+            let db = StateProviderDatabase::new(&*state_provider);
+            let mut state = State::builder().with_database(db).with_bundle_update().build();
+            let mut witness_record = ExecutionWitnessRecord::default();
 
-            block_executor.apply_pre_execution_changes().map_err(EthApiError::from)?;
+            {
+                let mut block_executor = evm_config
+                    .executor_for_block(&mut state, block.sealed_block())
+                    .map_err(|err| EthApiError::EvmCustom(err.to_string()))?;
 
-            for (idx, tx) in block.transactions_recovered().enumerate() {
-                let is_anchor_transaction = idx == 0;
+                block_executor.apply_pre_execution_changes().map_err(EthApiError::from)?;
 
-                // Taiko blocks never contain blob transactions: the build paths skip non-anchor
-                // ones (crates/payload/src/builder/execution.rs) and consensus validation rejects
-                // any block that includes one. Keep the same filtering, but never silently discard
-                // the mandatory anchor transaction.
-                match should_skip_disallowed_tx_type(tx.inner(), is_anchor_transaction) {
-                    Ok(true) => {
-                        continue;
-                    }
-                    Ok(false) => {}
-                    Err(err) => return Err(err.into()),
-                }
+                for (idx, tx) in block.transactions_recovered().enumerate() {
+                    let is_anchor_transaction = idx == 0;
 
-                match block_executor.execute_transaction(tx) {
-                    Ok(_) => {}
-                    Err(err) if is_recoverable_tx_list_error(&err, is_anchor_transaction) => {
-                        if is_zk_gas_limit_exceeded(&err) {
-                            break;
+                    // Taiko blocks never contain blob transactions: the build paths skip
+                    // non-anchor ones (crates/payload/src/builder/execution.rs) and consensus
+                    // validation rejects any block that includes one. Keep the same filtering,
+                    // but never silently discard the mandatory anchor transaction.
+                    match should_skip_disallowed_tx_type(tx.inner(), is_anchor_transaction) {
+                        Ok(true) => {
+                            continue;
                         }
+                        Ok(false) => {}
+                        Err(err) => return Err(err),
                     }
-                    Err(err) => return Err(EthApiError::from(err).into()),
+
+                    match block_executor.execute_transaction(tx) {
+                        Ok(_) => {}
+                        Err(err) if is_recoverable_tx_list_error(&err, is_anchor_transaction) => {
+                            if is_zk_gas_limit_exceeded(&err) {
+                                break;
+                            }
+                        }
+                        Err(err) => return Err(EthApiError::from(err)),
+                    }
+                }
+
+                match block_executor.apply_post_execution_changes() {
+                    Ok(_) => {}
+                    Err(err)
+                        if options.skip_zk_gas_difficulty_check &&
+                            is_zk_gas_difficulty_mismatch(&err) => {}
+                    Err(err) => return Err(EthApiError::from(err)),
                 }
             }
 
-            match block_executor.apply_post_execution_changes() {
-                Ok(_) => {}
-                Err(err)
-                    if options.skip_zk_gas_difficulty_check &&
-                        is_zk_gas_difficulty_mismatch(&err) => {}
-                Err(err) => return Err(EthApiError::from(err).into()),
-            }
-        }
+            state.merge_transitions(BundleRetention::Reverts);
+            witness_record.record_executed_state(&state, mode);
 
-        state.merge_transitions(BundleRetention::Reverts);
-        witness_record.record_executed_state(&state, mode);
+            witness_record
+                .into_execution_witness(&*state_provider, &header_provider, block_number, mode)
+                .map_err(EthApiError::from)
+        })
+        .await;
 
-        Ok(witness_record
-            .into_execution_witness(&*state_provider, &self.provider, block_number, mode)
-            .map_err(EthApiError::from)?)
+        Ok(flatten_blocking_task(witness_task)?)
     }
 }
 
@@ -274,7 +301,8 @@ where
         block: BlockNumberOrTag,
         mode: Option<ExecutionWitnessMode>,
     ) -> RpcResult<ExecutionWitness> {
-        let _permit = self.semaphore.acquire().await;
+        let _permit =
+            self.semaphore.acquire().await.expect("witness request semaphore is never closed");
         self.execution_witness_for_id(block.into(), mode.unwrap_or_default())
             .await
             .map_err(Into::into)
@@ -286,7 +314,8 @@ where
         hash: B256,
         mode: Option<ExecutionWitnessMode>,
     ) -> RpcResult<ExecutionWitness> {
-        let _permit = self.semaphore.acquire().await;
+        let _permit =
+            self.semaphore.acquire().await.expect("witness request semaphore is never closed");
         self.execution_witness_for_id(hash.into(), mode.unwrap_or_default())
             .await
             .map_err(Into::into)
@@ -300,7 +329,8 @@ where
         mode: Option<ExecutionWitnessMode>,
         options: Option<TxListWitnessOptions>,
     ) -> RpcResult<ExecutionWitness> {
-        let _permit = self.semaphore.acquire().await;
+        let _permit =
+            self.semaphore.acquire().await.expect("witness request semaphore is never closed");
         self.execution_witness_for_tx_list_for_id(
             block,
             tx_list,

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -165,9 +165,7 @@ where
             .recovered_block(block_id)
             .await?
             .ok_or(EthApiError::HeaderNotFound(block_id))?;
-        let txs = decode_recovered_tx_list(tx_list)?;
-        let block = block_with_tx_list(block.as_ref().clone(), txs);
-        self.execution_witness_for_tx_list_block(block, mode, options).await
+        self.execution_witness_for_tx_list_block(block, tx_list, mode, options).await
     }
 
     /// Re-executes the provided block against proof-history backed parent state and returns the
@@ -223,16 +221,23 @@ where
         Ok(flatten_blocking_task(witness_task)?)
     }
 
-    /// Replays the explicit transaction-list block with prover-style filtering, without enabling
-    /// the block crate's global `prover` feature for normal node execution.
+    /// Replays the explicit transaction list on the canonical block's parent state with
+    /// prover-style filtering, without enabling the block crate's global `prover` feature for
+    /// normal node execution.
+    ///
+    /// The raw transaction list is validated and decoded inside the permit-guarded blocking
+    /// closure: the size check zlib-compresses up to 16 MiB and decoding recovers every
+    /// transaction signer, which is far too much CPU for the async RPC workers and must stay
+    /// under the witness concurrency cap.
     async fn execution_witness_for_tx_list_block(
         &self,
-        block: RecoveredBlock<Block>,
+        canonical_block: Arc<RecoveredBlock<Block>>,
+        tx_list: Bytes,
         mode: ExecutionWitnessMode,
         options: TxListWitnessOptions,
     ) -> Result<ExecutionWitness, Eth::Error> {
-        let block_number = block.header().number();
-        let parent_block = BlockId::Hash(block.parent_hash().into());
+        let block_number = canonical_block.header().number();
+        let parent_block = BlockId::Hash(canonical_block.parent_hash().into());
         let (parent_number, canonical_state) = self
             .state_provider_factory
             .resolve_block_state(parent_block)
@@ -249,10 +254,12 @@ where
             .await
             .expect("witness request semaphore is never closed");
 
-        // Transaction replay and witness assembly are CPU/I/O heavy; keep them off the async
-        // RPC workers.
+        // Tx-list validation/decode, transaction replay, and witness assembly are CPU/I/O
+        // heavy; keep them off the async RPC workers and under the concurrency cap.
         let witness_task = tokio::task::spawn_blocking(move || {
             let _permit = permit;
+            let txs = decode_recovered_tx_list(tx_list)?;
+            let block = block_with_tx_list(canonical_block.as_ref().clone(), txs);
             let state_provider = factory
                 .state_provider_at(canonical_state, parent_number)
                 .map_err(EthApiError::from)?;

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -1,6 +1,8 @@
 //! Proof-history backed overrides for selected `debug_` RPC methods.
 
-use crate::proof_state::{ProofHistoryStateProviderFactory, flatten_blocking_task};
+use crate::proof_state::{
+    ProofHistoryReadiness, ProofHistoryStateProviderFactory, flatten_blocking_task,
+};
 use alethia_reth_block::{
     executor::{
         is_recoverable_non_anchor_tx_error, is_zk_gas_difficulty_mismatch, is_zk_gas_limit_exceeded,
@@ -107,7 +109,7 @@ pub struct TaikoDebugWitnessExt<Eth, Storage, Provider> {
     /// Factory for sidecar-backed state providers.
     state_provider_factory: ProofHistoryStateProviderFactory<Eth, Storage>,
     /// Semaphore limiting concurrent witness generation.
-    semaphore: Semaphore,
+    semaphore: Arc<Semaphore>,
 }
 
 impl<Eth, Storage, Provider> TaikoDebugWitnessExt<Eth, Storage, Provider>
@@ -118,12 +120,21 @@ where
     Provider::Header: BlockHeader + alloy_rlp::Encodable,
 {
     /// Creates a new proof-history backed debug witness override.
-    pub fn new(provider: Provider, eth_api: Eth, storage: OpProofsStorage<Storage>) -> Self {
+    pub fn new(
+        provider: Provider,
+        eth_api: Eth,
+        storage: OpProofsStorage<Storage>,
+        readiness: ProofHistoryReadiness,
+    ) -> Self {
         Self {
             provider,
-            state_provider_factory: ProofHistoryStateProviderFactory::new(eth_api.clone(), storage),
+            state_provider_factory: ProofHistoryStateProviderFactory::new(
+                eth_api.clone(),
+                storage,
+                readiness,
+            ),
             eth_api,
-            semaphore: Semaphore::new(MAX_CONCURRENT_WITNESS_REQUESTS),
+            semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_WITNESS_REQUESTS)),
         }
     }
 
@@ -176,10 +187,20 @@ where
         let factory = self.state_provider_factory.clone();
         let evm_config = self.eth_api.evm_config().clone();
         let header_provider = self.provider.clone();
+        // Acquire an owned permit and move it into the blocking closure: a permit held only by
+        // this (cancellable) future would be released on client disconnect while the
+        // non-abortable blocking work keeps running, letting cancelled requests bypass the cap.
+        let permit = self
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("witness request semaphore is never closed");
 
         // Block re-execution and witness assembly are CPU/I/O heavy; keep them off the async
         // RPC workers.
         let witness_task = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
             let state_provider = factory
                 .state_provider_at(canonical_state, parent_number)
                 .map_err(EthApiError::from)?;
@@ -220,10 +241,18 @@ where
         let factory = self.state_provider_factory.clone();
         let evm_config = self.eth_api.evm_config().clone();
         let header_provider = self.provider.clone();
+        // Owned permit moved into the closure; see `execution_witness_for_block`.
+        let permit = self
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("witness request semaphore is never closed");
 
         // Transaction replay and witness assembly are CPU/I/O heavy; keep them off the async
         // RPC workers.
         let witness_task = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
             let state_provider = factory
                 .state_provider_at(canonical_state, parent_number)
                 .map_err(EthApiError::from)?;
@@ -301,8 +330,6 @@ where
         block: BlockNumberOrTag,
         mode: Option<ExecutionWitnessMode>,
     ) -> RpcResult<ExecutionWitness> {
-        let _permit =
-            self.semaphore.acquire().await.expect("witness request semaphore is never closed");
         self.execution_witness_for_id(block.into(), mode.unwrap_or_default())
             .await
             .map_err(Into::into)
@@ -314,8 +341,6 @@ where
         hash: B256,
         mode: Option<ExecutionWitnessMode>,
     ) -> RpcResult<ExecutionWitness> {
-        let _permit =
-            self.semaphore.acquire().await.expect("witness request semaphore is never closed");
         self.execution_witness_for_id(hash.into(), mode.unwrap_or_default())
             .await
             .map_err(Into::into)
@@ -329,8 +354,6 @@ where
         mode: Option<ExecutionWitnessMode>,
         options: Option<TxListWitnessOptions>,
     ) -> RpcResult<ExecutionWitness> {
-        let _permit =
-            self.semaphore.acquire().await.expect("witness request semaphore is never closed");
         self.execution_witness_for_tx_list_for_id(
             block,
             tx_list,

--- a/crates/rpc/src/eth/proofs.rs
+++ b/crates/rpc/src/eth/proofs.rs
@@ -1,6 +1,8 @@
 //! Proof-history backed override for `eth_getProof`.
 
-use crate::proof_state::{ProofHistoryStateProviderFactory, flatten_blocking_task};
+use crate::proof_state::{
+    ProofHistoryReadiness, ProofHistoryStateProviderFactory, flatten_blocking_task,
+};
 use alloy_eips::BlockId;
 use alloy_primitives::Address;
 use alloy_rpc_types_eth::EIP1186AccountProofResponse;
@@ -48,9 +50,15 @@ where
     Storage: OpProofsStore + Clone + 'static,
 {
     /// Creates a new proof-history backed `eth_getProof` override.
-    pub fn new(eth_api: Eth, storage: OpProofsStorage<Storage>) -> Self {
+    pub fn new(
+        eth_api: Eth,
+        storage: OpProofsStorage<Storage>,
+        readiness: ProofHistoryReadiness,
+    ) -> Self {
         Self {
-            state_provider_factory: ProofHistoryStateProviderFactory::new(eth_api, storage),
+            state_provider_factory: ProofHistoryStateProviderFactory::new(
+                eth_api, storage, readiness,
+            ),
             semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_PROOF_REQUESTS)),
         }
     }
@@ -69,8 +77,15 @@ where
         keys: Vec<JsonStorageKey>,
         block_id: Option<BlockId>,
     ) -> RpcResult<EIP1186AccountProofResponse> {
-        let _permit =
-            self.semaphore.acquire().await.expect("proof request semaphore is never closed");
+        // Acquire an owned permit and move it into the blocking closure: a permit held only by
+        // this (cancellable) future would be released on client disconnect while the
+        // non-abortable blocking work keeps running, letting cancelled requests bypass the cap.
+        let permit = self
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("proof request semaphore is never closed");
         let storage_keys = keys.iter().map(JsonStorageKey::as_b256).collect::<Vec<_>>();
         let factory = self.state_provider_factory.clone();
         let (block_number, canonical_state) = factory
@@ -80,6 +95,7 @@ where
 
         // The trie walk is synchronous MDBX I/O; keep it off the async RPC workers.
         let proof_task = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
             let state_provider = factory
                 .state_provider_at(canonical_state, block_number)
                 .map_err(EthApiError::from)?;

--- a/crates/rpc/src/eth/proofs.rs
+++ b/crates/rpc/src/eth/proofs.rs
@@ -1,6 +1,6 @@
 //! Proof-history backed override for `eth_getProof`.
 
-use crate::proof_state::ProofHistoryStateProviderFactory;
+use crate::proof_state::{ProofHistoryStateProviderFactory, flatten_blocking_task};
 use alloy_eips::BlockId;
 use alloy_primitives::Address;
 use alloy_rpc_types_eth::EIP1186AccountProofResponse;
@@ -10,6 +10,14 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_optimism_trie::{OpProofsStorage, OpProofsStore};
 use reth_rpc_eth_api::helpers::FullEthApi;
 use reth_rpc_eth_types::EthApiError;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+/// Maximum number of concurrent `eth_getProof` computations.
+///
+/// Each request walks proof-history tries on the blocking pool; the cap keeps a proof storm from
+/// starving the pool (stock reth similarly gates `eth_getProof` behind a shared permit).
+const MAX_CONCURRENT_PROOF_REQUESTS: usize = 32;
 
 /// RPC server trait for Taiko proof-history backed `eth_getProof`.
 #[cfg_attr(not(test), rpc(server, namespace = "eth"))]
@@ -30,6 +38,8 @@ pub trait TaikoEthProofApi {
 pub struct TaikoEthProofExt<Eth, Storage> {
     /// Factory for sidecar-backed state providers.
     state_provider_factory: ProofHistoryStateProviderFactory<Eth, Storage>,
+    /// Semaphore limiting concurrent proof computations.
+    semaphore: Arc<Semaphore>,
 }
 
 impl<Eth, Storage> TaikoEthProofExt<Eth, Storage>
@@ -38,8 +48,11 @@ where
     Storage: OpProofsStore + Clone + 'static,
 {
     /// Creates a new proof-history backed `eth_getProof` override.
-    pub const fn new(eth_api: Eth, storage: OpProofsStorage<Storage>) -> Self {
-        Self { state_provider_factory: ProofHistoryStateProviderFactory::new(eth_api, storage) }
+    pub fn new(eth_api: Eth, storage: OpProofsStorage<Storage>) -> Self {
+        Self {
+            state_provider_factory: ProofHistoryStateProviderFactory::new(eth_api, storage),
+            semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_PROOF_REQUESTS)),
+        }
     }
 }
 
@@ -56,15 +69,26 @@ where
         keys: Vec<JsonStorageKey>,
         block_id: Option<BlockId>,
     ) -> RpcResult<EIP1186AccountProofResponse> {
+        let _permit =
+            self.semaphore.acquire().await.expect("proof request semaphore is never closed");
         let storage_keys = keys.iter().map(JsonStorageKey::as_b256).collect::<Vec<_>>();
-        let state_provider = self
-            .state_provider_factory
-            .state_provider(block_id.unwrap_or_default())
+        let factory = self.state_provider_factory.clone();
+        let (block_number, canonical_state) = factory
+            .resolve_block_state(block_id.unwrap_or_default())
             .await
             .map_err(EthApiError::from)?;
-        let proof = state_provider
-            .proof(Default::default(), address, &storage_keys)
-            .map_err(EthApiError::from)?;
+
+        // The trie walk is synchronous MDBX I/O; keep it off the async RPC workers.
+        let proof_task = tokio::task::spawn_blocking(move || {
+            let state_provider = factory
+                .state_provider_at(canonical_state, block_number)
+                .map_err(EthApiError::from)?;
+            state_provider
+                .proof(Default::default(), address, &storage_keys)
+                .map_err(EthApiError::from)
+        })
+        .await;
+        let proof = flatten_blocking_task(proof_task)?;
 
         Ok(proof.into_eip1186_response(keys))
     }

--- a/crates/rpc/src/proof_state.rs
+++ b/crates/rpc/src/proof_state.rs
@@ -9,7 +9,45 @@ use reth_provider::{
 };
 use reth_rpc_eth_api::helpers::FullEthApi;
 use reth_rpc_eth_types::EthApiError;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use tracing::{debug, warn};
+
+/// Shared flag tracking whether proof-history storage is reconciled against canonical state.
+///
+/// The sidecar sets the flag once startup reconciliation (or lag recovery) has validated the
+/// stored bounds against canonical block hashes, and clears it while reconciliation is pending.
+/// The RPC layer refuses to serve proof-history state while the flag is clear: after an
+/// ungraceful restart the stored head can describe a branch the canonical chain no longer
+/// follows, and bounds alone cannot tell. The flag cannot cover a divergence that has not been
+/// *detected* yet (in-flight snapshots, un-received notifications); it closes the known-waiting
+/// window where the sidecar itself knows storage is unvalidated.
+#[derive(Debug, Clone, Default)]
+pub struct ProofHistoryReadiness(Arc<AtomicBool>);
+
+impl ProofHistoryReadiness {
+    /// Creates a readiness handle that starts not ready.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Marks proof-history storage as reconciled with canonical state.
+    pub fn set_ready(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    /// Marks proof-history storage as pending reconciliation.
+    pub fn set_not_ready(&self) {
+        self.0.store(false, Ordering::Release);
+    }
+
+    /// Returns whether proof-history storage is reconciled with canonical state.
+    pub fn is_ready(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
 
 /// Maximum distance behind the canonical tip for which an uncovered proof request may fall back
 /// to canonical (revert-overlay) state instead of erroring.
@@ -20,16 +58,18 @@ use tracing::{debug, warn};
 /// rejected instead of risking minutes of CPU and an OOM-sized overlay per request.
 const PROOF_HISTORY_CANONICAL_FALLBACK_MAX_DISTANCE: u64 = 1024;
 
-/// A proof request outside the proof-history window and too deep to serve from canonical state.
+/// A proof request that proof-history cannot serve and that is too deep for canonical fallback.
 #[derive(Debug, thiserror::Error)]
 #[error(
-    "block {block_number} is not covered by proof-history storage (retained bounds: {bounds:?}) \
-     and lies {distance} blocks behind the canonical tip; deep-history proofs cannot be served \
-     from canonical fallback state"
+    "block {block_number} cannot be served from proof-history storage (reconciled: {reconciled}, \
+     retained bounds: {bounds:?}) and lies {distance} blocks behind the canonical tip; \
+     deep-history proofs cannot be served from canonical fallback state"
 )]
 struct ProofHistoryDeepHistoryError {
     /// Requested block number.
     block_number: u64,
+    /// Whether stored bounds were reconciled against canonical state at request time.
+    reconciled: bool,
     /// Retained proof-history bounds at request time.
     bounds: Option<(u64, u64)>,
     /// Distance between the canonical tip and the requested block.
@@ -73,6 +113,16 @@ fn proof_history_fallback_allowed(
     canonical_tip.saturating_sub(block_number) <= max_distance
 }
 
+/// Returns whether proof-history storage may serve `block_number`: it must be within the retained
+/// bounds *and* the bounds must have been reconciled against canonical state.
+fn proof_history_can_serve(
+    reconciled: bool,
+    block_number: u64,
+    bounds: Option<(u64, u64)>,
+) -> bool {
+    reconciled && proof_history_covers(block_number, bounds)
+}
+
 /// Creates state providers that overlay OP Proofs history on top of canonical state.
 #[derive(Debug, Clone)]
 pub struct ProofHistoryStateProviderFactory<Eth, Storage> {
@@ -80,12 +130,18 @@ pub struct ProofHistoryStateProviderFactory<Eth, Storage> {
     eth_api: Eth,
     /// Proof-history storage containing retained trie nodes and hashed leaves.
     storage: OpProofsStorage<Storage>,
+    /// Whether the sidecar has reconciled the stored bounds against canonical state.
+    readiness: ProofHistoryReadiness,
 }
 
 impl<Eth, Storage> ProofHistoryStateProviderFactory<Eth, Storage> {
     /// Creates a new proof-history state provider factory.
-    pub const fn new(eth_api: Eth, storage: OpProofsStorage<Storage>) -> Self {
-        Self { eth_api, storage }
+    pub const fn new(
+        eth_api: Eth,
+        storage: OpProofsStorage<Storage>,
+        readiness: ProofHistoryReadiness,
+    ) -> Self {
+        Self { eth_api, storage, readiness }
     }
 }
 
@@ -133,7 +189,8 @@ where
             .zip(earliest)
             .map(|((latest_number, _), (earliest_number, _))| (earliest_number, latest_number));
 
-        if !proof_history_covers(block_number, bounds) {
+        let reconciled = self.readiness.is_ready();
+        if !proof_history_can_serve(reconciled, block_number, bounds) {
             let canonical_tip = self.eth_api.provider().best_block_number()?;
             if !proof_history_fallback_allowed(
                 block_number,
@@ -144,17 +201,28 @@ where
                 warn!(
                     target: "reth::taiko::proof_history",
                     block_number,
+                    reconciled,
                     ?bounds,
                     distance,
                     "refusing canonical-state fallback for deep-history proof request"
                 );
                 return Err(ProviderError::other(ProofHistoryDeepHistoryError {
                     block_number,
+                    reconciled,
                     bounds,
                     distance,
                 }));
             }
-            if proof_history_miss_is_pruned(block_number, bounds) {
+            if !reconciled {
+                // Storage exists but has not been validated against canonical state yet (startup
+                // reconciliation or lag recovery in flight): expected and transient.
+                debug!(
+                    target: "reth::taiko::proof_history",
+                    block_number,
+                    ?bounds,
+                    "proof-history is awaiting reconciliation; serving from canonical state"
+                );
+            } else if proof_history_miss_is_pruned(block_number, bounds) {
                 // Below the retained window: the block is pruned from proof-history, a genuine gap.
                 warn!(
                     target: "reth::taiko::proof_history",
@@ -182,7 +250,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        proof_history_covers, proof_history_fallback_allowed, proof_history_miss_is_pruned,
+        ProofHistoryReadiness, proof_history_can_serve, proof_history_covers,
+        proof_history_fallback_allowed, proof_history_miss_is_pruned,
     };
 
     #[test]
@@ -251,5 +320,44 @@ mod tests {
         // A requested block above the tip has zero look-back distance; resolution already
         // failed earlier if the block does not exist.
         assert!(proof_history_fallback_allowed(1000, 900, 1024));
+    }
+
+    #[test]
+    fn readiness_starts_not_ready_and_toggles() {
+        let readiness = ProofHistoryReadiness::new();
+
+        assert!(!readiness.is_ready());
+        readiness.set_ready();
+        assert!(readiness.is_ready());
+        readiness.set_not_ready();
+        assert!(!readiness.is_ready());
+    }
+
+    #[test]
+    fn readiness_is_shared_across_clones() {
+        let sidecar_handle = ProofHistoryReadiness::new();
+        let rpc_handle = sidecar_handle.clone();
+
+        sidecar_handle.set_ready();
+
+        assert!(rpc_handle.is_ready());
+    }
+
+    #[test]
+    fn cannot_serve_covered_block_before_reconciliation() {
+        // The stored bounds may describe a branch the canonical chain no longer follows until
+        // reconciliation validates them; a covered block must not be served while not ready.
+        assert!(!proof_history_can_serve(false, 150, Some((100, 200))));
+    }
+
+    #[test]
+    fn serves_covered_block_when_reconciled() {
+        assert!(proof_history_can_serve(true, 150, Some((100, 200))));
+    }
+
+    #[test]
+    fn cannot_serve_uncovered_block_even_when_reconciled() {
+        assert!(!proof_history_can_serve(true, 250, Some((100, 200))));
+        assert!(!proof_history_can_serve(true, 150, None));
     }
 }

--- a/crates/rpc/src/proof_state.rs
+++ b/crates/rpc/src/proof_state.rs
@@ -4,10 +4,48 @@ use alloy_eips::BlockId;
 use reth_optimism_trie::{
     OpProofsStorage, OpProofsStore, api::OpProofsProviderRO, provider::OpProofsStateProviderRef,
 };
-use reth_provider::{BlockIdReader, ProviderError, ProviderResult, StateProvider};
+use reth_provider::{
+    BlockIdReader, BlockNumReader, ProviderError, ProviderResult, StateProvider, StateProviderBox,
+};
 use reth_rpc_eth_api::helpers::FullEthApi;
 use reth_rpc_eth_types::EthApiError;
 use tracing::{debug, warn};
+
+/// Maximum distance behind the canonical tip for which an uncovered proof request may fall back
+/// to canonical (revert-overlay) state instead of erroring.
+///
+/// The canonical fallback materializes per-block changesets from the requested block up to the
+/// tip, so its cost grows without bound as the request moves into deep history. Near-tip misses
+/// (sidecar catch-up lag, persistence gap) stay well within this bound; anything beyond it is
+/// rejected instead of risking minutes of CPU and an OOM-sized overlay per request.
+const PROOF_HISTORY_CANONICAL_FALLBACK_MAX_DISTANCE: u64 = 1024;
+
+/// A proof request outside the proof-history window and too deep to serve from canonical state.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "block {block_number} is not covered by proof-history storage (retained bounds: {bounds:?}) \
+     and lies {distance} blocks behind the canonical tip; deep-history proofs cannot be served \
+     from canonical fallback state"
+)]
+struct ProofHistoryDeepHistoryError {
+    /// Requested block number.
+    block_number: u64,
+    /// Retained proof-history bounds at request time.
+    bounds: Option<(u64, u64)>,
+    /// Distance between the canonical tip and the requested block.
+    distance: u64,
+}
+
+/// Flattens a `spawn_blocking` join result, preserving panics and surfacing join failures.
+pub(crate) fn flatten_blocking_task<T>(
+    result: Result<Result<T, EthApiError>, tokio::task::JoinError>,
+) -> Result<T, EthApiError> {
+    match result {
+        Ok(inner) => inner,
+        Err(error) if error.is_panic() => std::panic::resume_unwind(error.into_panic()),
+        Err(error) => Err(EthApiError::EvmCustom(format!("blocking task failed to join: {error}"))),
+    }
+}
 
 /// Returns whether proof-history storage can serve `block_number` given its retained bounds.
 ///
@@ -23,6 +61,16 @@ fn proof_history_covers(block_number: u64, bounds: Option<(u64, u64)>) -> bool {
 /// transient, so it should not spam `WARN` on every `eth_getProof` call while proof-history lags.
 fn proof_history_miss_is_pruned(block_number: u64, bounds: Option<(u64, u64)>) -> bool {
     matches!(bounds, Some((earliest, _)) if block_number < earliest)
+}
+
+/// Returns whether an uncovered `block_number` is close enough to the canonical tip to fall back
+/// to canonical (revert-overlay) state instead of erroring.
+fn proof_history_fallback_allowed(
+    block_number: u64,
+    canonical_tip: u64,
+    max_distance: u64,
+) -> bool {
+    canonical_tip.saturating_sub(block_number) <= max_distance
 }
 
 /// Creates state providers that overlay OP Proofs history on top of canonical state.
@@ -41,31 +89,42 @@ impl<Eth, Storage> ProofHistoryStateProviderFactory<Eth, Storage> {
     }
 }
 
-impl<'a, Eth, Storage> ProofHistoryStateProviderFactory<Eth, Storage>
+impl<Eth, Storage> ProofHistoryStateProviderFactory<Eth, Storage>
 where
     Eth: FullEthApi + Send + Sync + 'static,
-    Storage: OpProofsStore + Clone + 'a,
+    Storage: OpProofsStore + Clone + 'static,
 {
-    /// Creates a state provider for the given canonical block id.
-    ///
-    /// The returned provider serves account and storage reads from proof-history storage while
-    /// delegating non-state lookups, such as bytecode and block hashes, to the canonical provider.
-    /// Falls back to the canonical historical state provider (logging a warning) when the requested
-    /// block is outside the retained proof-history window, so a lagging sidecar does not block
-    /// proofs the node can still serve from canonical state.
-    pub async fn state_provider(
-        &'a self,
+    /// Resolves a block id to its canonical block number and base canonical state provider.
+    pub async fn resolve_block_state(
+        &self,
         block_id: BlockId,
-    ) -> ProviderResult<Box<dyn StateProvider + 'a>> {
+    ) -> ProviderResult<(u64, StateProviderBox)> {
         let block_number = self
             .eth_api
             .provider()
             .block_number_for_id(block_id)?
             .ok_or(EthApiError::HeaderNotFound(block_id))
             .map_err(ProviderError::other)?;
-
-        let historical_provider =
+        let canonical_state =
             self.eth_api.state_at_block_id(block_id).await.map_err(ProviderError::other)?;
+        Ok((block_number, canonical_state))
+    }
+
+    /// Wraps a resolved canonical state provider with proof-history state for `block_number`.
+    ///
+    /// The returned provider serves account and storage reads from proof-history storage while
+    /// delegating non-state lookups, such as bytecode and block hashes, to the canonical provider.
+    /// An uncovered block near the canonical tip falls back to the canonical provider (its
+    /// revert overlay is a few blocks deep), so a lagging sidecar does not block proofs the node
+    /// can still serve cheaply; an uncovered block deep in history is rejected instead of
+    /// materializing an unbounded revert overlay.
+    ///
+    /// Opens a proof-history read snapshot and performs trie I/O: call from a blocking context.
+    pub fn state_provider_at(
+        &self,
+        canonical_state: StateProviderBox,
+        block_number: u64,
+    ) -> ProviderResult<Box<dyn StateProvider + '_>> {
         let provider_ro = self.storage.provider_ro().map_err(ProviderError::from)?;
 
         let latest = provider_ro.get_latest_block_number().map_err(ProviderError::from)?;
@@ -75,6 +134,26 @@ where
             .map(|((latest_number, _), (earliest_number, _))| (earliest_number, latest_number));
 
         if !proof_history_covers(block_number, bounds) {
+            let canonical_tip = self.eth_api.provider().best_block_number()?;
+            if !proof_history_fallback_allowed(
+                block_number,
+                canonical_tip,
+                PROOF_HISTORY_CANONICAL_FALLBACK_MAX_DISTANCE,
+            ) {
+                let distance = canonical_tip.saturating_sub(block_number);
+                warn!(
+                    target: "reth::taiko::proof_history",
+                    block_number,
+                    ?bounds,
+                    distance,
+                    "refusing canonical-state fallback for deep-history proof request"
+                );
+                return Err(ProviderError::other(ProofHistoryDeepHistoryError {
+                    block_number,
+                    bounds,
+                    distance,
+                }));
+            }
             if proof_history_miss_is_pruned(block_number, bounds) {
                 // Below the retained window: the block is pruned from proof-history, a genuine gap.
                 warn!(
@@ -93,16 +172,18 @@ where
                     "proof-history does not yet cover requested block; serving from canonical state"
                 );
             }
-            return Ok(historical_provider);
+            return Ok(canonical_state);
         }
 
-        Ok(Box::new(OpProofsStateProviderRef::new(historical_provider, provider_ro, block_number)))
+        Ok(Box::new(OpProofsStateProviderRef::new(canonical_state, provider_ro, block_number)))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{proof_history_covers, proof_history_miss_is_pruned};
+    use super::{
+        proof_history_covers, proof_history_fallback_allowed, proof_history_miss_is_pruned,
+    };
 
     #[test]
     fn covers_block_within_bounds() {
@@ -147,5 +228,28 @@ mod tests {
     fn miss_with_empty_storage_is_not_pruned() {
         // Uninitialized storage: transient startup state, not a WARN.
         assert!(!proof_history_miss_is_pruned(150, None));
+    }
+
+    #[test]
+    fn fallback_allowed_near_tip() {
+        // Sidecar catch-up lag: cheap revert overlay, serve from canonical state.
+        assert!(proof_history_fallback_allowed(8_109_000, 8_109_500, 1024));
+        // Exactly at the distance bound stays allowed.
+        assert!(proof_history_fallback_allowed(100, 1124, 1024));
+    }
+
+    #[test]
+    fn fallback_rejected_deep_in_history() {
+        // A proof for a block far below the retained window would materialize changesets for
+        // every block up to the tip: reject instead of risking an unbounded overlay.
+        assert!(!proof_history_fallback_allowed(1, 8_109_500, 1024));
+        assert!(!proof_history_fallback_allowed(100, 1125, 1024));
+    }
+
+    #[test]
+    fn fallback_allowed_for_future_blocks() {
+        // A requested block above the tip has zero look-back distance; resolution already
+        // failed earlier if the block does not exist.
+        assert!(proof_history_fallback_allowed(1000, 900, 1024));
     }
 }


### PR DESCRIPTION
## Motivation

A review of the proof-history feature surfaced one high-impact recovery-behavior issue, several robustness/DoS gaps, and a handful of simplification opportunities. This PR fixes the issues and applies the simplifications.

## Fixes

**1. Ungraceful restarts no longer discard the retained window.** Live indexing follows in-memory canonical commits, which run ahead of the persisted head by up to the engine persistence threshold — so after a kill -9/OOM, startup reconciliation saw `stored latest > canonical best` and unwound the *entire* retained window (up to `window` = 1.3M blocks), then re-executed it at 50 blocks/batch for days. Reconciliation now **waits** (existing 5s retry tick) for the canonical chain to catch back up, then compares hashes: match → `Ready` with zero unwind; mismatch (real reorg while down) → unwind to the validated earliest anchor as before.

**2. Chain re-sync with retained proof storage no longer crash-loops.** A canonical chain that has not yet reached the stored earliest block (fresh chain DB, old backup) previously failed reconciliation → sidecar panic → node down → it could never sync past the point that would fix it. A missing canonical header now waits; a *mismatching* hash stays fail-closed, and all fail-closed errors now carry the "wipe proof-history storage" remediation.

**3. Proof-history RPC is gated on reconciliation readiness.** The overrides are installed at launch, but stored bounds are only trustworthy once the sidecar has validated them against canonical hashes. A shared `ProofHistoryReadiness` flag (set on successful reconciliation, cleared during lag recovery) now gates every proof-history read: while not ready, requests fall back to canonical state near the tip and fail closed for deep history, so a diverged-while-down branch can never be served during the catch-up wait.

**4. Proof RPCs are offloaded and bounded — including under cancellation.** `eth_getProof` and the `debug_executionWitness*` endpoints ran trie walks / full block re-execution directly on async RPC workers with no request gate (stock reth uses a permit + `spawn_blocking` + proof-window check). They now run on the blocking pool, `eth_getProof` is capped at 32 concurrent computations, and the semaphore permits are **owned and moved into the blocking closures**, so a client disconnect cannot release a permit while the non-abortable blocking work is still running, and the tx-list witness input is validated and decoded (zlib sizing + per-transaction signer recovery) inside the capped closure rather than on the async path. The canonical-state fallback for uncovered blocks is distance-capped (1024 blocks): near-tip misses still fall back, deep-history requests are rejected instead of materializing an unbounded revert-changeset overlay per request (OOM/CPU DoS vector on the public namespace).

**5. Initialization is restartable and runtime-friendly.** Historical initialization now **resumes** after a node restart: the recorded metadata pins the anchor start block, the target is recomputed from the current executed head, and the rebuilt overlay is re-verified against the anchor state root before any row is written (previously any restart on a live chain hit an anchor mismatch and required a wipe). Init, unwind, and backfill batches run on the blocking pool; the sync loop observes graceful shutdown; very wide revert spans log a RAM warning.

**6. The retention window can be lowered deliberately.** The startup prune safety threshold is now `--proofs-history.max-startup-prune-blocks` (default 1000, previous hardcoded value) and the error message names the flag.

## Simplifications

- Completed the notified-target demotion the code already documented as a follow-up: the sync target is provably just the on-disk executed head, so the value-carrying watch channel is now a `Notify` wake-up and `proof_history_sync_target` collapses to one comparison.
- Dropped the `reth-exex` dependency: the sidecar matches `CanonStateNotification` directly instead of converting through `ExExNotification` (module renamed `exex.rs` → `sidecar.rs`).
- Removed the duplicated `ProofHistorySidecarConfig` (the sidecar takes `ProofHistoryConfig` directly) and the dead `missed_start_logged` flag.
- Contiguous multi-block commits near the tip are consumed from notification trie data instead of being bounced to the re-execution backfill (which also stalled on the persistence gap).
- Witness semaphore permits are now `.expect(...)`ed instead of silently degrading if the semaphore were ever closed.

## Behavior changes to be aware of

- While reconciliation is pending (startup catch-up wait, lag recovery), proof-history storage is not served at all: near-tip requests are answered from canonical state, deep-history requests error. Previously the whole window was discarded at startup instead.
- `eth_getProof`/witness requests for blocks below the retained window (and more than 1024 blocks behind the tip) now return an error instead of a slow canonical-state fallback.

## Test plan

- `just fmt`, `just clippy` (warnings-as-errors) clean.
- `just test`: 222 tests pass, including new unit tests for the wait-vs-unwind startup decisions, the readiness gate (`proof_history_can_serve`, shared-handle semantics), the fallback distance gate, metadata resume validation (target refresh + start-mismatch rejection), commit contiguity, and the new CLI flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
