### PR TITLE
fix(evm): derive anchor context for replay-style RPC execution

### DIFF
--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -24,7 +24,7 @@ use revm_database_interface::{Database, DatabaseCommit};
 use crate::factory::TaikoBlockExecutionCtx;
 use alethia_reth_chainspec::spec::TaikoExecutorSpec;
 use alethia_reth_evm::{
-    alloy::{TAIKO_GOLDEN_TOUCH_ADDRESS, TaikoZkGasEvm},
+    alloy::{TAIKO_GOLDEN_TOUCH_ADDRESS, TaikoAnchorEvm, TaikoZkGasEvm},
     handler::get_treasury_address,
     zk_gas::{adapter::ZK_GAS_LIMIT_ERR, meter::ZkGasOutcome},
 };
@@ -138,7 +138,19 @@ where
     R: ReceiptBuilder,
 {
     /// Creates a new [`TaikoBlockExecutor`]
-    pub fn new(evm: Evm, ctx: TaikoBlockExecutionCtx<'a>, spec: Spec, receipt_builder: R) -> Self {
+    pub fn new(
+        mut evm: Evm,
+        ctx: TaikoBlockExecutionCtx<'a>,
+        spec: Spec,
+        receipt_builder: R,
+    ) -> Self
+    where
+        Evm: TaikoAnchorEvm,
+    {
+        // The executor installs the authoritative anchor context through the anchor system
+        // call in `apply_pre_execution_changes`; replay-only derivation must stay off so a
+        // missing initialization keeps failing loudly.
+        evm.set_anchor_ctx_derivation_enabled(false);
         Self {
             evm,
             ctx,

--- a/crates/evm/src/alloy.rs
+++ b/crates/evm/src/alloy.rs
@@ -158,6 +158,15 @@ impl<DB: Database, I, P> TaikoEvmWrapper<DB, I, P> {
     /// the EVM's lifetime, mirroring the per-block snapshot the system call takes: a crafted
     /// golden-touch transaction later in the block does not match the snapshot nonce and keeps
     /// consensus semantics (normal balance check).
+    ///
+    /// That protection is per EVM instance. Tracing helpers that create a fresh EVM per
+    /// transaction (`debug_traceBlock*`, and the target EVM of `debug_traceTransaction`)
+    /// re-derive from the already-advanced database nonce, so a deliberately crafted
+    /// golden-touch -> treasury transaction placed after the anchor is still wrongly exempted
+    /// in those traces while consensus charges it fees. Real anchors are unaffected in every
+    /// topology because the anchor system-call marker commits no state. Closing that gap needs
+    /// the block-start nonce carried through the EVM environment; see
+    /// `fresh_replay_evm_still_exempts_crafted_golden_touch_tx_after_anchor`.
     fn maybe_derive_anchor_execution_ctx(&mut self, tx: &TxEnv) -> Result<(), EVMError<DB::Error>> {
         if !self.derive_anchor_ctx || self.base_evm().extra_execution_ctx.is_some() {
             return Ok(());
@@ -809,6 +818,47 @@ mod tests {
         assert!(
             result.state.get(&treasury).is_none_or(|account| account.info.balance.is_zero()),
             "derived context must not route basefee income to the treasury"
+        );
+    }
+
+    #[test]
+    fn fresh_replay_evm_still_exempts_crafted_golden_touch_tx_after_anchor() {
+        // KNOWN LIMITATION, deliberately pinned: reth's tracing helpers create a fresh EVM per
+        // transaction (`debug_traceBlock*`) or for the traced target (`debug_traceTransaction`),
+        // sharing only the database between instances. A fresh EVM created after the real
+        // anchor committed sees the advanced golden-touch nonce and re-derives the anchor
+        // context from it, so a deliberately crafted golden-touch -> treasury transaction
+        // placed later in the block is wrongly exempted here, while consensus executes it as a
+        // fee-paying normal transaction. Real anchors are unaffected in every topology: the
+        // anchor system-call marker commits no state, so a block-start EVM always sees the
+        // pre-anchor nonce.
+        //
+        // Closing this requires the block-start golden-touch nonce (block-position metadata)
+        // to be carried through the EVM environment. When that lands, this test must flip to
+        // assert that the balance check applies to the crafted transaction again.
+        let chain_id = 167_000;
+        let golden_touch = Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS);
+        let treasury = get_treasury_address(chain_id);
+
+        // EVM #1 replays the real anchor (nonce 7) and commits it, advancing the golden-touch
+        // nonce to 8 in the shared database.
+        let mut evm =
+            TaikoEvmFactory::default().create_evm(replay_db(7, treasury), replay_env(chain_id));
+        evm.transact_commit(anchor_tx(treasury, 7)).expect("anchor must execute during replay");
+        let (db, env) = evm.finish();
+
+        // EVM #2 mirrors tracing a later crafted golden-touch -> treasury transaction: a fresh
+        // instance over the same database. The snapshot protection covered by
+        // `derived_anchor_context_only_exempts_the_snapshot_nonce` does not carry over.
+        let mut fresh_evm = TaikoEvmFactory::default().create_evm(db, env);
+        let result = fresh_evm
+            .transact(anchor_tx(treasury, 8))
+            .expect("fresh EVM wrongly exempts the crafted tx (see known limitation above)");
+        assert!(result.result.is_success(), "crafted tx executes: {:?}", result.result);
+        assert_eq!(
+            result.state.get(&golden_touch).expect("golden touch state").info.balance,
+            U256::from(GOLDEN_TOUCH_DUST_BALANCE),
+            "fresh EVM grants the fee exemption; consensus would charge gas fees here"
         );
     }
 

--- a/crates/evm/src/alloy.rs
+++ b/crates/evm/src/alloy.rs
@@ -21,7 +21,7 @@ use reth_revm::{
 use tracing::debug;
 
 use crate::{
-    evm::TaikoEvm,
+    evm::{TaikoEvm, TaikoEvmExtraExecutionCtx},
     handler::{TaikoEvmHandler, get_treasury_address},
     spec::TaikoSpecId,
     zk_gas::{
@@ -55,6 +55,11 @@ pub struct TaikoEvmWrapper<DB: Database, I, P> {
     inner: InnerTaikoEvm<DB, I, P>,
     /// Whether to run transactions through the inspector execution path.
     inspect: bool,
+    /// Whether [`Self::maybe_derive_anchor_execution_ctx`] may install a derived anchor
+    /// context for replay-style execution. Enabled by default; the block executor turns it off
+    /// because it installs the authoritative context through the anchor system call, and a
+    /// missing pre-execution initialization must keep failing loudly there.
+    derive_anchor_ctx: bool,
 }
 
 impl<DB: Database, I, P> TaikoEvmWrapper<DB, I, P> {
@@ -64,18 +69,18 @@ impl<DB: Database, I, P> TaikoEvmWrapper<DB, I, P> {
     where
         P: PrecompileProvider<TaikoEvmContext<DB>, Output = InterpreterResult>,
     {
-        Self { inner: revmc::revm_evm::JitEvm::disabled(evm), inspect }
+        Self { inner: revmc::revm_evm::JitEvm::disabled(evm), inspect, derive_anchor_ctx: true }
     }
 
     /// Creates an interpreter-backed [`TaikoEvmWrapper`] instance.
     #[cfg(not(feature = "jit"))]
     pub const fn new(evm: BaseTaikoEvm<DB, I, P>, inspect: bool) -> Self {
-        Self { inner: evm, inspect }
+        Self { inner: evm, inspect, derive_anchor_ctx: true }
     }
 
     /// Creates a wrapper around an already configured optional JIT dispatcher.
     pub(crate) fn new_with_inner(evm: InnerTaikoEvm<DB, I, P>, inspect: bool) -> Self {
-        Self { inner: evm, inspect }
+        Self { inner: evm, inspect, derive_anchor_ctx: true }
     }
 
     /// Consumes self and return the inner EVM instance.
@@ -137,6 +142,60 @@ impl<DB: Database, I, P> TaikoEvmWrapper<DB, I, P> {
         } else {
             self.base_evm_mut().inner.inspector.meter_mut()
         }
+    }
+
+    /// Derives and installs the anchor execution context from database state when no
+    /// authoritative context is present and the incoming transaction is anchor-shaped
+    /// (golden touch calling the network treasury).
+    ///
+    /// Block execution installs the context through the anchor system call before any
+    /// transaction runs, so this only fires on replay-style paths (`debug_trace*`, `trace_*`
+    /// and the `eth_call` family) that execute block transactions without the block executor.
+    /// Without a context those paths fail the anchor's balance check, which is what made every
+    /// trace of a real block error with `insufficient funds`.
+    ///
+    /// The golden-touch nonce is snapshotted on first derivation and the context is kept for
+    /// the EVM's lifetime, mirroring the per-block snapshot the system call takes: a crafted
+    /// golden-touch transaction later in the block does not match the snapshot nonce and keeps
+    /// consensus semantics (normal balance check).
+    fn maybe_derive_anchor_execution_ctx(&mut self, tx: &TxEnv) -> Result<(), EVMError<DB::Error>> {
+        if !self.derive_anchor_ctx || self.base_evm().extra_execution_ctx.is_some() {
+            return Ok(());
+        }
+        let golden_touch = Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS);
+        if tx.caller != golden_touch ||
+            tx.kind != TxKind::Call(get_treasury_address(self.ctx().cfg.chain_id))
+        {
+            return Ok(());
+        }
+        let nonce = self
+            .ctx_mut()
+            .journaled_state
+            .database
+            .basic(golden_touch)
+            .map_err(EVMError::Database)?
+            .map_or(0, |account| account.nonce);
+        self.base_evm_mut().extra_execution_ctx =
+            Some(TaikoEvmExtraExecutionCtx::derived(golden_touch, nonce));
+        Ok(())
+    }
+}
+
+/// EVM extension trait controlling the replay-only anchor context derivation.
+pub trait TaikoAnchorEvm {
+    /// Enables or disables on-the-fly anchor context derivation for replay-style execution.
+    ///
+    /// The block executor disables it before executing a block: it installs the authoritative
+    /// context through the anchor system call, and executing an anchor without that
+    /// initialization must keep failing loudly rather than silently falling back to derived
+    /// replay semantics.
+    fn set_anchor_ctx_derivation_enabled(&mut self, enabled: bool);
+}
+
+impl<DB: Database, I, P> TaikoAnchorEvm for TaikoEvmWrapper<DB, I, P> {
+    /// Enables or disables on-the-fly anchor context derivation for replay-style execution.
+    fn set_anchor_ctx_derivation_enabled(&mut self, enabled: bool) {
+        self.derive_anchor_ctx = enabled;
     }
 }
 
@@ -295,6 +354,7 @@ where
         &mut self,
         tx: Self::Tx,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        self.maybe_derive_anchor_execution_ctx(&tx)?;
         self.ctx_mut().set_tx(tx);
         // Run [`TaikoEvmHandler`] against the (possibly JIT-dispatching) inner EVM directly:
         // revmc's own `ExecuteEvm`/`InspectEvm` entry points would run revm's `MainnetHandler`
@@ -518,7 +578,11 @@ pub fn decode_anchor_system_call_data(bytes: &Bytes) -> Option<(u64, u64)> {
 mod tests {
     use alloy_evm::{Evm, EvmEnv, EvmFactory};
     use alloy_primitives::U256;
-    use reth_revm::{context::ContextTr, db::InMemoryDB, state::AccountInfo};
+    use reth_revm::{
+        context::{ContextTr, result::InvalidTransaction},
+        db::InMemoryDB,
+        state::AccountInfo,
+    };
 
     use super::*;
     use crate::{factory::TaikoEvmFactory, spec::TaikoSpecId};
@@ -610,6 +674,172 @@ mod tests {
         assert!(
             evm.ctx().journal().state.is_empty(),
             "an errored transaction must finalize the journal before the next transaction runs"
+        );
+    }
+
+    /// Golden-touch dust balance observed on mainnet: non-zero, but far below the anchor's
+    /// upfront cost of `gas_limit * gas_price` (`1_000_000 * 10_000_000 = 1e13` wei).
+    const GOLDEN_TOUCH_DUST_BALANCE: u64 = 316_794_861_226;
+
+    /// Basefee used by the replay tests, matching the anchor's gas price (wei).
+    const REPLAY_BASEFEE: u64 = 10_000_000;
+
+    /// Builds an [`EvmEnv`] the way RPC replay paths do: block context only, no anchor
+    /// system call ever happens on the resulting EVM.
+    fn replay_env(chain_id: u64) -> EvmEnv<TaikoSpecId> {
+        let mut env: EvmEnv<TaikoSpecId> = EvmEnv::default();
+        env.cfg_env.chain_id = chain_id;
+        env.block_env.basefee = REPLAY_BASEFEE;
+        env.block_env.gas_limit = 30_000_000;
+        env
+    }
+
+    /// Builds an anchor-shaped transaction: golden touch calling the treasury at the given
+    /// nonce, paying exactly the basefee.
+    fn anchor_tx(treasury: Address, nonce: u64) -> TxEnv {
+        TxEnv::builder()
+            .caller(Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS))
+            .kind(TxKind::Call(treasury))
+            .nonce(nonce)
+            .gas_limit(1_000_000)
+            .gas_price(u128::from(REPLAY_BASEFEE))
+            .chain_id(None)
+            .build()
+            .expect("valid anchor tx env")
+    }
+
+    /// Builds a plain funded-user transfer paying exactly the basefee.
+    fn user_tx(caller: Address, nonce: u64) -> TxEnv {
+        TxEnv::builder()
+            .caller(caller)
+            .kind(TxKind::Call(Address::with_last_byte(0xB0)))
+            .nonce(nonce)
+            .gas_limit(21_000)
+            .gas_price(u128::from(REPLAY_BASEFEE))
+            .chain_id(None)
+            .build()
+            .expect("valid user tx env")
+    }
+
+    /// Seeds a database with the golden-touch account at the given nonce plus an empty
+    /// treasury account, mirroring on-chain pre-block state.
+    fn replay_db(golden_touch_nonce: u64, treasury: Address) -> InMemoryDB {
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS),
+            AccountInfo {
+                nonce: golden_touch_nonce,
+                balance: U256::from(GOLDEN_TOUCH_DUST_BALANCE),
+                ..Default::default()
+            },
+        );
+        db.insert_account_info(treasury, AccountInfo::default());
+        db
+    }
+
+    #[test]
+    fn replayed_anchor_transaction_executes_without_prior_system_call() {
+        // RPC trace/replay paths (`debug_trace*`, `trace_*`) create the EVM straight from the
+        // factory and never issue the anchor system call, so the anchor exemption must be
+        // derivable from the transaction itself plus database state.
+        let chain_id = 167_000;
+        let golden_touch = Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS);
+        let treasury = get_treasury_address(chain_id);
+
+        let mut evm =
+            TaikoEvmFactory::default().create_evm(replay_db(7, treasury), replay_env(chain_id));
+
+        let result = evm
+            .transact(anchor_tx(treasury, 7))
+            .expect("anchor must execute during replay without a prior anchor system call");
+        assert!(result.result.is_success(), "anchor replay must succeed: {:?}", result.result);
+
+        let golden_touch_state =
+            result.state.get(&golden_touch).expect("golden touch must appear in the state");
+        assert_eq!(
+            golden_touch_state.info.balance,
+            U256::from(GOLDEN_TOUCH_DUST_BALANCE),
+            "anchor must not pay fees during replay"
+        );
+        assert_eq!(golden_touch_state.info.nonce, 8, "anchor must bump the golden touch nonce");
+    }
+
+    #[test]
+    fn derived_anchor_context_only_exempts_the_snapshot_nonce() {
+        // The derived context snapshots the golden-touch nonce before the anchor runs. A
+        // crafted golden-touch -> treasury transaction later in the same block is a normal
+        // transaction under consensus, so the replay must apply the balance check to it.
+        let chain_id = 167_000;
+        let treasury = get_treasury_address(chain_id);
+
+        let mut evm =
+            TaikoEvmFactory::default().create_evm(replay_db(7, treasury), replay_env(chain_id));
+
+        evm.transact_commit(anchor_tx(treasury, 7)).expect("anchor must execute during replay");
+
+        let err = evm
+            .transact(anchor_tx(treasury, 8))
+            .expect_err("a follow-up golden-touch tx must not inherit the anchor exemption");
+        assert!(
+            matches!(err, EVMError::Transaction(InvalidTransaction::LackOfFundForMaxFee { .. })),
+            "expected a balance-check failure, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn derived_anchor_context_does_not_apply_base_fee_sharing() {
+        // The basefee-share percentage comes from block extra data, which only the
+        // authoritative anchor system call knows. A derived replay context must keep the
+        // pre-existing replay behavior of not redistributing basefee income.
+        let chain_id = 167_000;
+        let treasury = get_treasury_address(chain_id);
+        let alice = Address::with_last_byte(0xA1);
+
+        let mut db = replay_db(7, treasury);
+        db.insert_account_info(
+            alice,
+            AccountInfo { balance: U256::from(10).pow(U256::from(18)), ..Default::default() },
+        );
+        let mut evm = TaikoEvmFactory::default().create_evm(db, replay_env(chain_id));
+
+        evm.transact_commit(anchor_tx(treasury, 7)).expect("anchor must execute during replay");
+
+        let result = evm.transact(user_tx(alice, 0)).expect("funded user tx must execute");
+        assert!(result.result.is_success(), "user tx must succeed: {:?}", result.result);
+        assert!(
+            result.state.get(&treasury).is_none_or(|account| account.info.balance.is_zero()),
+            "derived context must not route basefee income to the treasury"
+        );
+    }
+
+    #[test]
+    fn system_call_context_shares_base_fee_for_regular_transactions() {
+        // The authoritative context installed by the anchor system call must keep sharing
+        // basefee income between coinbase and treasury for non-anchor transactions.
+        let chain_id = 167_000;
+        let golden_touch = Address::from(TAIKO_GOLDEN_TOUCH_ADDRESS);
+        let treasury = get_treasury_address(chain_id);
+        let alice = Address::with_last_byte(0xA1);
+
+        let mut db = replay_db(7, treasury);
+        db.insert_account_info(
+            alice,
+            AccountInfo { balance: U256::from(10).pow(U256::from(18)), ..Default::default() },
+        );
+        let mut evm = TaikoEvmFactory::default().create_evm(db, replay_env(chain_id));
+
+        evm.transact_system_call(golden_touch, treasury, encode_anchor_system_call_data(25, 7))
+            .expect("anchor system call must succeed");
+
+        let result = evm.transact(user_tx(alice, 0)).expect("funded user tx must execute");
+        assert!(result.result.is_success(), "user tx must succeed: {:?}", result.result);
+
+        let base_fee_income = U256::from(21_000u64) * U256::from(REPLAY_BASEFEE);
+        let coinbase_share = base_fee_income * U256::from(25u64) / U256::from(100u64);
+        assert_eq!(
+            result.state.get(&treasury).expect("treasury must be rewarded").info.balance,
+            base_fee_income - coinbase_share,
+            "treasury must receive the non-coinbase share of the basefee income"
         );
     }
 }

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -67,11 +67,11 @@ impl<CTX: ContextTr, INSP, P> TaikoEvm<CTX, INSP, P> {
         anchor_caller_address: Address,
         anchor_caller_nonce: u64,
     ) {
-        self.extra_execution_ctx = Some(TaikoEvmExtraExecutionCtx {
+        self.extra_execution_ctx = Some(TaikoEvmExtraExecutionCtx::new(
             base_fee_share_pctg,
             anchor_caller_address,
             anchor_caller_nonce,
-        });
+        ));
     }
 }
 
@@ -241,16 +241,42 @@ pub struct TaikoEvmExtraExecutionCtx {
     anchor_caller_address: Address,
     /// Anchor caller nonce used to detect anchor transactions.
     anchor_caller_nonce: u64,
+    /// Whether this context was installed by the authoritative anchor system call issued by the
+    /// block executor. A `false` value marks a context derived on the fly for replay-style
+    /// execution (RPC tracing), where the basefee-share percentage from block extra data is
+    /// unknown and basefee sharing must therefore stay disabled.
+    from_anchor_system_call: bool,
 }
 
 impl TaikoEvmExtraExecutionCtx {
-    /// Creates a new instance of [`TaikoEvmExecutionExtraCtx`].
+    /// Creates the authoritative context installed by the anchor system call.
     pub fn new(
         base_fee_share_pctg: u64,
         anchor_caller_address: Address,
         anchor_caller_nonce: u64,
     ) -> Self {
-        Self { base_fee_share_pctg, anchor_caller_address, anchor_caller_nonce }
+        Self {
+            base_fee_share_pctg,
+            anchor_caller_address,
+            anchor_caller_nonce,
+            from_anchor_system_call: true,
+        }
+    }
+
+    /// Creates a context derived from database state for replay-style execution paths that
+    /// never issue the anchor system call (RPC tracing and transaction replay).
+    ///
+    /// The derived context carries the anchor caller identity needed for the anchor
+    /// exemptions, but no basefee-share percentage: that value comes from block extra data,
+    /// which replay paths do not have. [`Self::is_from_anchor_system_call`] returns `false` so
+    /// fee-sharing logic can tell the two apart.
+    pub fn derived(anchor_caller_address: Address, anchor_caller_nonce: u64) -> Self {
+        Self {
+            base_fee_share_pctg: 0,
+            anchor_caller_address,
+            anchor_caller_nonce,
+            from_anchor_system_call: false,
+        }
     }
 
     /// Returns the base fee share percentage.
@@ -269,6 +295,13 @@ impl TaikoEvmExtraExecutionCtx {
     #[inline]
     pub fn anchor_caller_nonce(&self) -> u64 {
         self.anchor_caller_nonce
+    }
+
+    /// Returns whether this context was installed by the authoritative anchor system call
+    /// (as opposed to being derived from database state for replay-style execution).
+    #[inline]
+    pub fn is_from_anchor_system_call(&self) -> bool {
+        self.from_anchor_system_call
     }
 }
 

--- a/crates/evm/src/handler.rs
+++ b/crates/evm/src/handler.rs
@@ -163,30 +163,36 @@ fn reward_beneficiary<CTX: ContextTr>(
         );
 
         // If the transaction is not an anchor transaction, we share the base fee income with the
-        // coinbase and treasury.
+        // coinbase and treasury. Sharing requires the authoritative context installed by the
+        // anchor system call: a context derived for replay-style execution carries no
+        // basefee-share percentage (it comes from block extra data), so redistribution stays
+        // disabled there, matching pre-existing replay behavior.
         if ctx.anchor_caller_address() != tx_caller ||
             ctx.anchor_caller_nonce() != tx_nonce ||
             context.tx().kind().to() != Some(&get_treasury_address(context.cfg().chain_id()))
         {
-            // Total base fee income; guard against underflow if refunded exceeds spent.
-            let spent_minus_refund = gas.total_gas_spent().saturating_sub(gas.refunded() as u64);
-            let total_fee = U256::from(basefee.saturating_mul(spent_minus_refund as u128));
+            if ctx.is_from_anchor_system_call() {
+                // Total base fee income; guard against underflow if refunded exceeds spent.
+                let spent_minus_refund =
+                    gas.total_gas_spent().saturating_sub(gas.refunded() as u64);
+                let total_fee = U256::from(basefee.saturating_mul(spent_minus_refund as u128));
 
-            // Share the base fee income with the coinbase and treasury.
-            let fee_coinbase = total_fee.saturating_mul(U256::from(ctx.base_fee_share_pctg())) /
-                U256::from(100u64);
-            let fee_treasury = total_fee.saturating_sub(fee_coinbase);
+                // Share the base fee income with the coinbase and treasury.
+                let fee_coinbase = total_fee.saturating_mul(U256::from(ctx.base_fee_share_pctg())) /
+                    U256::from(100u64);
+                let fee_treasury = total_fee.saturating_sub(fee_coinbase);
 
-            context.journal_mut().balance_incr(beneficiary, fee_coinbase)?;
+                context.journal_mut().balance_incr(beneficiary, fee_coinbase)?;
 
-            let chain_id = context.cfg().chain_id();
-            context.journal_mut().balance_incr(get_treasury_address(chain_id), fee_treasury)?;
+                let chain_id = context.cfg().chain_id();
+                context.journal_mut().balance_incr(get_treasury_address(chain_id), fee_treasury)?;
 
-            debug!(
-                target: "taiko_evm",
-                "Share basefee with coinbase: {} and treasury: {}, share percentage: {} at block: {:?}",
-                fee_coinbase, fee_treasury, ctx.base_fee_share_pctg(), block_number
-            );
+                debug!(
+                    target: "taiko_evm",
+                    "Share basefee with coinbase: {} and treasury: {}, share percentage: {} at block: {:?}",
+                    fee_coinbase, fee_treasury, ctx.base_fee_share_pctg(), block_number
+                );
+            }
         } else {
             // If the transaction is an anchor transaction, we do not share the base fee income.
             debug!(


### PR DESCRIPTION
## Problem

Every `debug_traceTransaction` / `debug_traceBlockByNumber` / `trace_*` call against a real block fails with:

```
{"code":-32003,"message":"insufficient funds for gas * price + value: have 316794861226 want 10000000000000"}
```

`want 10000000000000` is the anchor transaction's upfront cost (`gas_limit 1_000_000 × gas_price 0.01 gwei`), and `have …` is the golden-touch dust balance — the failure is the **anchor transaction** (tx[0] of every Taiko block), not the transaction being traced. This is why "debug trace is not available on the reth node" keeps being reported: the `debug`/`trace` namespaces are registered fine, but every call that replays a block errors at the anchor.

### Root cause

The anchor's balance-check exemption depends on `TaikoEvmExtraExecutionCtx`, which is only installed by the anchor system call in the block executor's `apply_pre_execution_changes`. reth's RPC replay helpers (`Trace::apply_pre_execution_changes`, `Call::replay_transactions_until`) run pre-execution on a throwaway executor and then replay transactions on a **fresh** `evm_with_env` EVM — the context never reaches the EVM that executes the transactions, so the anchor is treated as a normal transaction and fails the balance check.

## Fix

- `TaikoEvmWrapper::transact_raw` now derives the anchor context on the fly when none is installed and the incoming transaction is anchor-shaped (golden touch calling the network treasury). The golden-touch nonce is snapshotted from database state on first derivation and kept for the EVM's lifetime, mirroring the per-block snapshot the anchor system call takes.
- The derived context powers only the anchor exemptions (skip balance check, no reimbursement, no reward). Basefee sharing stays gated on the authoritative system-call context (`TaikoEvmExtraExecutionCtx::is_from_anchor_system_call`), because the share percentage comes from block extra data, which replay paths do not have. Replay fee-routing behavior is unchanged from before this PR.
- The block executor explicitly disables derivation (`TaikoAnchorEvm::set_anchor_ctx_derivation_enabled(false)`): it installs the authoritative context via the anchor system call, and executing an anchor without that initialization must keep failing loudly (guarded by the existing `test_apply_pre_execution_changes_initializes_anchor_context_from_account_nonce`).

Consensus paths are untouched: block execution/validation still runs the authoritative system-call context, and the executor-path guard test still passes.

### Known limitations

Both limitations are RPC-trace-fidelity only (no consensus impact) and share one root cause: the EVM environment carries no per-block metadata (block position / extra data). Closing them is the same follow-up refactor — carrying the block-start golden-touch nonce and the basefee-share percentage through the EVM environment.

1. **Fee routing in replays (pre-existing).** Replayed non-anchor transactions do not redistribute basefee income to coinbase/treasury (the share percentage lives in block extra data, which `EvmEnv` does not carry). Traced call trees, gas, logs and return data are exact; only coinbase/treasury balance deltas diverge, same as before this PR.
2. **Crafted golden-touch transactions in fresh-EVM topologies (review finding).** The snapshot protection is per EVM instance. Tracing helpers that create a fresh EVM per transaction (`debug_traceBlock*`, and the target EVM of `debug_traceTransaction`) re-derive from the already-advanced database nonce, so a deliberately crafted golden-touch → treasury transaction placed after the anchor (the golden-touch key is public) is wrongly shown as fee-exempt in those traces, while consensus charged it fees. Real anchors are unaffected in every topology because the anchor system-call marker commits no state. The boundary is pinned by `fresh_replay_evm_still_exempts_crafted_golden_touch_tx_after_anchor`, which must be flipped when the follow-up lands. Cheap in-EVM tightenings were considered and rejected: balance-conditional exemption lets a one-time ~1e13 wei donation to the golden-touch address flip every future anchor trace into fee-paying mode, and a `nonce == height - 1` formula breaks permanently after a single planted transaction, reintroducing the hard failure.

## Tests

- `replayed_anchor_transaction_executes_without_prior_system_call` — reproduces the exact mainnet failure (red before the fix with `LackOfFundForMaxFee { fee: 10000000000000, balance: 316794861226 }`), green after.
- `derived_anchor_context_only_exempts_the_snapshot_nonce` — a follow-up golden-touch → treasury tx does not inherit the exemption within one EVM instance.
- `fresh_replay_evm_still_exempts_crafted_golden_touch_tx_after_anchor` — two-EVM regression pinning the known limitation above.
- `derived_anchor_context_does_not_apply_base_fee_sharing` — derived context keeps replay fee behavior unchanged.
- `system_call_context_shares_base_fee_for_regular_transactions` — the authoritative path still shares basefee income.

## Verification

- `just fmt` ✅
- `just clippy` ✅
- `just test` ✅ (281/281 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)