### PR TITLE
fix(evm): meter each RPC transact against a fresh zk gas budget

### DIFF
--- a/.github/scripts/install_llvm_ubuntu.sh
+++ b/.github/scripts/install_llvm_ubuntu.sh
@@ -39,7 +39,7 @@ for attempt in $(seq "$attempts"); do
 done
 # Pin the upstream installer so CI and Docker builds fail loudly when it changes; review the new
 # script before updating this hash.
-echo "9474ecd78b52aba6e923976b1e9773f5613027cc7e237b9956986cb536e02a36  $llvm_installer" | sha256sum -c -
+echo "03878e08f47b66cc95bc4b544b0db3c6d9ce8d60e6cf2492ae357984330a9eae  $llvm_installer" | sha256sum -c -
 chmod +x "$llvm_installer"
 "$llvm_installer" "$version" all
 rm -f "$llvm_installer"

--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -145,12 +145,16 @@ where
         receipt_builder: R,
     ) -> Self
     where
-        Evm: TaikoAnchorEvm,
+        Evm: TaikoAnchorEvm + TaikoZkGasEvm,
     {
         // The executor installs the authoritative anchor context through the anchor system
         // call in `apply_pre_execution_changes`; replay-only derivation must stay off so a
         // missing initialization keeps failing loudly.
         evm.set_anchor_ctx_derivation_enabled(false);
+        // The executor owns the per-transaction zk gas bracket (reset, intrinsic charge,
+        // commit) in `execute_transaction_without_commit`; the wrapper's per-transact entry
+        // reset must stay off or it would wipe the intrinsic charged before `transact` runs.
+        evm.set_per_transact_zk_gas_reset_enabled(false);
         Self {
             evm,
             ctx,

--- a/crates/evm/src/alloy.rs
+++ b/crates/evm/src/alloy.rs
@@ -61,11 +61,14 @@ pub struct TaikoEvmWrapper<DB: Database, I, P> {
     /// missing pre-execution initialization must keep failing loudly there.
     derive_anchor_ctx: bool,
     /// Whether [`Evm::transact_raw`] discards in-flight zk gas before executing. Enabled by
-    /// default so replay-style consumers that reuse one EVM for repeated simulations
-    /// (`eth_estimateGas`'s binary search, `eth_createAccessList`, `eth_simulateV1`) meter
-    /// every run against a fresh transaction budget; the block executor turns it off because
-    /// it owns the per-transaction bracket (reset, intrinsic charge, commit) and an entry
-    /// reset here would wipe the intrinsic zk gas it charges before execution.
+    /// default so RPC-style consumers that reuse one EVM never accumulate zk gas across
+    /// transacts: `eth_estimateGas`'s repeated runs of the same transaction meter from zero,
+    /// and multi-transaction simulations over one raw EVM (`eth_callBundle`, the intra-block
+    /// replay helpers) get a fresh per-transaction budget rather than a consensus-shaped
+    /// cumulative one. Consensus-shaped execution (including `eth_simulateV1`) runs through
+    /// the block executor, which turns this off because it owns the per-transaction bracket
+    /// (reset, intrinsic charge, commit) and an entry reset here would wipe the intrinsic zk
+    /// gas it charges before execution.
     reset_zk_gas_per_transact: bool,
 }
 
@@ -224,11 +227,12 @@ impl<DB: Database, I, P> TaikoAnchorEvm for TaikoEvmWrapper<DB, I, P> {
 pub trait TaikoZkGasEvm {
     /// Enables or disables the automatic in-flight zk gas reset at the start of every transact.
     ///
-    /// Enabled by default: RPC-style consumers (`eth_estimateGas`'s binary search,
-    /// `eth_createAccessList`, `eth_simulateV1`) reuse one EVM for repeated simulations, and
-    /// each run must meter from zero. The block executor disables it because it drives the
-    /// meter through its own reset/intrinsic-charge/commit bracket, which an entry reset
-    /// would corrupt by wiping the intrinsic charged before execution.
+    /// Enabled by default: RPC-style consumers reuse one EVM across transacts
+    /// (`eth_estimateGas` re-runs the same transaction; `eth_callBundle` and the intra-block
+    /// replay helpers execute a transaction sequence), and each run must meter from zero
+    /// instead of inheriting earlier runs' usage. The block executor disables it because it
+    /// drives the meter through its own reset/intrinsic-charge/commit bracket, which an entry
+    /// reset would corrupt by wiping the intrinsic charged before execution.
     fn set_per_transact_zk_gas_reset_enabled(&mut self, enabled: bool);
 
     /// Discards any in-flight zk gas recorded for the current transaction.
@@ -263,10 +267,15 @@ where
     }
 
     /// Discards any in-flight zk gas recorded for the current transaction.
+    ///
+    /// Covers both metering homes — the production meter on the base EVM and the inspector's
+    /// meter plus its step bookkeeping (only one of the two is ever installed) — so nothing an
+    /// aborted run recorded can charge into the next transaction.
     fn reset_transaction_zk_gas(&mut self) {
-        if let Some(meter) = self.meter_mut() {
+        if let Some(meter) = self.base_evm_mut().zk_gas_meter_mut() {
             meter.reset_transaction();
         }
+        self.base_evm_mut().inner.inspector.reset_transaction();
     }
 
     /// Commits the current transaction's zk gas into the block total and returns the new total.
@@ -389,10 +398,12 @@ where
         &mut self,
         tx: Self::Tx,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        // Replay-style callers (`eth_estimateGas`'s binary search, `eth_createAccessList`,
-        // `eth_simulateV1`) reuse this EVM for repeated runs; without a reset the in-flight
-        // zk gas of previous runs accumulates and eventually trips the block budget. The block
-        // executor disables this and manages the per-transaction bracket itself.
+        // RPC callers that reuse one EVM (`eth_estimateGas`'s repeated runs of one transaction,
+        // `eth_callBundle`'s and the intra-block replay helpers' transaction sequences) never
+        // commit the meter, so without a reset the in-flight zk gas of previous runs
+        // accumulates and eventually trips the block budget. The block executor disables this
+        // and manages the per-transaction bracket itself; `eth_simulateV1` and consensus paths
+        // reach the meter through the block executor.
         if self.reset_zk_gas_per_transact {
             self.reset_transaction_zk_gas();
         }

--- a/crates/evm/src/alloy.rs
+++ b/crates/evm/src/alloy.rs
@@ -60,6 +60,13 @@ pub struct TaikoEvmWrapper<DB: Database, I, P> {
     /// because it installs the authoritative context through the anchor system call, and a
     /// missing pre-execution initialization must keep failing loudly there.
     derive_anchor_ctx: bool,
+    /// Whether [`Evm::transact_raw`] discards in-flight zk gas before executing. Enabled by
+    /// default so replay-style consumers that reuse one EVM for repeated simulations
+    /// (`eth_estimateGas`'s binary search, `eth_createAccessList`, `eth_simulateV1`) meter
+    /// every run against a fresh transaction budget; the block executor turns it off because
+    /// it owns the per-transaction bracket (reset, intrinsic charge, commit) and an entry
+    /// reset here would wipe the intrinsic zk gas it charges before execution.
+    reset_zk_gas_per_transact: bool,
 }
 
 impl<DB: Database, I, P> TaikoEvmWrapper<DB, I, P> {
@@ -69,18 +76,23 @@ impl<DB: Database, I, P> TaikoEvmWrapper<DB, I, P> {
     where
         P: PrecompileProvider<TaikoEvmContext<DB>, Output = InterpreterResult>,
     {
-        Self { inner: revmc::revm_evm::JitEvm::disabled(evm), inspect, derive_anchor_ctx: true }
+        Self {
+            inner: revmc::revm_evm::JitEvm::disabled(evm),
+            inspect,
+            derive_anchor_ctx: true,
+            reset_zk_gas_per_transact: true,
+        }
     }
 
     /// Creates an interpreter-backed [`TaikoEvmWrapper`] instance.
     #[cfg(not(feature = "jit"))]
     pub const fn new(evm: BaseTaikoEvm<DB, I, P>, inspect: bool) -> Self {
-        Self { inner: evm, inspect, derive_anchor_ctx: true }
+        Self { inner: evm, inspect, derive_anchor_ctx: true, reset_zk_gas_per_transact: true }
     }
 
     /// Creates a wrapper around an already configured optional JIT dispatcher.
     pub(crate) fn new_with_inner(evm: InnerTaikoEvm<DB, I, P>, inspect: bool) -> Self {
-        Self { inner: evm, inspect, derive_anchor_ctx: true }
+        Self { inner: evm, inspect, derive_anchor_ctx: true, reset_zk_gas_per_transact: true }
     }
 
     /// Consumes self and return the inner EVM instance.
@@ -210,6 +222,15 @@ impl<DB: Database, I, P> TaikoAnchorEvm for TaikoEvmWrapper<DB, I, P> {
 
 /// EVM extension trait for reading and mutating the zk gas meter state.
 pub trait TaikoZkGasEvm {
+    /// Enables or disables the automatic in-flight zk gas reset at the start of every transact.
+    ///
+    /// Enabled by default: RPC-style consumers (`eth_estimateGas`'s binary search,
+    /// `eth_createAccessList`, `eth_simulateV1`) reuse one EVM for repeated simulations, and
+    /// each run must meter from zero. The block executor disables it because it drives the
+    /// meter through its own reset/intrinsic-charge/commit bracket, which an entry reset
+    /// would corrupt by wiping the intrinsic charged before execution.
+    fn set_per_transact_zk_gas_reset_enabled(&mut self, enabled: bool);
+
     /// Discards any in-flight zk gas recorded for the current transaction.
     fn reset_transaction_zk_gas(&mut self);
 
@@ -236,6 +257,11 @@ where
     I: Inspector<TaikoEvmContext<DB>>,
     P: PrecompileProvider<TaikoEvmContext<DB>, Output = InterpreterResult>,
 {
+    /// Enables or disables the automatic in-flight zk gas reset at the start of every transact.
+    fn set_per_transact_zk_gas_reset_enabled(&mut self, enabled: bool) {
+        self.reset_zk_gas_per_transact = enabled;
+    }
+
     /// Discards any in-flight zk gas recorded for the current transaction.
     fn reset_transaction_zk_gas(&mut self) {
         if let Some(meter) = self.meter_mut() {
@@ -363,6 +389,13 @@ where
         &mut self,
         tx: Self::Tx,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        // Replay-style callers (`eth_estimateGas`'s binary search, `eth_createAccessList`,
+        // `eth_simulateV1`) reuse this EVM for repeated runs; without a reset the in-flight
+        // zk gas of previous runs accumulates and eventually trips the block budget. The block
+        // executor disables this and manages the per-transaction bracket itself.
+        if self.reset_zk_gas_per_transact {
+            self.reset_transaction_zk_gas();
+        }
         self.maybe_derive_anchor_execution_ctx(&tx)?;
         self.ctx_mut().set_tx(tx);
         // Run [`TaikoEvmHandler`] against the (possibly JIT-dispatching) inner EVM directly:

--- a/crates/evm/src/zk_gas/adapter.rs
+++ b/crates/evm/src/zk_gas/adapter.rs
@@ -75,6 +75,16 @@ impl<I> ZkGasInspector<I> {
     pub(crate) fn meter_mut(&mut self) -> Option<&mut ZkGasMeter<'static>> {
         self.metering.as_mut().map(|state| &mut state.meter)
     }
+
+    /// Discards in-flight transaction metering state, if metering is enabled.
+    ///
+    /// Clears both the meter's per-transaction usage and the inspector's step bookkeeping so
+    /// nothing recorded by an aborted transaction can charge into the next one.
+    pub(crate) fn reset_transaction(&mut self) {
+        if let Some(metering) = &mut self.metering {
+            metering.reset_transaction();
+        }
+    }
 }
 
 impl<DB, I> Inspector<TaikoEvmContext<DB>, EthInterpreter> for ZkGasInspector<I>
@@ -302,6 +312,21 @@ impl ZkGasMeteringState {
         }
     }
 
+    /// Discards the in-flight transaction zk gas together with all per-frame step bookkeeping.
+    ///
+    /// The unwind of a failed transaction drains deferred steps through `call_end`/`create_end`
+    /// today, but that invariant lives in revm's frame handling; resetting everything here keeps
+    /// the transaction boundary self-contained regardless of how execution aborted.
+    fn reset_transaction(&mut self) {
+        self.meter.reset_transaction();
+        for index in 0..=self.max_active_depth {
+            self.pending_steps[index] = PendingStep::EMPTY;
+            self.deferred_steps[index] = None;
+        }
+        self.has_deferred_steps = false;
+        self.max_active_depth = 0;
+    }
+
     /// Records the opcode and gas snapshot for the current frame depth.
     #[inline(always)]
     fn begin_step(&mut self, depth: usize, opcode: u8, gas_remaining: u64) {
@@ -502,6 +527,24 @@ mod tests {
         assert!(metering.has_deferred_steps);
         assert!(metering.deferred_steps[0].is_none());
         assert!(metering.deferred_steps[1].is_some());
+    }
+
+    #[test]
+    fn reset_transaction_clears_meter_and_step_bookkeeping() {
+        let mut metering = ZkGasMeteringState::new(&UNZEN_ZK_GAS_SCHEDULE);
+        metering.begin_step(1, 0x01, 10);
+        metering.defer_step(0, FinishedStep { opcode: 0xf1, step_gas: 5, spawned: true });
+        metering.defer_step(1, FinishedStep { opcode: 0x01, step_gas: 3, spawned: false });
+        metering.meter.charge_opcode(0x01, 3).expect("charge fits");
+
+        metering.reset_transaction();
+
+        assert_eq!(metering.meter.tx_zk_gas_used(), 0);
+        assert!(!metering.has_deferred_steps);
+        assert!(metering.deferred_steps[..2].iter().all(Option::is_none));
+        assert_eq!(metering.pending_steps[1].opcode, 0);
+        assert_eq!(metering.pending_steps[1].gas_remaining, 0);
+        assert_eq!(metering.max_active_depth, 0);
     }
 
     #[test]

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -398,6 +398,57 @@ fn disabled_per_transact_reset_preserves_executor_accumulation_semantics() {
 }
 
 #[test]
+fn reset_clears_deferred_charges_left_by_a_limit_exceeded_nested_call() {
+    // A zk gas limit hit inside a nested call aborts execution while CALL-family steps are
+    // still deferred (`flush_deferred_steps` deliberately keeps later entries on error). The
+    // per-transact reset must drop that bookkeeping too, or the next transaction on the same
+    // EVM starts by flushing the previous transaction's charges into its fresh meter.
+    let cheap_target = Address::with_last_byte(0xEE);
+
+    assert_no_deferred_leak_across_transacts(limit_exceeding_keccak_bytecode(), cheap_target);
+}
+
+#[test]
+fn reset_clears_deferred_charges_when_the_flush_itself_is_over_budget() {
+    // Variant where the budget is ground down by ~250k-zk keccak iterations, so the remaining
+    // budget at failure time is below one CALL spawn estimate and the unwind-time flush of the
+    // deferred CALL charges errors instead of draining them.
+    assert_no_deferred_leak_across_transacts(
+        quarter_million_keccak_loop_bytecode(),
+        Address::with_last_byte(0xEF),
+    );
+}
+
+/// Runs the shared deferred-leak scenario: a nested call chain to `buster_bytecode` busts the
+/// zk gas limit on a reused EVM, then a cheap unrelated transaction must meter exactly like a
+/// fresh EVM would — any difference is leftover bookkeeping leaking across transacts.
+fn assert_no_deferred_leak_across_transacts(buster_bytecode: Bytecode, cheap_target: Address) {
+    let mut evm = TaikoEvmFactory::default().create_evm_with_inspector(
+        nested_limit_db(cheap_target, buster_bytecode.clone()),
+        evm_env(TaikoSpecId::UNZEN),
+        NoOpInspector {},
+    );
+    let err = evm.transact(tx_env(16_000_000)).expect_err("nested call must bust the limit");
+    assert!(err.to_string().contains(ZK_GAS_LIMIT_ERR), "unexpected error: {err}");
+
+    evm.transact(cheap_tx_env(cheap_target)).expect("cheap tx should execute after the failure");
+    let reused = evm.meter().expect("Unzen should install a meter").tx_zk_gas_used();
+
+    let mut fresh_evm = TaikoEvmFactory::default().create_evm_with_inspector(
+        nested_limit_db(cheap_target, buster_bytecode),
+        evm_env(TaikoSpecId::UNZEN),
+        NoOpInspector {},
+    );
+    fresh_evm.transact(cheap_tx_env(cheap_target)).expect("cheap tx should execute");
+    let fresh = fresh_evm.meter().expect("Unzen should install a meter").tx_zk_gas_used();
+
+    assert_eq!(
+        reused, fresh,
+        "deferred steps left by a failed transaction must not leak into the next one"
+    );
+}
+
+#[test]
 fn reused_evm_replays_a_heavy_tx_without_tripping_the_block_limit() {
     // Regression for the observed `eth_estimateGas` failure: a transaction whose single run
     // costs ~68M zk gas (under the 100M Unzen block limit) was pushed over the limit by the
@@ -780,6 +831,86 @@ fn limit_exceeding_keccak_bytecode() -> Bytecode {
         opcode::KECCAK256,
         opcode::STOP,
     ]))
+}
+
+/// Pushes a zero-arg, zero-value `CALL` to `target` forwarding `gas`, then `STOP`.
+fn call_into_bytecode(target: Address, gas: u32) -> Bytecode {
+    let mut code = vec![
+        opcode::PUSH1,
+        0x00, // retLen
+        opcode::PUSH1,
+        0x00, // retOff
+        opcode::PUSH1,
+        0x00, // argLen
+        opcode::PUSH1,
+        0x00, // argOff
+        opcode::PUSH1,
+        0x00, // value
+        opcode::PUSH20,
+    ];
+    code.extend_from_slice(target.as_slice());
+    code.push(opcode::PUSH4);
+    code.extend_from_slice(&gas.to_be_bytes());
+    code.push(opcode::CALL);
+    code.push(opcode::STOP);
+    Bytecode::new_raw(Bytes::from(code))
+}
+
+/// `BENCH_TARGET` -> middle -> buster call chain, so two CALL-family steps are still deferred
+/// when the deepest frame busts the block zk gas limit; `cheap_target` holds an unrelated
+/// cheap contract for the follow-up transaction.
+fn nested_limit_db(cheap_target: Address, buster_bytecode: Bytecode) -> InMemoryDB {
+    let middle = Address::with_last_byte(0xCA);
+    let buster = Address::with_last_byte(0xDB);
+    let mut db = db_with_contract(call_into_bytecode(middle, 15_000_000));
+    insert_contract(&mut db, middle, call_into_bytecode(buster, 14_000_000));
+    insert_contract(&mut db, buster, buster_bytecode);
+    insert_contract(&mut db, cheap_target, simple_arithmetic_bytecode());
+    db
+}
+
+/// Loops `KECCAK256` over a fixed ~42 KiB span so every iteration charges just under 250k zk
+/// gas. When the budget dies, the remaining zk gas is below one CALL spawn estimate (250k), so
+/// the deferred CALL charges cannot be flushed during the failure unwind. The zk budget is
+/// exhausted long before the forwarded EVM gas.
+fn quarter_million_keccak_loop_bytecode() -> Bytecode {
+    Bytecode::new_raw(Bytes::from(vec![
+        opcode::PUSH2,
+        0xA7,
+        0x60, // size: 42,848 bytes
+        opcode::PUSH1,
+        0x00,             // offset
+        opcode::JUMPDEST, // pc = 5
+        opcode::KECCAK256,
+        opcode::POP,
+        opcode::PUSH2,
+        0xA7,
+        0x60,
+        opcode::PUSH1,
+        0x00,
+        opcode::PUSH1,
+        0x05,
+        opcode::JUMP,
+    ]))
+}
+
+fn insert_contract(db: &mut InMemoryDB, address: Address, bytecode: Bytecode) {
+    let code_hash = bytecode.hash_slow();
+    db.insert_account_info(
+        address,
+        AccountInfo { nonce: 1, code_hash, code: Some(bytecode), ..Default::default() },
+    );
+}
+
+/// A 100k-gas call from `BENCH_CALLER` to `target`.
+fn cheap_tx_env(target: Address) -> TxEnv {
+    TxEnv::builder()
+        .caller(BENCH_CALLER)
+        .kind(TxKind::Call(target))
+        .chain_id(Some(167))
+        .gas_limit(100_000)
+        .build()
+        .unwrap()
 }
 
 fn half_limit_keccak_bytecode() -> Bytecode {

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -20,7 +20,7 @@ use revm_database_interface::{
     BENCH_CALLER, BENCH_CALLER_BALANCE, BENCH_TARGET, BENCH_TARGET_BALANCE,
 };
 
-use crate::{factory::TaikoEvmFactory, spec::TaikoSpecId};
+use crate::{alloy::TaikoZkGasEvm, factory::TaikoEvmFactory, spec::TaikoSpecId};
 
 use super::{
     adapter::ZK_GAS_LIMIT_ERR,
@@ -329,6 +329,88 @@ fn production_metered_path_matches_inspector_path_for_ordinary_opcodes() {
         inspector_evm.meter().expect("inspector path should install a meter").tx_zk_gas_used();
 
     assert_eq!(production_zk_gas, inspector_zk_gas);
+}
+
+#[test]
+fn transact_meters_each_run_from_zero_on_a_reused_evm() {
+    // RPC helpers like `eth_estimateGas` build one EVM and re-run the same transaction many
+    // times (initial run, optimistic run, binary search). Every run must meter against a fresh
+    // transaction budget instead of inheriting the in-flight zk gas of the previous runs.
+    let mut evm = TaikoEvmFactory::default()
+        .create_evm(db_with_contract(simple_arithmetic_bytecode()), evm_env(TaikoSpecId::UNZEN));
+
+    evm.transact(tx_env(100_000)).expect("first run should execute");
+    let first_run = evm.meter().expect("Unzen should install a meter").tx_zk_gas_used();
+    assert!(first_run > 0, "the metered run must charge zk gas");
+
+    evm.transact(tx_env(100_000)).expect("second run should execute");
+    let second_run = evm.meter().expect("Unzen should install a meter").tx_zk_gas_used();
+
+    assert_eq!(
+        second_run, first_run,
+        "a reused EVM must not accumulate in-flight zk gas across transact calls"
+    );
+}
+
+#[test]
+fn inspected_transact_meters_each_run_from_zero_on_a_reused_evm() {
+    // Same reused-EVM shape as the production-path test above, on the inspector metering path.
+    let mut evm = TaikoEvmFactory::default().create_evm_with_inspector(
+        db_with_contract(simple_arithmetic_bytecode()),
+        evm_env(TaikoSpecId::UNZEN),
+        NoOpInspector {},
+    );
+
+    evm.transact(tx_env(100_000)).expect("first run should execute");
+    let first_run = evm.meter().expect("Unzen should install a meter").tx_zk_gas_used();
+    assert!(first_run > 0, "the metered run must charge zk gas");
+
+    evm.transact(tx_env(100_000)).expect("second run should execute");
+    let second_run = evm.meter().expect("Unzen should install a meter").tx_zk_gas_used();
+
+    assert_eq!(
+        second_run, first_run,
+        "a reused EVM must not accumulate in-flight zk gas across transact calls"
+    );
+}
+
+#[test]
+fn disabled_per_transact_reset_preserves_executor_accumulation_semantics() {
+    // The block executor calls `set_per_transact_zk_gas_reset_enabled(false)` and brackets
+    // each transaction itself (reset, intrinsic charge, commit); with the entry reset
+    // disabled, in-flight usage must keep accumulating across transact calls.
+    let mut evm = TaikoEvmFactory::default()
+        .create_evm(db_with_contract(simple_arithmetic_bytecode()), evm_env(TaikoSpecId::UNZEN));
+    evm.set_per_transact_zk_gas_reset_enabled(false);
+
+    evm.transact(tx_env(100_000)).expect("first run should execute");
+    let first_run = evm.meter().expect("Unzen should install a meter").tx_zk_gas_used();
+    assert!(first_run > 0, "the metered run must charge zk gas");
+
+    evm.transact(tx_env(100_000)).expect("second run should execute");
+    let second_run = evm.meter().expect("Unzen should install a meter").tx_zk_gas_used();
+
+    assert_eq!(
+        second_run,
+        first_run * 2,
+        "a disabled entry reset must preserve cross-transact accumulation for the executor"
+    );
+}
+
+#[test]
+fn reused_evm_replays_a_heavy_tx_without_tripping_the_block_limit() {
+    // Regression for the observed `eth_estimateGas` failure: a transaction whose single run
+    // costs ~68M zk gas (under the 100M Unzen block limit) was pushed over the limit by the
+    // estimate flow's repeated simulations because the meter carried usage between runs.
+    let mut evm = TaikoEvmFactory::default()
+        .create_evm(db_with_contract(half_limit_keccak_bytecode()), evm_env(TaikoSpecId::UNZEN));
+
+    for run in 0..4u32 {
+        let result = evm
+            .transact(tx_env(5_000_000))
+            .unwrap_or_else(|err| panic!("run {run} must not hit the zk gas limit: {err}"));
+        assert!(result.result.is_success(), "run {run} must succeed: {:?}", result.result);
+    }
 }
 
 /// Executes `bytecode` on Unzen through the production (no-inspector) and the inspected
@@ -693,6 +775,22 @@ fn limit_exceeding_keccak_bytecode() -> Bytecode {
         0x20,
         opcode::PUSH3,
         0x18,
+        0x00,
+        0x00,
+        opcode::KECCAK256,
+        opcode::STOP,
+    ]))
+}
+
+fn half_limit_keccak_bytecode() -> Bytecode {
+    // Same shape as `limit_exceeding_keccak_bytecode`, sized down so the memory expansion stops
+    // near 1 MiB: one metered run costs ~68M zk gas — under the 100M Unzen block limit — while
+    // two accumulated runs would bust it.
+    Bytecode::new_raw(Bytes::from(vec![
+        opcode::PUSH1,
+        0x20,
+        opcode::PUSH3,
+        0x10,
         0x00,
         0x00,
         opcode::KECCAK256,


### PR DESCRIPTION
## Summary

`eth_estimateGas` fails with `Revm error: zk gas limit exceeded` for any transaction whose single run costs more than a fraction of the 100M Unzen block zk gas budget (observed live with Boundless proof fulfillments at ~28M zk gas per run), while `eth_call` on the same state succeeds.

Root cause: reth's `EstimateCall::estimate_gas_with` builds **one** EVM and re-runs the same transaction many times (full-gas run, optimistic run, binary search, retry). The `ZkGasMeter` lives on the EVM instance, and `TaikoEvmWrapper::transact_raw` never reset it — `reset_transaction_zk_gas` / `commit_transaction_zk_gas` are only wired into `TaikoBlockExecutor`. Every simulation therefore inherits the in-flight zk gas of the previous runs (28M → 56M → 84M → limit), and the estimate errors even though the chain is nearly empty. The same accumulation-without-commit affects the other raw-EVM multi-transact paths: `eth_callBundle` and the intra-block replay helpers (`replay_transactions_until`).

## Fix

- `TaikoEvmWrapper` now discards in-flight zk gas at the start of every `transact_raw`, so each simulation meters against a fresh transaction budget. The reset clears the whole metering state: the meter itself plus the inspector-path step bookkeeping (`pending_steps` / `deferred_steps` / flags), so nothing recorded by an aborted run can charge into the next one.
- The reset is controlled by a new `TaikoZkGasEvm::set_per_transact_zk_gas_reset_enabled` switch (default **on**), mirroring the existing `set_anchor_ctx_derivation_enabled` pattern: `TaikoBlockExecutor::new` turns it **off** because the executor owns the per-transaction bracket (reset → intrinsic charge → commit) and an entry reset would wipe the intrinsic zk gas it charges before `transact` runs.
- Consensus paths (payload building, derived-block execution, prover) and `eth_simulateV1` all drive execution through `TaikoBlockExecutor`, so their metering semantics are byte-for-byte unchanged; the existing executor tests (`executor_includes_tx_intrinsic_in_committed_block_zk_gas`, `executor_discards_limit_exceeded_tx_and_stops_after_it`) pin that. `eth_createAccessList` builds a fresh EVM per run and was never affected.

Semantics note: multi-transaction simulations over one raw (non-executor) EVM — `eth_callBundle`, intra-block replay — now give each transaction a fresh 100M budget instead of the accidental cumulative-without-commit behavior. For replaying canonical blocks this can never false-fail; for `eth_callBundle` it means a bundle whose *total* zk gas exceeds the block budget is no longer flagged mid-simulation (the old behavior was itself only an approximation: no per-tx intrinsic, and the failure surfaced as an EVM error rather than a bundle verdict). Making `eth_callBundle` consensus-shaped needs a Taiko-aware bundle endpoint that drives the real executor bracket — deliberately out of scope here and tracked as a follow-up.

## Review response (round 1)

- **Inspector bookkeeping reset**: `reset_transaction_zk_gas` now also clears `ZkGasMeteringState`'s deferred/pending step state via `ZkGasMeteringState::reset_transaction`. Two adversarial integration tests try to leak deferred CALL charges across transacts (a single over-budget charge, and a budget ground down so the unwind-time flush itself is over budget); both come out clean on current revm because the frame unwind drains deferred entries, and they now pin that invariant against future revm bumps while the reset makes it locally provable.
- **Doc scope**: the flag/comment docs previously cited `eth_createAccessList` (uses a fresh EVM per run) and `eth_simulateV1` (runs through the block executor) as beneficiaries — both corrected to the verified set: `eth_estimateGas`, `eth_callBundle`, intra-block replay helpers.

## Tests

- `transact_meters_each_run_from_zero_on_a_reused_evm` — production metering path; previously failed with doubled zk gas (222 vs 111).
- `inspected_transact_meters_each_run_from_zero_on_a_reused_evm` — same on the inspector metering path.
- `reused_evm_replays_a_heavy_tx_without_tripping_the_block_limit` — regression for the observed failure: a ~68M zk gas keccak transaction replayed 4× on one EVM; previously died on run 2 with `zk gas limit exceeded`.
- `disabled_per_transact_reset_preserves_executor_accumulation_semantics` — pins the executor-mode accumulation behavior behind the switch.
- `reset_clears_deferred_charges_left_by_a_limit_exceeded_nested_call` / `reset_clears_deferred_charges_when_the_flush_itself_is_over_budget` — adversarial nested-call constructions pinning that no deferred charge survives a failed transaction on a reused EVM.
- `reset_transaction_clears_meter_and_step_bookkeeping` — white-box contract of the full metering-state reset.

The first four were written first and confirmed red on `main` before the fix.

## Commands run

- `just fmt`
- `just clippy`
- `just test`

## CI note

The first CI round failed in the LLVM **setup** step, unrelated to this change: apt.llvm.org now serves the llvm.sh installer from upstream HEAD (`opencollab/llvm-jenkins.debian.net@6dc0d1ad`), so the checksum pinned in `install_llvm_ubuntu.sh` (which matched upstream `@eeed6742`) failed loudly, exactly as designed. The second commit repins the hash after reviewing the full upstream delta (usage exit-code tweak, `--help`/`--version` long-option parsing, LLVM 23/24 version patterns) and verifying the served file is byte-for-byte identical to the upstream repository HEAD. Our `llvm.sh 22 all` invocation is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
