### PR TITLE
fix(docker): harden apt.llvm.org bootstrap

### DIFF
--- a/.github/scripts/install_llvm_ubuntu.sh
+++ b/.github/scripts/install_llvm_ubuntu.sh
@@ -41,6 +41,16 @@ done
 # script before updating this hash.
 echo "03878e08f47b66cc95bc4b544b0db3c6d9ce8d60e6cf2492ae357984330a9eae  $llvm_installer" | sha256sum -c -
 chmod +x "$llvm_installer"
+# The pinned installer rejects the distribution when a redundant HEAD request to the repository
+# times out. Remove only that preflight after verifying the script hash; apt-get update below is
+# the authoritative repository check and already uses Acquire::Retries.
+llvm_repo_probe="    if ! check_url \"\${BASE_URL}/\${CODENAME}/\"; then"
+if [[ "$(grep -Fxc "$llvm_repo_probe" "$llvm_installer")" -ne 1 ]]; then
+    echo "Error: could not locate the expected apt.llvm.org repository probe." >&2
+    exit 1
+fi
+sed -i "s|^    if ! check_url \"\${BASE_URL}/\${CODENAME}/\"; then$|    if false; then|" \
+    "$llvm_installer"
 # Fetch the signing key with the same bounded GET used for the installer. The upstream script
 # otherwise probes this URL with `wget --method=HEAD` before downloading it; that probe repeatedly
 # timed out on the arm64 runner even while GETs from apt.llvm.org succeeded. Install the key only
@@ -63,12 +73,9 @@ if [[ ! -f "$llvm_key_path" ]]; then
     install -m 0644 "$llvm_key_download" "$llvm_key_path"
     rm -f "$llvm_key_download"
 fi
-# Retry the installer too. Before touching apt it preflights apt.llvm.org with a single
-# `wget --method=HEAD` (its check_url), and reports *any* failure of that probe -- including a
-# connection blip -- as a fatal "Distribution 'debian' in version '13 (trixie)' is not supported
-# by this script.", exit 2. Neither the download loop above nor Acquire::Retries covers that raw
-# wget, so one unlucky HEAD request aborted an arm64 image build even though the repository was
-# up. The probe runs before any state is written, so re-running the installer is the fix.
+# Retry the installer too so transient failures from its remaining apt operations do not abort the
+# image build. The installer can append its source stanza before failing, so retries remove that
+# partial state first.
 install_attempts=3
 for install_attempt in $(seq "$install_attempts"); do
     if "$llvm_installer" "$version" all; then

--- a/.github/scripts/install_llvm_ubuntu.sh
+++ b/.github/scripts/install_llvm_ubuntu.sh
@@ -41,6 +41,28 @@ done
 # script before updating this hash.
 echo "03878e08f47b66cc95bc4b544b0db3c6d9ce8d60e6cf2492ae357984330a9eae  $llvm_installer" | sha256sum -c -
 chmod +x "$llvm_installer"
+# Fetch the signing key with the same bounded GET used for the installer. The upstream script
+# otherwise probes this URL with `wget --method=HEAD` before downloading it; that probe repeatedly
+# timed out on the arm64 runner even while GETs from apt.llvm.org succeeded. Install the key only
+# after a complete download so a failed attempt cannot make upstream skip the key setup.
+llvm_key_path=/etc/apt/trusted.gpg.d/apt.llvm.org.asc
+if [[ ! -f "$llvm_key_path" ]]; then
+    llvm_key_download=$(mktemp)
+    for key_attempt in $(seq "$attempts"); do
+        if wget -nv --timeout=20 --tries=1 -O "$llvm_key_download" \
+            https://apt.llvm.org/llvm-snapshot.gpg.key; then
+            break
+        fi
+        if [[ "$key_attempt" -eq "$attempts" ]]; then
+            echo "Error: could not download the apt.llvm.org signing key ($attempts attempts)" >&2
+            exit 1
+        fi
+        echo "Retrying the apt.llvm.org signing key in $((key_attempt * 5))s" >&2
+        sleep $((key_attempt * 5))
+    done
+    install -m 0644 "$llvm_key_download" "$llvm_key_path"
+    rm -f "$llvm_key_download"
+fi
 # Retry the installer too. Before touching apt it preflights apt.llvm.org with a single
 # `wget --method=HEAD` (its check_url), and reports *any* failure of that probe -- including a
 # connection blip -- as a fatal "Distribution 'debian' in version '13 (trixie)' is not supported

