### PR TITLE
feat(chainspec): set Mainnet Unzen fork time

### DIFF
--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -72,7 +72,7 @@ pub static TAIKO_MAINNET_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| 
         (TaikoHardfork::Ontake.boxed(), ForkCondition::Block(538_304)),
         (TaikoHardfork::Pacaya.boxed(), ForkCondition::Block(1_166_000)),
         (TaikoHardfork::Shasta.boxed(), ForkCondition::Timestamp(1_775_135_700)),
-        (TaikoHardfork::Unzen.boxed(), ForkCondition::Never),
+        (TaikoHardfork::Unzen.boxed(), ForkCondition::Timestamp(1_786_021_200)),
     ]))
 });
 
@@ -281,6 +281,13 @@ mod test {
         let shasta = TAIKO_MAINNET_HARDFORKS.fork(TaikoHardfork::Shasta);
         assert!(shasta.is_timestamp(), "shasta activation should be timestamp-based");
         assert_eq!(shasta, ForkCondition::Timestamp(1_775_135_700));
+    }
+
+    #[test]
+    fn test_mainnet_unzen_timestamp() {
+        let unzen = TAIKO_MAINNET_HARDFORKS.fork(TaikoHardfork::Unzen);
+        assert!(unzen.is_timestamp(), "unzen activation should be timestamp-based");
+        assert_eq!(unzen, ForkCondition::Timestamp(1_786_021_200));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Sets the **Unzen** hardfork activation time on **Taiko Mainnet** to **2026-08-06 13:00:00 UTC** (timestamp `1_786_021_200`), replacing the prior `ForkCondition::Never`.

This mirrors the Hoodi activation from #210, applying the same one-line change to `TAIKO_MAINNET_HARDFORKS` plus a matching timestamp test.

## Changes

- `crates/chainspec/src/hardfork.rs`: Mainnet Unzen `ForkCondition::Never` → `ForkCondition::Timestamp(1_786_021_200)`.
- Add `test_mainnet_unzen_timestamp` asserting the activation timestamp.

## Verification

```
cargo test -p alethia-reth-chainspec unzen
# 9 passed; 0 failed — includes test_mainnet_unzen_timestamp
```

Timestamp round-trip: `date -u -r 1786021200` → `2026-08-06 13:00:00 UTC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)