### PR TITLE
fix(reth): honor beacon root overrides and reject unsupported JIT

### DIFF
--- a/crates/block/src/config.rs
+++ b/crates/block/src/config.rs
@@ -263,7 +263,10 @@ impl ConfigureEvm for TaikoEvmConfig {
         let is_unzen_active = self.chain_spec().is_unzen_active(ctx.timestamp);
         Ok(TaikoBlockExecutionCtx {
             parent_hash: parent.hash(),
-            parent_beacon_block_root: normalize_parent_beacon_block_root(is_unzen_active, None),
+            parent_beacon_block_root: normalize_parent_beacon_block_root(
+                is_unzen_active,
+                ctx.parent_beacon_block_root,
+            ),
             ommers: &[],
             withdrawals: Some(Cow::Owned(Withdrawals::new(vec![]))),
             basefee_per_gas: ctx.base_fee_per_gas,
@@ -382,6 +385,8 @@ pub struct TaikoNextBlockEnvAttributes {
     pub extra_data: Bytes,
     /// The base fee per gas for the next block.
     pub base_fee_per_gas: u64,
+    /// Parent beacon block root used by the EIP-4788 system call.
+    pub parent_beacon_block_root: Option<B256>,
 }
 
 /// Map the latest active hardfork at the given header to a [`TaikoSpecId`].
@@ -424,12 +429,9 @@ where
 #[cfg(feature = "net")]
 impl BuildPendingEnv<Header> for TaikoNextBlockEnvAttributes {
     /// Builds a [`ConfigureEvm::NextBlockEnvCtx`] for pending block.
-    ///
-    /// Block overrides are ignored: the only override the upstream implementation consults is
-    /// the beacon root, and Taiko's next-block attributes carry no parent beacon block root.
     fn build_pending_env(
         parent: &SealedHeader<Header>,
-        _block_overrides: Option<&alloy_rpc_types_eth::BlockOverrides>,
+        block_overrides: Option<&alloy_rpc_types_eth::BlockOverrides>,
     ) -> Self {
         Self {
             timestamp: parent.timestamp.saturating_add(12),
@@ -438,6 +440,7 @@ impl BuildPendingEnv<Header> for TaikoNextBlockEnvAttributes {
             gas_limit: parent.gas_limit,
             extra_data: parent.extra_data.clone(),
             base_fee_per_gas: parent.base_fee_per_gas.unwrap_or_default(),
+            parent_beacon_block_root: block_overrides.and_then(|overrides| overrides.beacon_root),
         }
     }
 }
@@ -448,6 +451,15 @@ mod tests {
     use alethia_reth_chainspec::{TAIKO_DEVNET, hardfork::TaikoHardfork};
     use alloy_hardforks::ForkCondition;
     use std::sync::Arc;
+
+    fn config_with_unzen_at(timestamp: u64) -> TaikoEvmConfig {
+        let mut chain_spec = (*TAIKO_DEVNET).as_ref().clone();
+        chain_spec
+            .inner
+            .hardforks
+            .insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(timestamp));
+        TaikoEvmConfig::new(Arc::new(chain_spec))
+    }
 
     #[test]
     fn unzen_takes_precedence_over_shasta() {
@@ -506,6 +518,29 @@ mod tests {
     }
 
     #[cfg(feature = "net")]
+    #[test]
+    fn pending_env_preserves_beacon_root_override_for_unzen_context() {
+        let root = B256::repeat_byte(0x33);
+        let parent = SealedHeader::seal_slow(Header {
+            number: 1,
+            timestamp: 1,
+            gas_limit: 30_000_000,
+            base_fee_per_gas: Some(1),
+            ..Header::default()
+        });
+        let overrides =
+            alloy_rpc_types_eth::BlockOverrides { beacon_root: Some(root), ..Default::default() };
+        let attributes = TaikoNextBlockEnvAttributes::build_pending_env(&parent, Some(&overrides));
+        let config = config_with_unzen_at(0);
+
+        let ctx = config
+            .context_for_next_block(&parent, attributes)
+            .expect("pending Unzen context should build");
+
+        assert_eq!(ctx.parent_beacon_block_root, Some(root));
+    }
+
+    #[cfg(feature = "net")]
     mod payload_ctx {
         use super::*;
         use alethia_reth_primitives::engine::types::{
@@ -540,15 +575,6 @@ mod tests {
                     slot_number: None,
                 },
             }
-        }
-
-        fn config_with_unzen_at(timestamp: u64) -> TaikoEvmConfig {
-            let mut chain_spec = (*TAIKO_DEVNET).as_ref().clone();
-            chain_spec
-                .inner
-                .hardforks
-                .insert(TaikoHardfork::Unzen, ForkCondition::Timestamp(timestamp));
-            TaikoEvmConfig::new(Arc::new(chain_spec))
         }
 
         #[test]

--- a/crates/block/src/derived_block.rs
+++ b/crates/block/src/derived_block.rs
@@ -51,6 +51,7 @@ fn attributes_from_derived_block(
         gas_limit: header.gas_limit,
         extra_data: header.extra_data.clone(),
         base_fee_per_gas,
+        parent_beacon_block_root: header.parent_beacon_block_root,
     })
 }
 

--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -769,6 +769,7 @@ mod test {
                         gas_limit: 30_000_000,
                         extra_data: Bytes::new(),
                         base_fee_per_gas: 1,
+                        parent_beacon_block_root: None,
                     },
                 )
                 .expect("next block env should build");

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -35,6 +35,22 @@ use reth_storage_api::noop::NoopProvider;
 
 use crate::command::{TaikoNodeCommand, TaikoNodeExtArgs};
 
+/// Rejects command options that Alethia cannot honor.
+fn ensure_command_supported<C, Ext>(command: &Commands<C, Ext>) -> eyre::Result<()>
+where
+    C: ChainSpecParser,
+    Ext: clap::Args + fmt::Debug,
+{
+    if let Commands::ReExecute(command) = command &&
+        command.jit.enabled
+    {
+        eyre::bail!(
+            "JIT compilation was requested with --jit, but alethia-reth does not support revmc JIT execution"
+        );
+    }
+    Ok(())
+}
+
 /// Node-command wrappers and extension traits for Taiko runtime options.
 pub mod command;
 /// Chain-spec parser implementations for Taiko network names and genesis input.
@@ -200,6 +216,8 @@ impl<
         C: ChainSpecParser<ChainSpec = TaikoChainSpec>,
         <<N as NodeTypes>::Primitives as NodePrimitives>::BlockHeader: From<Header>,
     {
+        ensure_command_supported(&self.inner.command)?;
+
         // Add network name if available to the logs dir
         if let Some(chain_spec) = self.inner.command.chain_spec() {
             self.inner.logs.log_file_directory =
@@ -285,7 +303,8 @@ mod tests {
 
     use super::{
         DEFAULT_PROOF_HISTORY_MAX_STARTUP_PRUNE_BLOCKS,
-        DEFAULT_PROOF_HISTORY_VERIFICATION_INTERVAL, DEFAULT_PROOF_HISTORY_WINDOW, TaikoCliExtArgs,
+        DEFAULT_PROOF_HISTORY_VERIFICATION_INTERVAL, DEFAULT_PROOF_HISTORY_WINDOW,
+        TaikoChainSpecParser, TaikoCli, TaikoCliExtArgs, ensure_command_supported,
     };
     use crate::command::TaikoNodeExtArgs;
 
@@ -389,5 +408,19 @@ mod tests {
             .expect_err("legacy flag should be rejected");
 
         assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn test_re_execute_rejects_jit() {
+        let cli = TaikoCli::<TaikoChainSpecParser>::try_parse_args_from([
+            "alethia-reth",
+            "re-execute",
+            "--jit",
+        ])
+        .expect("re-execute JIT args should parse");
+        let err =
+            ensure_command_supported(&cli.inner.command).expect_err("JIT requests should fail");
+
+        assert!(err.to_string().contains("--jit"));
     }
 }

--- a/crates/payload/src/builder/mod.rs
+++ b/crates/payload/src/builder/mod.rs
@@ -231,6 +231,7 @@ where
                 gas_limit: attributes.gas_limit,
                 extra_data: attributes.extra_data.clone(),
                 base_fee_per_gas: attributes.base_fee_per_gas,
+                parent_beacon_block_root: attributes.parent_beacon_block_root,
             },
         )
         .map_err(PayloadBuilderError::other)?;

--- a/crates/rpc/src/eth/auth/mod.rs
+++ b/crates/rpc/src/eth/auth/mod.rs
@@ -346,6 +346,7 @@ where
                     gas_limit: combined_gas_limit,
                     extra_data: parent.extra_data().clone(),
                     base_fee_per_gas: base_fee,
+                    parent_beacon_block_root: None,
                 },
             )
             .map_err(|_| {


### PR DESCRIPTION
## Why

After the reth v2.4 upgrade, Unzen `eth_simulateV1` requests could ignore `blockOverrides.beaconRoot`, causing the EIP-4788 system call to use the zero root instead of the caller-provided value. The `re-execute --jit` path also accepted an unsupported option while continuing with the interpreter.

Related: #225

## How

- Carry the requested parent beacon block root through the next-block attributes into the Unzen execution context, while preserving the existing zero-root fallback when no override is supplied.
- Reject `re-execute --jit` before tracing initialization and command dispatch.
- Cover both regressions with focused tests.

## Tests

- `just fmt`
- `just clippy`
- `just test` — 264 passed, 0 skipped
- `cargo +1.95.0 run --locked -p alethia-reth-bin -- re-execute --jit` — exits with the unsupported-JIT error
