### PR TITLE
feat(rpc): reserve anchor zk gas during tx selection

### DIFF
--- a/crates/block/src/executor.rs
+++ b/crates/block/src/executor.rs
@@ -184,6 +184,22 @@ where
         }
     }
 
+    /// Reserves finalized block zk gas without executing or committing a transaction.
+    ///
+    /// This supports simulations that need to preserve budget for a mandatory transaction they
+    /// cannot execute. Pre-Unzen EVMs have no meter, so the reservation is a successful no-op.
+    pub fn reserve_block_zk_gas(&mut self, amount: u64) -> Result<(), BlockExecutionError>
+    where
+        Evm: TaikoZkGasEvm,
+    {
+        match self.evm.reserve_block_zk_gas(amount) {
+            Ok(Some(zk_gas)) => self.ctx.set_finalized_block_zk_gas(zk_gas),
+            Ok(None) => {}
+            Err(ZkGasOutcome::LimitExceeded) => return Err(Self::zk_gas_limit_error()),
+        }
+        Ok(())
+    }
+
     /// Discards any in-flight zk gas for the current transaction while preserving the committed
     /// block total.
     fn reset_current_transaction_zk_gas(&mut self)
@@ -588,7 +604,7 @@ mod test {
     };
 
     use alethia_reth_evm::{
-        alloy::decode_anchor_system_call_data, factory::TaikoEvmFactory,
+        alloy::decode_anchor_system_call_data, factory::TaikoEvmFactory, spec::TaikoSpecId,
         zk_gas::unzen::TX_INTRINSIC_ZK_GAS,
     };
 
@@ -628,6 +644,38 @@ mod test {
             )),
             base_fee_share_pctg
         );
+    }
+
+    #[test]
+    fn executor_reserves_block_zk_gas_and_synchronizes_execution_context() {
+        let chain_spec = Arc::new(unzen_chain_spec());
+        let mut state =
+            State::builder().with_database(db_with_contracts(&[])).with_bundle_update().build();
+        let evm = TaikoEvmFactory::default().create_evm(&mut state, unzen_evm_env());
+        let ctx = unzen_execution_ctx();
+        let mut executor =
+            TaikoBlockExecutor::new(evm, ctx.clone(), chain_spec, RethReceiptBuilder::default());
+
+        executor.reserve_block_zk_gas(2_000_000).expect("reserve should fit");
+
+        assert_eq!(ctx.finalized_block_zk_gas(), 2_000_000);
+    }
+
+    #[test]
+    fn executor_reserves_block_zk_gas_as_noop_without_meter() {
+        let chain_spec = Arc::new(unzen_chain_spec());
+        let mut state =
+            State::builder().with_database(db_with_contracts(&[])).with_bundle_update().build();
+        let mut env = unzen_evm_env();
+        env.cfg_env.spec = TaikoSpecId::SHASTA;
+        let evm = TaikoEvmFactory::default().create_evm(&mut state, env);
+        let ctx = unzen_execution_ctx();
+        let mut executor =
+            TaikoBlockExecutor::new(evm, ctx.clone(), chain_spec, RethReceiptBuilder::default());
+
+        executor.reserve_block_zk_gas(2_000_000).expect("pre-Unzen reserve should be a no-op");
+
+        assert_eq!(ctx.finalized_block_zk_gas(), 0);
     }
 
     #[test]

--- a/crates/block/src/testutil.rs
+++ b/crates/block/src/testutil.rs
@@ -30,6 +30,10 @@ pub const BENCH_SUCCESS_TARGET: Address = Address::with_last_byte(0x21);
 /// Target address for contracts whose execution exceeds the zk gas limit.
 pub const BENCH_LIMIT_TARGET: Address = Address::with_last_byte(0x22);
 
