### PR TITLE
chore(docker): retry the apt.llvm.org installer on transient failures

### DIFF
--- a/.github/scripts/install_llvm_ubuntu.sh
+++ b/.github/scripts/install_llvm_ubuntu.sh
@@ -41,7 +41,30 @@ done
 # script before updating this hash.
 echo "03878e08f47b66cc95bc4b544b0db3c6d9ce8d60e6cf2492ae357984330a9eae  $llvm_installer" | sha256sum -c -
 chmod +x "$llvm_installer"
-"$llvm_installer" "$version" all
+# Retry the installer too. Before touching apt it preflights apt.llvm.org with a single
+# `wget --method=HEAD` (its check_url), and reports *any* failure of that probe -- including a
+# connection blip -- as a fatal "Distribution 'debian' in version '13 (trixie)' is not supported
+# by this script.", exit 2. Neither the download loop above nor Acquire::Retries covers that raw
+# wget, so one unlucky HEAD request aborted an arm64 image build even though the repository was
+# up. The probe runs before any state is written, so re-running the installer is the fix.
+install_attempts=3
+for install_attempt in $(seq "$install_attempts"); do
+    if "$llvm_installer" "$version" all; then
+        break
+    fi
+    if [[ "$install_attempt" -eq "$install_attempts" ]]; then
+        echo "Error: the apt.llvm.org installer failed $install_attempts times." >&2
+        echo "Note: an 'is not supported by this script' error above can also mean apt.llvm.org" \
+             "was unreachable rather than that the distribution is genuinely unsupported." >&2
+        exit 1
+    fi
+    # On distributions that get the deb822 layout the installer appends its stanza with `tee -a`,
+    # so an attempt that failed after writing it would leave apt with a duplicate on the next pass.
+    # Dropping the file is safe here because the retry immediately below rewrites it.
+    rm -f /etc/apt/sources.list.d/*apt_llvm_org*.sources
+    echo "Retrying the apt.llvm.org installer in $((install_attempt * 10))s" >&2
+    sleep $((install_attempt * 10))
+done
 rm -f "$llvm_installer"
 
 for bin in "${bins[@]}"; do


### PR DESCRIPTION
## The failure

The arm64 leg of the image build on `main` died with:

```
[error] Distribution 'debian' in version '13 (trixie)' is not supported by this script.
```

([run 31672415154, `build (linux/arm64, arc-runner-set-arm64)`](https://github.com/taikoxyz/alethia-reth/actions/runs/31672415154/job/94359650498))

That message is a red herring. `https://apt.llvm.org/trixie/` is up and serving its package index, and trixie is precisely the release we target because it is the one publishing arm64 LLVM 22 packages.

## Root cause

`.github/scripts/install_llvm_ubuntu.sh` hands off to the pinned upstream `llvm.sh`, which preflights the repository with one unretried probe:

```
wget -q --method=HEAD --timeout=15 --tries=3 https://apt.llvm.org/trixie/
```

`llvm.sh` maps *any* failure of that probe to a fatal "distribution is not supported", `exit 2`. In the failing job the probe died silently after 15.07 s while apt.llvm.org was flaky from that runner — the same job had already logged two `Unable to establish SSL connection` errors against the same host seconds earlier, and only got past them because our wrapper retries its own download of `llvm.sh`.

The wrapper's existing hardening does not reach this probe. The retry loop covers only the `llvm.sh` download; `Acquire::Retries "3"` covers only apt's own fetches. The raw wget preflight inside `llvm.sh` is covered by neither, and the installer was invoked exactly once.

## The fix

Give the installer invocation the same bounded retry the download already has: 3 attempts, 10 s/20 s backoff. The probe runs before `llvm.sh` writes any state, so re-running it is a clean retry rather than a resumed one.

Between attempts the deb822 source stanza is dropped, because upstream appends it with `tee -a` — an attempt that failed *after* writing it would otherwise leave apt with a duplicate entry on the next pass.

The retry budget spans ~75 s (15 s probe + 10 s backoff + 15 s + 20 s backoff + 15 s). In the failing job connections to apt.llvm.org failed *intermittently* rather than continuously — TLS failures at 26.9 s and 52.0 s, a successful fetch at 62.1 s, then the fatal probe timing out at 77.2 s — so a second attempt has a good chance of landing in a working window, and a third is cheap insurance.

The final error message now also notes that "is not supported by this script" can mean apt.llvm.org was unreachable rather than that the distribution is genuinely unsupported, so the next person does not chase a phantom.

## Verification

Reproduced deterministically on arm64 in `debian:trixie` — the same image and architecture as the `llvm-arm64` CI guard job — using a `wget` shim that fails only the first `--method=HEAD` probe of the repo index and delegates everything else to the real wget:

- **before:** `exit 2`, with the CI message reproduced verbatim
- **after:** first probe fails, installer is retried, second probe succeeds, LLVM 22 installs, `exit 0`

Also ran unshimmed to confirm the happy path is unchanged (no spurious retries). `shellcheck` clean.

No Rust changed, so `just clippy` / `just test` are untouched by this.

Note: `docker-build.yml` only runs on push to `main`, so this PR cannot re-exercise the image build itself. The `llvm-arm64` CI job does run the changed script on a real arm64 runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