--- a/.github/scripts/tests/install_llvm_ubuntu_test.sh
+++ b/.github/scripts/tests/install_llvm_ubuntu_test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly llvm_key_url="https://apt.llvm.org/llvm-snapshot.gpg.key"
+readonly llvm_script_url="https://apt.llvm.org/llvm.sh"
+
+fake_wget() {
+    local destination=""
+    local method="GET"
+    local next_is_destination=false
+    local url=""
+
+    for argument in "$@"; do
+        if [[ "$next_is_destination" == true ]]; then
+            destination="$argument"
+            next_is_destination=false
+            continue
+        fi
+
+        case "$argument" in
+            -O)
+                next_is_destination=true
+                ;;
+            -O*)
+                destination="${argument#-O}"
+                ;;
+            --method=HEAD)
+                method="HEAD"
+                ;;
+            https://*)
+                url="$argument"
+                ;;
+        esac
+    done
+
+    if [[ "$url" == "$llvm_key_url" && "$method" == "HEAD" ]]; then
+        return 1
+    fi
+
+    case "$url" in
+        "$llvm_script_url")
+            cp /work/install_llvm_ubuntu_test.sh "$destination"
+            ;;
+        "$llvm_key_url")
+            if [[ -n "$destination" && "$destination" != "-" ]]; then
+                printf 'fake-llvm-signing-key\n' > "$destination"
+            else
+                printf 'fake-llvm-signing-key\n'
+            fi
+            ;;
+    esac
+}
+
+fake_installer() {
+    local version="$1"
+    local key_path="/etc/apt/trusted.gpg.d/apt.llvm.org.asc"
+    local bin
+
+    if [[ ! -f "$key_path" ]]; then
+        wget -q --method=HEAD --timeout=15 --tries=3 "$llvm_key_url"
+        wget -qO- --tries=3 "$llvm_key_url" > "$key_path"
+    fi
+
+    for bin in clang llvm-config lld ld.lld FileCheck; do
+        ln -fs /work/install_llvm_ubuntu_test.sh "/tmp/fake-bin/$bin-$version"
+    done
+}
+
+dispatch_fake_command() {
+    local command_name
+    command_name="$(basename "$0")"
+
+    case "$command_name" in
+        apt-get|sleep)
+            return 0
+            ;;
+        sha256sum)
+            while IFS= read -r _; do :; done
+            return 0
+            ;;
+        wget)
+            fake_wget "$@"
+            return
+            ;;
+        clang|clang-22|llvm-config|llvm-config-22|lld|lld-22|ld.lld|ld.lld-22|FileCheck|FileCheck-22)
+            printf '22.0.0\n'
+            return 0
+            ;;
+    esac
+
+    if [[ "${1:-}" == "22" ]]; then
+        fake_installer "$@"
+        return
+    fi
+
+    return 127
+}
+
+run_in_container() {
+    local script_dir
+    local test_script
+
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    test_script="$script_dir/install_llvm_ubuntu_test.sh"
+
+    docker run --rm \
+        --volume "$script_dir/../install_llvm_ubuntu.sh:/work/install_llvm_ubuntu.sh:ro" \
+        --volume "$test_script:/work/install_llvm_ubuntu_test.sh:ro" \
+        debian:trixie \
+        bash /work/install_llvm_ubuntu_test.sh --inside
+}
+
+run_test() {
+    local fake_command
+    local output
+
+    mkdir -p /tmp/fake-bin
+    for fake_command in apt-get sha256sum sleep wget; do
+        ln -fs /work/install_llvm_ubuntu_test.sh "/tmp/fake-bin/$fake_command"
+    done
+
+    if ! PATH="/tmp/fake-bin:$PATH" /work/install_llvm_ubuntu.sh; then
+        echo "Expected the installer wrapper to avoid the failing GPG-key HEAD probe." >&2
+        return 1
+    fi
+
+    output="$(/usr/bin/llvm-config --version)"
+    if [[ "$output" != "22.0.0" ]]; then
+        echo "Expected the installed llvm-config shim to report 22.0.0, got: $output" >&2
+        return 1
+    fi
+
+    output="$(</etc/apt/trusted.gpg.d/apt.llvm.org.asc)"
+    if [[ "$output" != "fake-llvm-signing-key" ]]; then
+        echo "Expected the signing key to be installed by a bounded GET, got: $output" >&2
+        return 1
+    fi
+}
+
+case "$(basename "$0")" in
+    apt-get|sha256sum|sleep|wget|clang|clang-22|llvm-config|llvm-config-22|lld|lld-22|ld.lld|ld.lld-22|FileCheck|FileCheck-22)
+        dispatch_fake_command "$@"
+        ;;
+    *)
+        if [[ "${1:-}" == "--inside" ]]; then
+            run_test
+        elif [[ "${1:-}" == "22" ]]; then
+            fake_installer "$@"
+        else
+            run_in_container
+        fi
+        ;;
+esac