+/// Target address for contracts whose execution fits the full block zk gas budget but not the
+/// tx-pool budget after reserving zk gas for the anchor transaction.
+pub const BENCH_NEAR_LIMIT_TARGET: Address = Address::with_last_byte(0x23);
+
 /// Returns a [`TaikoChainSpec`] with Unzen activated at timestamp 0.
 pub fn unzen_chain_spec() -> TaikoChainSpec {
     let mut chain_spec = (*TAIKO_DEVNET).as_ref().clone();
@@ -104,6 +108,7 @@ pub fn db_with_contracts(accounts: &[(Address, u64)]) -> InMemoryDB {
     let mut db = InMemoryDB::default();
     insert_contract(&mut db, BENCH_SUCCESS_TARGET, arithmetic_bytecode());
     insert_contract(&mut db, BENCH_LIMIT_TARGET, limit_exceeding_keccak_bytecode());
+    insert_contract(&mut db, BENCH_NEAR_LIMIT_TARGET, near_limit_keccak_bytecode());
     for &(address, nonce) in accounts {
         db.insert_account_info(
             address,
@@ -160,6 +165,23 @@ pub fn limit_exceeding_keccak_bytecode() -> Bytecode {
         opcode::PUSH1,
         0x00,         // jump destination 0
         opcode::JUMP, // loop
+    ]))
+}
+
+/// KECCAK256 bytecode that consumes about 99.04M zk gas under the Unzen schedule.
+///
+/// Expanding memory to offset `0x135a00` keeps the transaction below the full 100M block budget,
+/// but pushes it above the 98M user budget left after the tx-pool anchor reserve.
+pub fn near_limit_keccak_bytecode() -> Bytecode {
+    Bytecode::new_raw(Bytes::from(vec![
+        opcode::PUSH1,
+        0x20, // hash one 32-byte word
+        opcode::PUSH3,
+        0x13,
+        0x5a,
+        0x00, // memory offset 0x135a00
+        opcode::KECCAK256,
+        opcode::STOP,
     ]))
 }
 

--- a/crates/block/src/tx_selection/mod.rs
+++ b/crates/block/src/tx_selection/mod.rs
@@ -285,8 +285,9 @@ mod tests {
     use crate::{
         executor::TaikoBlockExecutor,
         testutil::{
-            BENCH_LIMIT_TARGET, BENCH_SUCCESS_TARGET, ExecutorBackedBuilder, db_with_contracts,
-            recovered_tx, unzen_chain_spec, unzen_evm_env, unzen_execution_ctx,
+            BENCH_LIMIT_TARGET, BENCH_NEAR_LIMIT_TARGET, BENCH_SUCCESS_TARGET,
+            ExecutorBackedBuilder, db_with_contracts, recovered_tx, unzen_chain_spec,
+            unzen_evm_env, unzen_execution_ctx,
         },
     };
     use alethia_reth_evm::factory::TaikoEvmFactory;
@@ -295,6 +296,45 @@ mod tests {
     const BENCH_INCLUDED_CALLER: Address = Address::with_last_byte(0x31);
     const BENCH_LIMIT_CALLER: Address = Address::with_last_byte(0x32);
     const BENCH_LATE_CALLER: Address = Address::with_last_byte(0x33);
+
+    fn select_near_limit_transaction(reserved_zk_gas: u64) -> (SelectionOutcome, u64) {
+        let chain_spec = Arc::new(unzen_chain_spec());
+        let mut state = State::builder()
+            .with_database(db_with_contracts(&[(BENCH_INCLUDED_CALLER, 0)]))
+            .with_bundle_update()
+            .build();
+        let evm = TaikoEvmFactory::default().create_evm(&mut state, unzen_evm_env());
+        let ctx = unzen_execution_ctx();
+        let executor =
+            TaikoBlockExecutor::new(evm, ctx.clone(), chain_spec, RethReceiptBuilder::default());
+        let mut builder = ExecutorBackedBuilder { executor };
+        builder.executor.reserve_block_zk_gas(reserved_zk_gas).expect("test reserve should fit");
+        let pool = testing_pool();
+        let rt = tokio::runtime::Builder::new_current_thread().build().expect("test runtime");
+        rt.block_on(pool.add_consensus_transaction(
+            recovered_tx(BENCH_INCLUDED_CALLER, BENCH_NEAR_LIMIT_TARGET, 0, 10),
+            TransactionOrigin::External,
+        ))
+        .expect("near-limit tx should enter the pool");
+
+        let outcome = select_and_execute_pool_transactions(
+            &mut builder,
+            &pool,
+            &TxSelectionConfig {
+                base_fee: 0,
+                gas_limit_per_list: 30_000_000,
+                max_da_bytes_per_list: 1_000_000,
+                da_size_zlib_guard_bytes: 0,
+                max_lists: 1,
+                min_tip: 0,
+                locals: vec![],
+            },
+            || false,
+        )
+        .expect("near-limit selection should complete cleanly");
+
+        (outcome, ctx.finalized_block_zk_gas())
+    }
 
     #[test]
     fn tx_selection_does_not_preallocate_the_caller_supplied_list_limit() {
@@ -332,6 +372,24 @@ mod tests {
         };
         assert_eq!(lists.len(), 1);
         assert!(lists[0].transactions.is_empty());
+    }
+
+    #[test]
+    fn tx_selection_respects_reserved_anchor_zk_gas() {
+        let (without_reserve, without_reserve_zk_gas) = select_near_limit_transaction(0);
+        let SelectionOutcome::Completed(without_reserve) = without_reserve else {
+            panic!("selection should not cancel")
+        };
+        assert_eq!(without_reserve[0].transactions.len(), 1);
+        assert!(without_reserve_zk_gas > 98_000_000);
+        assert!(without_reserve_zk_gas <= 100_000_000);
+
+        let (with_reserve, with_reserve_zk_gas) = select_near_limit_transaction(2_000_000);
+        let SelectionOutcome::Completed(with_reserve) = with_reserve else {
+            panic!("selection should not cancel")
+        };
+        assert!(with_reserve[0].transactions.is_empty());
+        assert_eq!(with_reserve_zk_gas, 2_000_000);
     }
 
     #[test]

--- a/crates/evm/src/alloy.rs
+++ b/crates/evm/src/alloy.rs
@@ -249,6 +249,11 @@ pub trait TaikoZkGasEvm {
     /// Returns the finalized block zk gas that has already been committed.
     fn block_zk_gas_used(&self) -> Option<u64>;
 
+    /// Reserves finalized block zk gas without executing a transaction.
+    ///
+    /// Returns the new finalized block total, or `None` when no meter is installed.
+    fn reserve_block_zk_gas(&mut self, amount: u64) -> Result<Option<u64>, ZkGasOutcome>;
+
     /// Charges the fixed per-transaction intrinsic zk gas defined by the active schedule.
     ///
     /// Returns `Ok(())` when the EVM has no meter installed (pre-Unzen specs).
@@ -295,6 +300,15 @@ where
     /// Returns the finalized block zk gas that has already been committed.
     fn block_zk_gas_used(&self) -> Option<u64> {
         self.meter().map(|m| m.block_zk_gas_used())
+    }
+
+    /// Reserves finalized block zk gas through the active meter.
+    fn reserve_block_zk_gas(&mut self, amount: u64) -> Result<Option<u64>, ZkGasOutcome> {
+        let Some(meter) = self.meter_mut() else {
+            return Ok(None);
+        };
+        meter.reserve_block_budget(amount)?;
+        Ok(Some(meter.block_zk_gas_used()))
     }
 
     /// Charges the fixed per-transaction intrinsic zk gas through the meter.

--- a/crates/evm/src/zk_gas/meter.rs
+++ b/crates/evm/src/zk_gas/meter.rs
@@ -77,6 +77,22 @@ impl<'a> ZkGasMeter<'a> {
         Ok(())
     }
 
+    /// Reserves finalized block zk gas without charging the in-flight transaction.
+    ///
+    /// This is intended for simulations that must account for a mandatory transaction they
+    /// cannot execute directly. The reservation is rejected without mutation when it exceeds
+    /// the remaining block budget or overflows the finalized block total.
+    pub fn reserve_block_budget(&mut self, amount: u64) -> Result<(), ZkGasOutcome> {
+        let next_block =
+            self.block_zk_gas_used.checked_add(amount).ok_or(ZkGasOutcome::LimitExceeded)?;
+        if next_block > self.schedule.block_limit || amount > self.remaining_zk_gas {
+            return Err(ZkGasOutcome::LimitExceeded);
+        }
+        self.block_zk_gas_used = next_block;
+        self.remaining_zk_gas -= amount;
+        Ok(())
+    }
+
     /// Returns `true` when [`Self::commit_transaction`] would fail: committing the in-flight
     /// transaction zk gas would exceed the block budget or overflow `u64` arithmetic.
     pub const fn commit_would_exceed_block_limit(&self) -> bool {

--- a/crates/evm/src/zk_gas/tests.rs
+++ b/crates/evm/src/zk_gas/tests.rs
@@ -89,6 +89,28 @@ fn meter_promotes_committed_tx_usage_into_block_usage() {
 }
 
 #[test]
+fn meter_reserves_finalized_block_budget_without_touching_in_flight_usage() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
+    let mut meter = ZkGasMeter::new(schedule);
+    meter.charge_opcode(0xf0, 7).expect("in-flight charge");
+
+    meter.reserve_block_budget(2_000_000).expect("reserve");
+
+    assert_eq!(meter.block_zk_gas_used(), 2_000_000);
+    assert_eq!(meter.tx_zk_gas_used(), 7);
+}
+
+#[test]
+fn meter_rejects_reserve_past_remaining_budget_without_mutation() {
+    let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
+    let mut meter = ZkGasMeter::new(schedule);
+    meter.reserve_block_budget(schedule.block_limit - 1).expect("initial reserve");
+
+    assert_eq!(meter.reserve_block_budget(2), Err(ZkGasOutcome::LimitExceeded));
+    assert_eq!(meter.block_zk_gas_used(), schedule.block_limit - 1);
+}
+
+#[test]
 fn meter_charge_tx_intrinsic_adds_schedule_value_to_in_flight_tx() {
     let schedule = schedule_for(TaikoSpecId::UNZEN).expect("Unzen schedule");
     let mut meter = ZkGasMeter::new(schedule);

--- a/crates/rpc/src/eth/auth/mod.rs
+++ b/crates/rpc/src/eth/auth/mod.rs
@@ -14,7 +14,10 @@ use reth::{
 };
 use reth_db_api::transaction::{DbTx, DbTxMut};
 use reth_ethereum::{EthPrimitives, TransactionSigned};
-use reth_evm::ConfigureEngineEvm;
+use reth_evm::{
+    ConfigureEngineEvm, block::BlockExecutionError, eth::receipt_builder::ReceiptBuilder,
+    execute::BlockBuilder,
+};
 use reth_evm_ethereum::RethReceiptBuilder;
 use reth_node_api::{Block, NodePrimitives};
 use reth_provider::{
@@ -29,6 +32,7 @@ use crate::eth::error::internal_eth_error;
 use alethia_reth_block::{
     assembler::TaikoBlockAssembler,
     config::TaikoNextBlockEnvAttributes,
+    executor::TaikoBlockExecutor,
     factory::TaikoBlockExecutorFactory,
     tx_selection::{
         DEFAULT_DA_ZLIB_GUARD_BYTES, SelectionOutcome, TxSelectionConfig,
@@ -39,7 +43,7 @@ use alethia_reth_chainspec::spec::TaikoChainSpec;
 use alethia_reth_db::model::{
     BatchToLastBlock, STORED_L1_HEAD_ORIGIN_KEY, StoredL1HeadOriginTable, StoredL1OriginTable,
 };
-use alethia_reth_evm::factory::TaikoEvmFactory;
+use alethia_reth_evm::{alloy::TaikoZkGasEvm, factory::TaikoEvmFactory};
 use alethia_reth_primitives::{
     engine::types::TaikoExecutionData, payload::attributes::RpcL1Origin,
 };
@@ -50,6 +54,25 @@ mod lookup;
 mod types;
 
 pub use types::{PreBuiltTxList, TxPoolContentParams, TxPoolContentWithMinTipParams};
+
+/// Conservative zk gas reserved for the mandatory anchor during tx-pool preselection.
+///
+/// Recent mainnet anchor-only blocks used 1,160,754 zk gas. The 2M reservation leaves modest
+/// headroom for anchor execution changes while retaining 98% of the Unzen block budget for user
+/// transactions. Revisit this value if the anchor implementation changes substantially.
+const TX_POOL_ANCHOR_ZK_GAS_RESERVE: u64 = 2_000_000;
+
+/// Applies the anchor zk gas safety margin before tx-pool transaction simulation.
+fn reserve_anchor_zk_gas_for_tx_pool_selection<Evm, Spec, R>(
+    executor: &mut TaikoBlockExecutor<'_, Evm, Spec, R>,
+) -> Result<(), BlockExecutionError>
+where
+    Evm: TaikoZkGasEvm,
+    Spec: Clone,
+    R: ReceiptBuilder,
+{
+    executor.reserve_block_zk_gas(TX_POOL_ANCHOR_ZK_GAS_RESERVE)
+}
 
 #[cfg(test)]
 mod tests;
@@ -352,6 +375,9 @@ where
             .map_err(|_| {
                 EthApiError::EvmCustom("failed to create block builder from EVM config".to_string())
             })?;
+
+        reserve_anchor_zk_gas_for_tx_pool_selection(builder.executor_mut())
+            .map_err(|err| EthApiError::Internal(err.into()))?;
 
         info!(target: "taiko_rpc_payload_builder", ?base_fee, ?block_max_gas_limit, ?max_bytes_per_tx_list, ?locals, ?max_transactions_lists, "Building prebuilt transaction lists from the pool");
 

--- a/crates/rpc/src/eth/auth/tests.rs
+++ b/crates/rpc/src/eth/auth/tests.rs
@@ -2,7 +2,8 @@ use super::{
     lookup::{MAX_BACKWARD_SCAN_BLOCKS, max_backward_scan_blocks},
     *,
 };
-use alethia_reth_chainspec::TAIKO_MAINNET;
+use alethia_reth_block::{executor::TaikoBlockExecutor, factory::TaikoBlockExecutionCtx};
+use alethia_reth_chainspec::{TAIKO_DEVNET, TAIKO_MAINNET};
 use alethia_reth_consensus::validation::ANCHOR_V4_SELECTOR;
 use alethia_reth_db::model::{
     BatchToLastBlock, STORED_L1_HEAD_ORIGIN_KEY, StoredL1HeadOriginTable, StoredL1Origin,
@@ -21,13 +22,18 @@ use reth_db::{
 };
 use reth_db_api::transaction::{DbTx, DbTxMut};
 use reth_ethereum::{TransactionSigned, chainspec::MAINNET};
+use reth_evm::{EvmEnv, EvmFactory};
+use reth_evm_ethereum::RethReceiptBuilder;
 use reth_primitives_traits::{RecoveredBlock, SealedHeader};
 use reth_provider::{
     BlockWriter, ProviderFactory,
     providers::{BlockchainProvider, RocksDBBuilder, StaticFileProvider},
     test_utils::MockNodeTypesWithDB,
 };
+use reth_revm::{State, db::InMemoryDB};
 use std::{path::PathBuf, sync::Arc};
+
+use alethia_reth_evm::{factory::TaikoEvmFactory, spec::TaikoSpecId};
 
 // ---------------------------------------------------------------------------
 // Shared test helpers
@@ -206,6 +212,37 @@ fn tx_pool_content_params_conversion_defaults_min_tip_to_zero() {
 fn combined_tx_lists_gas_limit_rejects_u64_overflow() {
     assert_eq!(super::combined_tx_lists_gas_limit(30_000_000, 4).unwrap(), 120_000_000);
     assert!(super::combined_tx_lists_gas_limit(u64::MAX, 2).is_err());
+}
+
+#[test]
+fn reserves_anchor_zk_gas_for_tx_pool_selection() {
+    let mut state =
+        State::builder().with_database(InMemoryDB::default()).with_bundle_update().build();
+    let mut env: EvmEnv<TaikoSpecId> = EvmEnv::default();
+    env.cfg_env.spec = TaikoSpecId::UNZEN;
+    let evm = TaikoEvmFactory::default().create_evm(&mut state, env);
+    let ctx = TaikoBlockExecutionCtx {
+        parent_hash: Default::default(),
+        parent_beacon_block_root: Some(Default::default()),
+        ommers: &[],
+        withdrawals: None,
+        basefee_per_gas: 0,
+        extra_data: Default::default(),
+        is_unzen_active: true,
+        expected_difficulty: None,
+        finalized_block_zk_gas: Default::default(),
+    };
+    let mut executor = TaikoBlockExecutor::new(
+        evm,
+        ctx.clone(),
+        TAIKO_DEVNET.clone(),
+        RethReceiptBuilder::default(),
+    );
+
+    super::reserve_anchor_zk_gas_for_tx_pool_selection(&mut executor)
+        .expect("tx-pool anchor reserve should fit");
+
+    assert_eq!(ctx.finalized_block_zk_gas(), super::TX_POOL_ANCHOR_ZK_GAS_RESERVE);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- reserve 2,000,000 zk gas for the mandatory anchor before tx-pool preselection
- add checked zk-gas reservation support at the meter and block-executor layers, with a pre-Unzen no-op
- cover the near-limit case where a transaction fits the full 100M budget but not the 98M user budget left after the anchor reserve

## Why

The tx-pool preselection path installs the Unzen zk-gas meter, but it does not execute the mandatory anchor transaction. It therefore selected transactions against the full 100M block budget, while the eventual payload executes the anchor first.

Recent mainnet anchor-only blocks consistently used 1,160,754 zk gas. Reserving a conservative 2M margin prevents preselection from advertising a transaction list that the payload builder may later truncate after accounting for the anchor.

The reservation is applied once to the shared selection executor, including when multiple transaction lists are requested. It does not change payload execution, consensus validation, or RPC request/response shapes.

## Validation

- `cargo +nightly-2026-04-18 fmt --check`
- `cargo sort --workspace --grouped --check`
- `just clippy`
- `just test` — 294 passed, 0 skipped

