### PR TITLE
fix(consensus): require the exact 7-byte Shasta extraData layout

### DIFF
--- a/crates/consensus/src/validation/mod.rs
+++ b/crates/consensus/src/validation/mod.rs
@@ -22,7 +22,7 @@ use crate::eip4396::{
     calculate_next_block_eip4396_base_fee,
 };
 use alethia_reth_chainspec::{TAIKO_MAINNET, hardfork::TaikoHardforks, spec::TaikoChainSpec};
-use alethia_reth_primitives::transaction::is_allowed_tx_type;
+use alethia_reth_primitives::{SHASTA_EXTRA_DATA_LEN, transaction::is_allowed_tx_type};
 
 /// Anchor transaction selectors, gas rules, and validation functions.
 mod anchor;
@@ -152,6 +152,20 @@ where
         }
 
         validate_header_extra_data(header, MAXIMUM_EXTRA_DATA_SIZE)?;
+
+        // Shasta extraData must be the 7-byte [pctg | proposalId(6)] layout — the only shape the
+        // drivers produce and the live chains carry. Reject anything else at import so a
+        // misbehaving block producer fails loudly here instead of minting headers whose embedded
+        // proposalId consumers cannot decode.
+        if self.chain_spec.is_shasta_active(header.timestamp()) &&
+            header.extra_data().len() != SHASTA_EXTRA_DATA_LEN
+        {
+            return Err(ConsensusError::Other(format!(
+                "invalid Shasta extra-data length: have {}, want {SHASTA_EXTRA_DATA_LEN}",
+                header.extra_data().len()
+            )));
+        }
+
         validate_header_gas(header)?;
         validate_header_base_fee(header, &self.chain_spec)
     }

--- a/crates/consensus/src/validation/tests.rs
+++ b/crates/consensus/src/validation/tests.rs
@@ -174,12 +174,63 @@ fn unzen_header_allows_nonzero_difficulty() {
         difficulty: U256::from(7_u64),
         base_fee_per_gas: Some(1),
         gas_limit: 30_000_000,
+        extra_data: shasta_extra_data(),
         ..Default::default()
     };
 
     consensus
         .validate_header(&SealedHeader::new_unhashed(header))
         .expect("Unzen headers should allow nonzero difficulty");
+}
+
+#[test]
+fn shasta_header_requires_exact_extra_data_len() {
+    let consensus = test_consensus(devnet_chain_spec());
+    let base = Header {
+        timestamp: 1,
+        base_fee_per_gas: Some(1),
+        gas_limit: 30_000_000,
+        ..Default::default()
+    };
+
+    consensus
+        .validate_header(&SealedHeader::new_unhashed(Header {
+            extra_data: shasta_extra_data(),
+            ..base.clone()
+        }))
+        .expect("the 7-byte extraData layout should validate");
+
+    for (name, extra) in [
+        ("empty", Bytes::new()),
+        ("2 bytes", Bytes::from_static(&[75, 0])),
+        ("3 bytes", Bytes::from_static(&[75, 0, 1])),
+        ("12 bytes", Bytes::from_static(&[0; 12])),
+    ] {
+        let err = consensus
+            .validate_header(&SealedHeader::new_unhashed(Header {
+                extra_data: extra,
+                ..base.clone()
+            }))
+            .expect_err(name);
+        assert!(matches!(err, ConsensusError::Other(_)), "{name}: unexpected error {err:?}");
+    }
+}
+
+#[test]
+fn pre_shasta_header_has_no_extra_data_len_rule() {
+    let mut chain_spec = devnet_chain_spec();
+    chain_spec.inner.hardforks.insert(TaikoHardfork::Shasta, ForkCondition::Never);
+    let consensus = test_consensus(chain_spec);
+    let header = Header {
+        timestamp: 1,
+        base_fee_per_gas: Some(1),
+        gas_limit: 30_000_000,
+        ..Default::default()
+    };
+
+    consensus
+        .validate_header(&SealedHeader::new_unhashed(header))
+        .expect("pre-Shasta headers have no extraData length rule");
 }
 
 #[test]