--- a/.github/scripts/tests/install_llvm_ubuntu_test.sh
+++ b/.github/scripts/tests/install_llvm_ubuntu_test.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 readonly llvm_key_url="https://apt.llvm.org/llvm-snapshot.gpg.key"
+readonly llvm_repo_url="https://apt.llvm.org/trixie/"
 readonly llvm_script_url="https://apt.llvm.org/llvm.sh"
 
 fake_wget() {
@@ -34,7 +35,8 @@ fake_wget() {
         esac
     done
 
-    if [[ "$url" == "$llvm_key_url" && "$method" == "HEAD" ]]; then
+    if [[ "$method" == "HEAD" && \
+          ( "$url" == "$llvm_key_url" || "$url" == "$llvm_repo_url" ) ]]; then
         return 1
     fi
 
@@ -52,10 +54,20 @@ fake_wget() {
     esac
 }
 
+check_url() {
+    wget -q --method=HEAD --timeout=15 --tries=3 "$1"
+}
+
 fake_installer() {
     local version="$1"
     local key_path="/etc/apt/trusted.gpg.d/apt.llvm.org.asc"
     local bin
+    local BASE_URL="https://apt.llvm.org"
+    local CODENAME="trixie"
+
+    if ! check_url "${BASE_URL}/${CODENAME}/"; then
+        return 2
+    fi
 
     if [[ ! -f "$key_path" ]]; then
         wget -q --method=HEAD --timeout=15 --tries=3 "$llvm_key_url"
@@ -121,7 +133,7 @@ run_test() {
     done
 
     if ! PATH="/tmp/fake-bin:$PATH" /work/install_llvm_ubuntu.sh; then
-        echo "Expected the installer wrapper to avoid the failing GPG-key HEAD probe." >&2
+        echo "Expected the installer wrapper to avoid the failing upstream HEAD probes." >&2
         return 1
     fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
+      - name: Test LLVM installer wrapper
+        run: .github/scripts/tests/install_llvm_ubuntu_test.sh
       # Guards the Docker build on ARM64 hosts: apt.llvm.org omits arm64 packages for some
       # Debian releases (bookworm has no arm64 LLVM 22), which only surfaces when installing
       # on an ARM64 machine. Runs the same installer inside the Docker base distribution.


### PR DESCRIPTION
## Summary

- fetch `llvm.sh` and its signing key with bounded GET retries
- remove the hash-pinned installer repository HEAD preflight and let signed `apt-get update` validate the repository
- pre-seed the key so upstream skips its key HEAD and unbounded key GET
- test both failing HEAD probes deterministically in the arm64 LLVM CI job

## Root cause

Three arm64 jobs exposed separate network failure signatures against apt.llvm.org:

- [job 94359650498](https://github.com/taikoxyz/alethia-reth/actions/runs/31672415154/job/94359650498): the `/trixie/` HEAD preflight timed out
- [job 94366430808](https://github.com/taikoxyz/alethia-reth/actions/runs/31674635806/job/94366430808): key HEAD timed out twice and `/trixie/` HEAD timed out once
- [job 94383071812](https://github.com/taikoxyz/alethia-reth/actions/runs/31674635806/job/94383071812): the key GET stalled for 900 seconds, followed by two `/trixie/` HEAD timeouts

The pinned upstream installer treats a transient repository HEAD failure as an unsupported distribution and performs its key GET with the default 900-second wget timeout.

The wrapper now verifies the upstream script hash, disables only its redundant repository HEAD check, and relies on the signed `apt-get update` already protected by `Acquire::Retries`. It also downloads the signing key atomically using four bounded GET attempts, which eliminates both upstream key operations.

## Regression coverage

The Docker integration test runs the real wrapper in Debian Trixie and makes both repository and signing-key HEAD requests fail while bounded GETs succeed.

- before the repository-probe fix: all three installer attempts failed and the test exited 1
- after the fix: no upstream HEAD request is required and the LLVM command contract completes

## Validation

- red-green Docker regression test
- native `linux/arm64` Debian Trixie install: LLVM 22.1.8
- ShellCheck
- actionlint
- `just fmt-check`
- `just clippy`
- `just test`: 294 passed