### PR TITLE
feat(rpc): engine capabilities routing, tx-list gas overflow, and L1-origin row decoding

### DIFF
--- a/crates/block/src/tx_selection/mod.rs
+++ b/crates/block/src/tx_selection/mod.rs
@@ -133,11 +133,9 @@ where
     let mut best_txs = pool
         .best_transactions_with_attributes(BestTransactionsAttributes::new(config.base_fee, None));
 
-    let mut lists = Vec::with_capacity(config.max_lists.max(1));
-    lists.push(ExecutedTxList::default());
+    let mut lists = vec![ExecutedTxList::default()];
     // Per-list state for adaptive DA size calibration.
-    let mut da_guard_states = Vec::with_capacity(config.max_lists.max(1));
-    da_guard_states.push(DaRatioState::default());
+    let mut da_guard_states = vec![DaRatioState::default()];
 
     while let Some(pool_tx) = best_txs.next() {
         // 1. Check cancellation
@@ -299,6 +297,44 @@ mod tests {
     const BENCH_INCLUDED_CALLER: Address = Address::with_last_byte(0x31);
     const BENCH_LIMIT_CALLER: Address = Address::with_last_byte(0x32);
     const BENCH_LATE_CALLER: Address = Address::with_last_byte(0x33);
+
+    #[test]
+    fn tx_selection_does_not_preallocate_the_caller_supplied_list_limit() {
+        let chain_spec = Arc::new(unzen_chain_spec());
+        let mut state =
+            State::builder().with_database(db_with_contracts(&[])).with_bundle_update().build();
+        let evm = TaikoEvmFactory.create_evm(&mut state, unzen_evm_env());
+        let executor = TaikoBlockExecutor::new(
+            evm,
+            unzen_execution_ctx(),
+            chain_spec,
+            RethReceiptBuilder::default(),
+        );
+        let mut builder = ExecutorBackedBuilder { executor };
+        let pool = testing_pool();
+
+        let outcome = select_and_execute_pool_transactions(
+            &mut builder,
+            &pool,
+            &TxSelectionConfig {
+                base_fee: 0,
+                gas_limit_per_list: 1,
+                max_da_bytes_per_list: 1,
+                da_size_zlib_guard_bytes: 0,
+                max_lists: usize::MAX,
+                min_tip: 0,
+                locals: vec![],
+            },
+            || false,
+        )
+        .expect("an empty pool should complete without allocating the maximum list count");
+
+        let SelectionOutcome::Completed(lists) = outcome else {
+            panic!("selection should not cancel")
+        };
+        assert_eq!(lists.len(), 1);
+        assert!(lists[0].transactions.is_empty());
+    }
 
     #[test]
     fn tx_selection_breaks_on_zk_gas_error_but_keeps_skipping_invalid_txs() {

--- a/crates/db/src/compress.rs
+++ b/crates/db/src/compress.rs
@@ -4,6 +4,11 @@ use reth_codecs::{Compact, DecompressError};
 
 use crate::model::StoredL1Origin;
 
+/// Fixed byte length of a `Compact`-encoded [`StoredL1Origin`] row: `block_id` (32) +
+/// `l2_block_hash` (32) + `l1_block_height` (32) + `l1_block_hash` (32) +
+/// `build_payload_args_id` (8) + `is_forced_inclusion` (1) + `signature` (65).
+const STORED_L1_ORIGIN_COMPACT_LEN: usize = 32 + 32 + 32 + 32 + 8 + 1 + 65;
+
 impl Compact for StoredL1Origin {
     /// Takes a buffer which can be written to. *Ideally*, it returns the length written to.
     fn to_compact<B>(&self, buf: &mut B) -> usize
@@ -83,6 +88,14 @@ impl reth_db_api::table::Compress for StoredL1Origin {
 impl reth_db_api::table::Decompress for StoredL1Origin {
     /// Decompresses owned data coming from the database.
     fn decompress(value: &[u8]) -> Result<Self, DecompressError> {
+        // `from_compact` reads a fixed-size layout with panicking cursor reads, so a
+        // truncated/corrupt row must be rejected here where an error can be returned.
+        if value.len() < STORED_L1_ORIGIN_COMPACT_LEN {
+            return Err(DecompressError::new(std::io::Error::other(format!(
+                "StoredL1Origin row too short: got {} bytes, expected {STORED_L1_ORIGIN_COMPACT_LEN}",
+                value.len()
+            ))));
+        }
         let (obj, _) = Compact::from_compact(value, value.len());
         Ok(obj)
     }
@@ -113,6 +126,30 @@ mod test {
         let (decompressed, remaining) = StoredL1Origin::from_compact(&buf, len);
         assert!(remaining.is_empty());
         assert_eq!(stored, decompressed);
+    }
+
+    #[test]
+    fn test_decompress_truncated_row_returns_error() {
+        let stored = StoredL1Origin {
+            block_id: U256::random(),
+            l2_block_hash: B256::random(),
+            l1_block_height: U256::random(),
+            l1_block_hash: B256::random(),
+            build_payload_args_id: [1u8; 8],
+            is_forced_inclusion: true,
+            signature: [1u8; 65],
+        };
+
+        let mut buf = Vec::new();
+        stored.compress_to_buf(&mut buf);
+
+        // A corrupt/truncated row must surface as a `DecompressError`, not a panic.
+        for len in [0, 1, 32, buf.len() - 1] {
+            assert!(
+                StoredL1Origin::decompress(&buf[..len]).is_err(),
+                "decompress of {len}-byte row should fail"
+            );
+        }
     }
 
     #[test]

--- a/crates/db/src/compress.rs
+++ b/crates/db/src/compress.rs
@@ -88,11 +88,13 @@ impl reth_db_api::table::Compress for StoredL1Origin {
 impl reth_db_api::table::Decompress for StoredL1Origin {
     /// Decompresses owned data coming from the database.
     fn decompress(value: &[u8]) -> Result<Self, DecompressError> {
-        // `from_compact` reads a fixed-size layout with panicking cursor reads, so a
-        // truncated/corrupt row must be rejected here where an error can be returned.
-        if value.len() < STORED_L1_ORIGIN_COMPACT_LEN {
+        // `from_compact` reads a fixed-size layout with panicking cursor reads and returns any
+        // trailing bytes separately, so reject every non-exact row here instead of panicking or
+        // silently ignoring corruption.
+        if value.len() != STORED_L1_ORIGIN_COMPACT_LEN {
             return Err(DecompressError::new(std::io::Error::other(format!(
-                "StoredL1Origin row too short: got {} bytes, expected {STORED_L1_ORIGIN_COMPACT_LEN}",
+                "StoredL1Origin row has invalid length: got {} bytes, expected \
+                 {STORED_L1_ORIGIN_COMPACT_LEN}",
                 value.len()
             ))));
         }
@@ -150,6 +152,25 @@ mod test {
                 "decompress of {len}-byte row should fail"
             );
         }
+    }
+
+    #[test]
+    fn test_decompress_oversized_row_returns_error() {
+        let stored = StoredL1Origin {
+            block_id: U256::random(),
+            l2_block_hash: B256::random(),
+            l1_block_height: U256::random(),
+            l1_block_hash: B256::random(),
+            build_payload_args_id: [1u8; 8],
+            is_forced_inclusion: true,
+            signature: [1u8; 65],
+        };
+
+        let mut buf = Vec::new();
+        stored.compress_to_buf(&mut buf);
+        buf.push(0xff);
+
+        assert!(StoredL1Origin::decompress(&buf).is_err());
     }
 
     #[test]

--- a/crates/rpc/src/engine/api.rs
+++ b/crates/rpc/src/engine/api.rs
@@ -27,7 +27,7 @@ use reth_provider::{
     BlockReader, DBProvider, DatabaseProviderFactory, HeaderProvider, StateProviderFactory,
 };
 use reth_rpc::EngineApi;
-use reth_rpc_engine_api::EngineApiError;
+use reth_rpc_engine_api::{EngineApiError, EngineCapabilities};
 
 use alethia_reth_chainspec::{hardfork::TaikoHardforks, spec::TaikoChainSpec};
 use alethia_reth_db::model::{
@@ -36,8 +36,15 @@ use alethia_reth_db::model::{
 };
 
 /// The list of all supported Engine capabilities available over the engine endpoint.
+///
+/// Per the Engine API spec, `engine_exchangeCapabilities` itself is served but never listed.
 pub const TAIKO_ENGINE_CAPABILITIES: &[&str] =
     &["engine_forkchoiceUpdatedV2", "engine_getPayloadV2", "engine_newPayloadV2"];
+
+/// Returns the Engine API capabilities advertised by the Taiko engine endpoint.
+pub fn taiko_engine_capabilities() -> EngineCapabilities {
+    EngineCapabilities::new(TAIKO_ENGINE_CAPABILITIES.iter().copied())
+}
 
 /// Extension trait that gives access to Taiko engine API RPC methods.
 ///
@@ -64,6 +71,10 @@ pub trait TaikoEngineApi<Engine: EngineTypes> {
         &self,
         payload_id: PayloadId,
     ) -> RpcResult<Engine::ExecutionPayloadEnvelopeV2>;
+
+    /// Exchange the list of supported Engine API methods with the connected driver.
+    #[method(name = "exchangeCapabilities")]
+    async fn exchange_capabilities(&self, capabilities: Vec<String>) -> RpcResult<Vec<String>>;
 }
 
 /// A concrete implementation of the `TaikoEngineApi` trait.
@@ -254,6 +265,13 @@ where
             self.wait_for_built_payload(payload_id).await.map_err(ErrorObjectOwned::from)?;
         Ok(self.convert_built_payload_to_execution_payload_envelope_v2(built_payload))
     }
+
+    /// Exchanges supported Engine API methods with the driver, returning this node's list.
+    async fn exchange_capabilities(&self, capabilities: Vec<String>) -> RpcResult<Vec<String>> {
+        let el_capabilities = self.inner.capabilities();
+        el_capabilities.log_capability_mismatches(&capabilities);
+        Ok(el_capabilities.list())
+    }
 }
 
 impl<Provider, EngineT, Pool, Validator, ChainSpec> IntoEngineApiRpcModule
@@ -302,6 +320,19 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes, U256};
     use reth_primitives_traits::Block as _;
     use std::sync::Arc;
+
+    #[test]
+    fn engine_capabilities_advertise_exactly_the_served_methods() {
+        let mut capabilities = taiko_engine_capabilities().list();
+        capabilities.sort();
+
+        // Exactly the methods routed by `TaikoEngineApiServer::into_rpc`; per the Engine API
+        // spec, `engine_exchangeCapabilities` itself must not be part of the list.
+        assert_eq!(
+            capabilities,
+            vec!["engine_forkchoiceUpdatedV2", "engine_getPayloadV2", "engine_newPayloadV2"]
+        );
+    }
 
     #[test]
     fn unzen_payload_overwrites_block_value_with_header_difficulty() {

--- a/crates/rpc/src/engine/builder.rs
+++ b/crates/rpc/src/engine/builder.rs
@@ -6,13 +6,12 @@ use reth_node_api::{AddOnsContext, FullNodeComponents, NodeTypes};
 use reth_node_builder::rpc::{EngineApiBuilder, PayloadValidatorBuilder};
 use reth_node_core::version::{CLIENT_CODE, version_metadata};
 use reth_rpc::EngineApi;
-use reth_rpc_engine_api::EngineCapabilities;
 
 use alethia_reth_chainspec::spec::TaikoChainSpec;
 use alethia_reth_primitives::engine::TaikoEngineTypes;
 use reth_ethereum::EthPrimitives;
 
-use crate::engine::api::TaikoEngineApi;
+use crate::engine::api::{TaikoEngineApi, taiko_engine_capabilities};
 
 /// Builder for basic [`EngineApi`] implementation.
 ///
@@ -74,7 +73,7 @@ where
             ctx.node.pool().clone(),
             ctx.node.task_executor().clone(),
             client,
-            EngineCapabilities::default(),
+            taiko_engine_capabilities(),
             engine_validator,
             ctx.config.engine.accept_execution_requests_hash,
             ctx.node.network().clone(),

--- a/crates/rpc/src/eth/auth/mod.rs
+++ b/crates/rpc/src/eth/auth/mod.rs
@@ -54,6 +54,19 @@ pub use types::{PreBuiltTxList, TxPoolContentParams, TxPoolContentWithMinTipPara
 #[cfg(test)]
 mod tests;
 
+/// Computes the combined gas budget across all requested candidate tx lists, rejecting
+/// parameter combinations whose product does not fit in a `u64`.
+fn combined_tx_lists_gas_limit(
+    block_max_gas_limit: u64,
+    max_transactions_lists: u64,
+) -> Result<u64, EthApiError> {
+    block_max_gas_limit.checked_mul(max_transactions_lists).ok_or_else(|| {
+        EthApiError::InvalidParams(
+            "`blockMaxGasLimit` * `maxTransactionsLists` overflows u64".to_string(),
+        )
+    })
+}
+
 /// trait interface for a custom auth rpc namespace: `taikoAuth`
 ///
 /// This defines the Taiko namespace where all methods are configured as trait functions.
@@ -298,6 +311,8 @@ where
             )
             .into());
         }
+        let combined_gas_limit =
+            combined_tx_lists_gas_limit(block_max_gas_limit, max_transactions_lists)?;
 
         // Fetch the parent block and its state, for building the prebuilt transaction lists later.
         let parent_block = self
@@ -328,7 +343,7 @@ where
                     timestamp: parent.timestamp(),
                     suggested_fee_recipient: beneficiary,
                     prev_randao: parent.mix_hash().unwrap_or_default(),
-                    gas_limit: block_max_gas_limit * max_transactions_lists,
+                    gas_limit: combined_gas_limit,
                     extra_data: parent.extra_data().clone(),
                     base_fee_per_gas: base_fee,
                 },

--- a/crates/rpc/src/eth/auth/tests.rs
+++ b/crates/rpc/src/eth/auth/tests.rs
@@ -201,6 +201,13 @@ fn tx_pool_content_params_conversion_defaults_min_tip_to_zero() {
     assert_eq!(with_tip.min_tip, 0);
 }
 
+#[test]
+/// Ensures the combined tx-list gas limit multiplies normally and rejects u64 overflow.
+fn combined_tx_lists_gas_limit_rejects_u64_overflow() {
+    assert_eq!(super::combined_tx_lists_gas_limit(30_000_000, 4).unwrap(), 120_000_000);
+    assert!(super::combined_tx_lists_gas_limit(u64::MAX, 2).is_err());
+}
+
 // ---------------------------------------------------------------------------
 // Proposal ID decoding tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three correctness fixes surfaced by a crate-wide architecture review, each implemented test-first (failing test observed before the fix):

**1. `engine_exchangeCapabilities` was not served, and the capability config was dishonest (crates/rpc)**
The Taiko engine module routes only the methods on `TaikoEngineApi`, so `engine_exchangeCapabilities` returned method-not-found to the driver. Meanwhile the inner `EngineApi` was configured with `EngineCapabilities::default()` (reth's full ~23-method list) while the accurate `TAIKO_ENGINE_CAPABILITIES` constant sat dead. The method is now routed on the Taiko engine trait (delegating to the inner `EngineApi`, including CL/EL mismatch logging) and advertises exactly the three served methods: `engine_forkchoiceUpdatedV2`, `engine_getPayloadV2`, `engine_newPayloadV2`. Per the Engine API spec, `engine_exchangeCapabilities` itself is served but not listed.

**2. Unchecked `u64` multiply on `taikoAuth_txPoolContent*` params (crates/rpc)**
`block_max_gas_limit * max_transactions_lists` used caller-supplied values: silent wrap in release builds (nonsense combined gas limit), panic in debug builds. Now `checked_mul` with an invalid-params error, next to the existing `maxTransactionsLists != 0` guard.

**3. Corrupt `StoredL1Origin` row panicked the node (crates/db)**
`Decompress::decompress` fed raw DB bytes into fixed-size cursor reads that panic on short input. A truncated/corrupt row now returns a `DecompressError` (the layout is a fixed 202 bytes, guarded up front) instead of crashing the node.

## Testing

- New tests: `engine_capabilities_advertise_exactly_the_served_methods`, `combined_tx_lists_gas_limit_rejects_u64_overflow`, `test_decompress_truncated_row_returns_error` — each observed failing before its fix
- `just fmt` / `just clippy` (warnings-as-errors) clean; `cargo check -p alethia-reth-rpc --features client` passes
- Full workspace suite: 226/226 pass

## Notes for reviewers

- Not verified against a live driver: whether taiko-client calls `engine_exchangeCapabilities` today (adding the route is additive either way).
- `engine_getClientVersionV1` is likewise unrouted; the spec expects EL clients to support it. Left out of scope here — worth a follow-up decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)