### PR TITLE
fix(docker): bound and retry the apt.llvm.org installer fetch

### DIFF
--- a/.github/scripts/install_llvm_ubuntu.sh
+++ b/.github/scripts/install_llvm_ubuntu.sh
@@ -9,6 +9,11 @@ set -eo pipefail
 version=${1:-22}
 bins=(clang llvm-config lld ld.lld FileCheck)
 
+# apt does not retry failed downloads by default, so a single blip reaching deb.debian.org or
+# apt.llvm.org aborts the image build. This also covers the apt calls inside the upstream
+# installer invoked below, which this script cannot pass options to.
+printf 'Acquire::Retries "3";\n' > /etc/apt/apt.conf.d/80-alethia-retries
+
 # The official installer needs this package on Debian bookworm but not on newer distributions.
 apt-get update -qq
 apt-get install -y --no-install-recommends \
@@ -16,7 +21,22 @@ apt-get install -y --no-install-recommends \
 apt-get install -y --no-install-recommends software-properties-common 2>/dev/null || true
 
 llvm_installer=$(mktemp)
-wget -qO "$llvm_installer" https://apt.llvm.org/llvm.sh
+# Bound and retry this fetch ourselves. wget's default --timeout is 900s, so one stalled
+# connection to apt.llvm.org used to wedge the build for a silent 15 minutes and then abort with
+# a bare "exit code: 4". --timeout caps DNS, connect and read alike; the outer loop retries
+# regardless of which of them wget reports, and -nv restores the error text that -q swallowed.
+attempts=4
+for attempt in $(seq "$attempts"); do
+    if wget -nv --timeout=20 --tries=1 -O "$llvm_installer" https://apt.llvm.org/llvm.sh; then
+        break
+    fi
+    if [[ "$attempt" -eq "$attempts" ]]; then
+        echo "Error: could not download https://apt.llvm.org/llvm.sh ($attempts attempts)" >&2
+        exit 1
+    fi
+    echo "Retrying https://apt.llvm.org/llvm.sh in $((attempt * 5))s" >&2
+    sleep $((attempt * 5))
+done
 # Pin the upstream installer so CI and Docker builds fail loudly when it changes; review the new
 # script before updating this hash.
 echo "9474ecd78b52aba6e923976b1e9773f5613027cc7e237b9956986cb536e02a36  $llvm_installer" | sha256sum -c -


### PR DESCRIPTION
Fixes the `build (linux/arm64, arc-runner-set-arm64)` failure on `main` introduced by #227:
[run 30443344056](https://github.com/taikoxyz/alethia-reth/actions/runs/30443344056/job/90758571285).

## Root cause

The arm64 job stalled for **exactly 900.079s** and then died with a bare `exit code: 4` and no
output. Isolating the failure to a single line:

| | last log line | next log line | gap |
|---|---|---|---|
| amd64 ✅ | `#12 6.026 Reading state information...` | `#12 6.026 /tmp/tmp.DvnCMrJSsX: OK` | 0.12s |
| arm64 ❌ | `#12 6.974 Reading state information...` | `ERROR ... exit code: 4` | **900.079s** |

The only command in that window is [`install_llvm_ubuntu.sh:19`](https://github.com/taikoxyz/alethia-reth/blob/862ef51/.github/scripts/install_llvm_ubuntu.sh#L19):

```bash
wget -qO "$llvm_installer" https://apt.llvm.org/llvm.sh
```

It ran with wget's defaults. `--timeout` defaults to **900s**, so one stalled connection to
apt.llvm.org wedges the build for 15 minutes; exit code 4 is wget's documented "Network
failure"; and `-q` suppresses the error text, so the failure surfaces with nothing to diagnose.
Notably the upstream llvm.sh installer guards its own fetches (`--timeout=15 --tries=3`) — this
wrapper was the one unguarded network call in the chain.

**This is not a package-availability problem.** `apt.llvm.org/trixie/dists/llvm-toolchain-trixie-22/main/binary-arm64/Packages.gz`
serves fine (HTTP 200), and the `llvm install (linux/arm64)` guard job passed on #227 with a real
install (`LLVM 22 installed: 22.1.8`). amd64 succeeded on the same commit. The trigger was a
transient network stall on the self-hosted arm64 pool; the defect is that our code turned it into
a 15-minute silent hard failure.

## Fix

- Cap each attempt at `--timeout=20` (bounds DNS, connect and read alike) and retry 4× with
  backoff in the shell. The outer loop is what rides out a blip — it retries uniformly regardless
  of which failure mode wget reports.
- `-nv` instead of `-q`, so the next failure is diagnosable rather than a bare exit code.
- `Acquire::Retries "3"` so the apt calls **inside** the upstream installer — which this script
  cannot pass options to — survive the same class of blip. Defense-in-depth for the same root
  cause at the adjacent layer, not an unrelated change.

## Verification

All on native arm64 (`debian:trixie`), with apt.llvm.org blackholed to a dropped route to
reproduce the stall:

| scenario | before | after |
|---|---|---|
| happy path | ok | **exit 0, 11s**, checksum `OK` |
| stalled connection | **exit 4, zero output** (reproduces CI signature) | **exit 1, 110s**, retries logged, error names the URL |
| full installer, `docker run ... debian:trixie /scripts/install_llvm_ubuntu.sh` (same command as the `llvm-arm64` CI guard) | — | **exit 0**, `LLVM 22 installed: 22.1.8` |

`shellcheck` clean. No Rust changed, so no new tests — per the request.

## Note

The Docker build only runs on push to `main`, so this class of breakage cannot be caught before
merge. That gap is tracked separately and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)