@@ -271,6 +322,10 @@ fn make_legacy_tx() -> TransactionSigned {
 
 fn test_consensus(chain_spec: TaikoChainSpec) -> TaikoBeaconConsensus {
     TaikoBeaconConsensus::new(Arc::new(chain_spec), Arc::new(NullBlockReader))
+}
+
+fn shasta_extra_data() -> Bytes {
+    Bytes::from_static(&[75, 0, 0, 0, 0, 0x4c, 0x81])
 }
 
 fn devnet_chain_spec() -> TaikoChainSpec {

--- a/crates/primitives/src/extra_data.rs
+++ b/crates/primitives/src/extra_data.rs
@@ -1,6 +1,7 @@
 //! Helpers for decoding Taiko-specific block `extraData` fields.
 
-/// Minimum number of bytes required for Shasta extra data.
+/// Exact length of the Shasta extra data layout: `[basefeeSharingPctg | proposalId(6)]`.
+/// Header validation rejects Shasta headers whose extra data has any other length.
 pub const SHASTA_EXTRA_DATA_LEN: usize = 7;
 
 /// Returns the base fee sharing percentage encoded in Shasta extra data.


### PR DESCRIPTION
## Summary

Shasta `extraData` is driver-authored, and the ecosystem has exactly one shape for it: the 7-byte `[basefeeSharingPctg | proposalId(6, big-endian)]` layout. Both drivers on taiko-mono `main` emit it (Go `EncodeShastaExtraData`, Rust `encode_extra_data`), the live chains carry it (mainnet block 8,382,598: `0x4b000000004c81`; hoodi block 13,518,608: `0x4b00000000c52d`), and this client's own consumers already require the 7-byte tail to read the embedded proposalId out of canonical headers (`decode_shasta_proposal_id` returns `None` for anything shorter, and the batch lookup walk turns that into an error).

Header validation didn't say that: `validate_header` enforced only the generic 32-byte cap, so a Shasta header with any 0–32-byte `extraData` would import. This PR pins the rule to the contract — a Shasta header whose `extraData` is not exactly 7 bytes now fails header validation.

The strictness matters on the preconfirmation path: a preconfirmation envelope's `extraData` reaches the EL verbatim (ingress validation only checks non-emptiness), so the header rule is the backstop that makes a malformed envelope fail loudly at import instead of minting a header whose proposalId downstream consumers cannot decode.

This mirrors taikoxyz/taiko-geth#591, which pins the same exact-length rule in geth's `verifyHeader` (replacing its previous `>= 7` floor), keeping Shasta header acceptance identical across both execution clients.

## Changes

- `crates/consensus/src/validation/mod.rs`: `TaikoBeaconConsensus::validate_header` rejects Shasta-active headers whose `extraData` length differs from `SHASTA_EXTRA_DATA_LEN` (7), right after the generic 32-byte cap check. Pre-Shasta headers are untouched.
- `crates/primitives/src/extra_data.rs`: document `SHASTA_EXTRA_DATA_LEN` as the exact layout length (was "minimum"). The tolerant decoders (`decode_shasta_basefee_sharing_pctg`, `decode_shasta_proposal_id`) are unchanged.

## Test plan

- [x] New: `shasta_header_requires_exact_extra_data_len` — the 7-byte layout validates; empty, 2-byte, 3-byte, and 12-byte extra are rejected (12 bytes was previously importable).
- [x] New: `pre_shasta_header_has_no_extra_data_len_rule` — fork gating leaves pre-Shasta headers untouched.
- [x] Updated: `unzen_header_allows_nonzero_difficulty` now carries the 7-byte layout (its header is Shasta-active).
- [x] `cargo nextest run -p alethia-reth-consensus` (20/20 pass), `cargo +nightly fmt`, clippy with the CI flags on the touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
